### PR TITLE
Fix: release-raft should only be run on the main branch

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-
   pull_request:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
@@ -18,7 +17,11 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
     steps:
       - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitish: main


### PR DESCRIPTION
Each commit added in the PullRequest will create incomplete release notes.
So we'll change the setting to create releases based on the main branch only.