### PR TITLE
Add Develop Build Number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
 
       # Build plugin
       - name: Build plugin
-        run: ./gradlew buildPlugin -PpluginVersion=0.3.0
+        run: ./gradlew buildPlugin -PpluginVersion=0.3.0-${{ github.run_number }}
 
       # Prepare plugin archive content for creating artifact
       - name: Prepare Plugin Artifact


### PR DESCRIPTION
An identification number is assigned to the build file to identify the latest build file.