### PR TITLE
Fix: element type condition checking in DAO argument usage check.

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/inspector/DaoMethodVariableInspector.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/inspector/DaoMethodVariableInspector.kt
@@ -94,7 +94,7 @@ class DaoMethodVariableInspector : AbstractBaseJavaLocalInspectionTool() {
             object : PsiRecursiveElementVisitor() {
                 // Recursively explore child elements in a file with PsiRecursiveElementVisitor.
                 override fun visitElement(element: PsiElement) {
-                    if (element !is SqlElPrimaryExpr) {
+                    if (element is SqlElPrimaryExpr) {
                         iterator = args.minus(elements.toSet()).iterator()
                         while (iterator.hasNext()) {
                             val arg = iterator.next()


### PR DESCRIPTION
# Description
The condition to search for elements of type Sql Primary Expr was incorrect, but was something other than that. This has been fixed.