### PR TITLE
Fix: Reference checks for repeated elements in the for directive do not work correctly

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/action/sql/JumpToDaoFromSQLAction.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/action/sql/JumpToDaoFromSQLAction.kt
@@ -37,7 +37,7 @@ class JumpToDaoFromSQLAction : AnAction() {
         currentFile = e.getData(CommonDataKeys.PSI_FILE) ?: return
         findDaoMethod(currentFile!!) ?: return
         e.presentation.isEnabledAndVisible =
-            isSupportFileType(currentFile!!.virtualFile)
+            isSupportFileType(currentFile!!)
     }
 
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
@@ -53,7 +53,7 @@ class JumpToDaoFromSQLAction : AnAction() {
         )
 
         val project = e.project ?: return
-        val daoFile = findDaoFile(project, currentFile?.virtualFile!!) ?: return
+        val daoFile = findDaoFile(project, currentFile!!) ?: return
 
         jumpToDaoMethod(project, currentFile?.virtualFile?.nameWithoutExtension!!, daoFile)
         PluginLoggerUtil.countLoggingByAction(

--- a/src/main/kotlin/org/domaframework/doma/intellij/action/sql/JumpToDeclarationFromSqlAction.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/action/sql/JumpToDeclarationFromSqlAction.kt
@@ -15,12 +15,14 @@
  */
 package org.domaframework.doma.intellij.action.sql
 
+import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiType
 import com.intellij.psi.tree.IFileElementType
@@ -35,7 +37,6 @@ import org.domaframework.doma.intellij.common.psi.PsiStaticElement
 import org.domaframework.doma.intellij.extension.psi.findParameter
 import org.domaframework.doma.intellij.extension.psi.getDomaAnnotationType
 import org.domaframework.doma.intellij.extension.psi.getIterableClazz
-import org.domaframework.doma.intellij.extension.psi.initPsiFileAndElement
 import org.domaframework.doma.intellij.extension.psi.isNotWhiteSpace
 import org.domaframework.doma.intellij.extension.psi.methodParameters
 import org.domaframework.doma.intellij.psi.SqlElClass
@@ -54,7 +55,7 @@ class JumpToDeclarationFromSqlAction : AnAction() {
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = false
         val editor = e.getData(CommonDataKeys.EDITOR) ?: return
-        val caretOffset = editor.caretModel.offset
+        val caretOffset = editor.caretModel.primaryCaret.selectionStart
 
         currentFile = e.getData(CommonDataKeys.PSI_FILE) ?: return
         currentFile?.let { element = it.findElementAt(caretOffset) ?: return }
@@ -62,7 +63,15 @@ class JumpToDeclarationFromSqlAction : AnAction() {
 
         val project = element?.project ?: return
         if (isJavaOrKotlinFileType(currentFile ?: return)) {
-            currentFile = currentFile!!.initPsiFileAndElement(project, caretOffset)
+            val injectedLanguageManager =
+                InjectedLanguageManager.getInstance(project)
+            val literal = PsiTreeUtil.getParentOfType(element, PsiLiteralExpression::class.java)
+            currentFile =
+                injectedLanguageManager
+                    .getInjectedPsiFiles(literal!!)
+                    ?.firstOrNull()
+                    ?.first as? PsiFile
+            element = currentFile?.findElementAt(countInjectionOffset(literal, caretOffset))
         }
         findDaoMethod(currentFile ?: return) ?: return
 
@@ -75,6 +84,31 @@ class JumpToDeclarationFromSqlAction : AnAction() {
 
         val targetElement = getBlockCommentElements(element ?: return)
         if (targetElement.isNotEmpty()) e.presentation.isEnabledAndVisible = true
+    }
+
+    private fun countInjectionOffset(
+        literal: PsiLiteralExpression,
+        caretOffset: Int,
+    ): Int {
+        val quoteCount = countLeadingDoubleQuotes(literal.text)
+        val literalOffset = caretOffset - literal.textOffset
+        val indentCount =
+            literal.text.substring(0, literalOffset)
+        val indentRegex = Regex("(?<=\\n)[ \\t]+")
+        val indentSpacesCount = indentRegex.findAll(indentCount).sumOf { it.value.length }
+        return literalOffset - quoteCount - indentSpacesCount
+    }
+
+    private fun countLeadingDoubleQuotes(s: String): Int {
+        var count = 0
+        for (i in 0..<s.length) {
+            if (s[i] == '"') {
+                count++
+            } else {
+                break
+            }
+        }
+        return count
     }
 
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT

--- a/src/main/kotlin/org/domaframework/doma/intellij/action/sql/JumpToDeclarationFromSqlAction.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/action/sql/JumpToDeclarationFromSqlAction.kt
@@ -101,8 +101,8 @@ class JumpToDeclarationFromSqlAction : AnAction() {
 
     private fun countLeadingDoubleQuotes(s: String): Int {
         var count = 0
-        for (i in 0..<s.length) {
-            if (s[i] == '"') {
+        for (char in s) {
+            if (char == '"') {
                 count++
             } else {
                 break

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/FileTypeCheck.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/FileTypeCheck.kt
@@ -48,12 +48,22 @@ fun isJavaOrKotlinFileType(daoFile: PsiFile): Boolean {
 /*
  * Determine whether the open file is an SQL template file extension
  */
-fun isSupportFileType(file: VirtualFile): Boolean {
-    val extension = file.extension
+fun isSupportFileType(file: PsiFile): Boolean {
+    val extension = file.fileType.defaultExtension
     return when (extension) {
         "sql", "script" -> true
         else -> false
     }
+}
+
+fun isInjectionSqlFile(file: PsiFile): Boolean {
+    val extension = file.fileType.defaultExtension
+    val filePath = file.virtualFile.path
+    return when (extension) {
+        "sql" -> true
+        else -> false
+    } &&
+        !(filePath.endsWith(".sql") || filePath.endsWith(".script"))
 }
 
 /**

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/inspector/SqlBindVariableValidInspector.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/inspector/SqlBindVariableValidInspector.kt
@@ -84,11 +84,13 @@ class SqlBindVariableValidInspector : LocalInspectionTool() {
         END,
     }
 
+    override fun runForWholeFile(): Boolean = true
+
     override fun buildVisitor(
         holder: ProblemsHolder,
         isOnTheFly: Boolean,
     ): SqlVisitor {
-        val topElm = holder.file.firstChild
+        val topElm = holder.file.firstChild ?: return object : SqlVisitor() {}
         val directiveBlocks =
             topElm.nextLeafs
                 .filter { elm ->

--- a/src/test/kotlin/org/domaframework/doma/intellij/gutteraction/sql/SqlJumpActionTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/gutteraction/sql/SqlJumpActionTest.kt
@@ -24,6 +24,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.vfs.VirtualFile
 import org.domaframework.doma.intellij.DomaSqlTest
 import java.awt.event.InputEvent
 import java.awt.event.MouseEvent
@@ -37,6 +38,7 @@ class SqlJumpActionTest : DomaSqlTest() {
     override fun setUp() {
         super.setUp()
         addDaoJavaFile("$packageName/JumpActionTestDao.java")
+        addDaoJavaFile("$packageName/JumpDeclarationActionSqlAnnotationTestDao.java")
         addSqlFile(
             "$packageName/JumpActionTestDao/jumpToDaoFile.sql",
             "$packageName/JumpActionTestDao/notDisplayGutterWithNonExistentDaoMethod.sql",
@@ -128,6 +130,16 @@ class SqlJumpActionTest : DomaSqlTest() {
         jumpToDaoTest(action, "ProjectDetail.java")
     }
 
+    fun testJumpToDeclarationSqlAnnotation() {
+        val dao = findDaoClass("$packageName.JumpDeclarationActionSqlAnnotationTestDao")
+        val action: AnAction? = getJumpVariableActionTestOnSqlAnnotation(dao.containingFile.virtualFile)
+        assertNotNull("Not Found Action", action)
+        if (action == null) return
+
+        isDisplayedActionTest(action)
+        jumpToDaoTest(action, "Employee.java")
+    }
+
     private fun getJumDaoActionTest(sqlName: String): AnAction? {
         val sql = findSqlFile(sqlName)
         assertNotNull("Not Found SQL File", sql)
@@ -148,6 +160,14 @@ class SqlJumpActionTest : DomaSqlTest() {
 
         myFixture.configureFromExistingVirtualFile(sql)
 
+        val actionId = "org.domaframework.doma.intellij.JumpToDeclarationFromSql"
+        val action: AnAction = ActionManager.getInstance().getAction(actionId)
+        assertNotNull("Not Found Action", action)
+        return action
+    }
+
+    private fun getJumpVariableActionTestOnSqlAnnotation(daoFile: VirtualFile): AnAction {
+        myFixture.configureFromExistingVirtualFile(daoFile)
         val actionId = "org.domaframework.doma.intellij.JumpToDeclarationFromSql"
         val action: AnAction = ActionManager.getInstance().getAction(actionId)
         assertNotNull("Not Found Action", action)

--- a/src/test/testData/src/main/java/doma/example/dao/gutteraction/JumpDeclarationActionSqlAnnotationTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/gutteraction/JumpDeclarationActionSqlAnnotationTestDao.java
@@ -1,0 +1,17 @@
+package doma.example.dao.gutteraction;
+
+import java.util.List;
+import doma.example.entity.*;
+import org.seasar.doma.*;
+
+@Dao
+interface JumpDeclarationActionSqlAnnotationTestDao {
+
+  @Select
+  @Sql("""
+      select * from emp 
+        where name = /* employee.employee<caret>Name */'name'
+      """)
+  List<Employee> jumpToEntity(Employee employee);
+
+}


### PR DESCRIPTION
# Description
Fixed an issue where changing an element name in the for directive did not result in an error for bind variables that use that element in a block.

Specifically, the following issues were fixed:

- Added a flag to inspect the entire file every time a change is made within the file.

- Fixed to prevent NPE from occurring in subsequent processing if there are no elements in the file.

- Fixed a problem where code inspection for SQL injected into SQL annotations in Java files did not work when runForWholeFile() was added, so child elements of PsiLiteralExpression are revisited.