### PR TITLE
Regular expressions to match tag name format updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -290,7 +290,7 @@ tasks.register("updateChangelog") {
         }
 
         val tagsOutput = runCommand("git tag --sort=-v:refname")
-        val semverRegex = Regex("^v\\d+\\.\\d+\\.\\d+$")
+        val semverRegex = Regex("^\\d+\\.\\d+\\.\\d+$")
         val tags = tagsOutput.lines().filter { semverRegex.matches(it) }
         if (tags.isEmpty()) {
             throw GradleException("Not Found Release Tag")


### PR DESCRIPTION
The release tag format has changed since 0.3.1, so we also changed the regular expression used in updatechangelog-action to obtain the last tag.
https://github.com/domaframework/doma-tools-for-intellij/pull/43