### PR TITLE
Fix: IntelliJ Platform version upgrades

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
   <depends>org.intellij.intelliLang</depends>
   <depends>org.toml.lang</depends>
   <depends optional="true" config-file="kotlin.xml">org.jetbrains.kotlin</depends>
-  <idea-version since-build="231" until-build="243.*"/>
+  <idea-version since-build="231"/>
 
   <resource-bundle>messages.DomaToolsBundle</resource-bundle>
   <resource-bundle>messages.LLMInstallerBundle</resource-bundle>


### PR DESCRIPTION
Addresses warnings that occur when building plugins with IntelliJ Platform version 2.3.0.
https://github.com/JetBrains/intellij-platform-gradle-plugin/commit/529c51faae399977c9380c963f631a2289d29c35
#10 