### PR TITLE
Ci/modify release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,28 +35,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      # Set environment variables
-      - name: Export Properties
-        id: properties
-        shell: bash
-        run: |
-          CHANGELOG="$(cat << 'EOM' | sed -e 's/^[[:space:]]*$//g' -e '/./,$!d'
-          ${{ github.event.release.body }}
-          EOM
-          )"
-          
-          echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      # Update the Unreleased section with the current release note
-      - name: Patch Changelog
-        if: ${{ steps.properties.outputs.changelog != '' }}
-        env:
-          CHANGELOG: ${{ steps.properties.outputs.changelog }}
-        run: |
-          ./gradlew patchChangelog --release-note="$CHANGELOG"
-
       # Generate Lexer and Parser
       - name: Generate Lexer
         run: ./gradlew generateLexer
@@ -78,31 +56,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
-
-      # Create a pull request
-      - name: Create Pull Request
-        if: ${{ steps.properties.outputs.changelog != '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          BRANCH="changelog-update-$VERSION"
-          LABEL="release changelog"
-
-          git config user.email "action@github.com"
-          git config user.name "GitHub Action"
-
-          git checkout -b $BRANCH
-          git commit -am "Changelog update - $VERSION"
-          git push --set-upstream origin $BRANCH
-          
-          gh label create "$LABEL" \
-            --description "Pull requests with release changelog update" \
-            --force \
-            || true
-
-          gh pr create \
-            --title "Changelog update - \`$VERSION\`" \
-            --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
-            --label "$LABEL" \
-            --head $BRANCH

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -16,9 +16,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  update-changelog:
+  check-commit-message:
     runs-on: ubuntu-latest
     if: startsWith(github.event.head_commit.message, 'Merge pull request')
+    outputs:
+      skip_job: ${{ steps.check.outputs.SKIP_JOB }}
+    steps:
+      - name: Check Commit Message
+        id: check
+        run: |
+          if [[ "${{ github.event.head_commit.message }}" =~ ^Merge\ pull\ request\ #[0-9]+\ from\ ${{ github.repository_owner }}/doc/changelog-update-.*$ ]]; then
+            echo "This commit is not target. Skip the workflow."
+            echo "SKIP_JOB=true" >> $GITHUB_OUTPUT
+          else
+            echo "SKIP_JOB=false" >> $GITHUB_OUTPUT
+          fi
+
+  update-changelog:
+    runs-on: ubuntu-latest
+    if: ${{ needs.check-commit-message.outputs.skip_job != 'true' }}
+    outputs:
+      changelog: ${{ steps.properties.outputs.changelog }}
+    needs: [ check-commit-message ]
     steps:
 
       - name: Checkout repository
@@ -38,6 +57,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run Gradle updateChangelog
+        id: updateChangelog
         run: |
           ./gradlew updateChangelog -PreleaseDate=$(date +'%Y-%m-%d')
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -208,7 +208,7 @@ tasks.register("updateChangelog") {
         val id: Long = 0,
         val name: String = "",
         val color: String = "",
-        val description: String = "",
+        val description: String? = "",
     )
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -458,9 +458,10 @@ tasks.register("checkExistChangelogPullRequest") {
         // https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
         val apiPath = "https://api.github.com/search/issues"
         val status = "is:open"
+        val type = "type:pr"
         val label = "label:changelog,skip-changelog"
         val branch = "base:main+head:$newBranch"
-        val apiUrl = "$apiPath?q=repo:$repo+is:pr+$branch+$label+$status"
+        val apiUrl = "$apiPath?q=repo:$repo+$branch+$label+$status+$type"
         val connection =
             URL(apiUrl).openConnection().apply {
                 setRequestProperty("Authorization", "token $githubToken")


### PR DESCRIPTION
Fixed the update process for CHANGELOG.md.

- Exclude unnecessary update processes from each action to manage them with the update-changelog action.
- Check the commit message and skip the process so that a log update PR merge does not trigger a duplicate PR to be created.
- Prevent an error from occurring even if the description property of the label information is null.