### PR TITLE
Revert "Update dependency org.seasar.doma:doma-core to v3.5.1"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 junit = "4.13.2"
-doma = "3.5.1"
+doma = "3.2.0"
 logback = "1.5.17"
 
 # plugins


### PR DESCRIPTION
Reverts domaframework/doma-tools-for-intellij#11
Do not change the test version of Doma.