### PR TITLE
Add Char type to the condition as a literal

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/inspector/SqlBindVariableValidInspector.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/inspector/SqlBindVariableValidInspector.kt
@@ -256,6 +256,7 @@ class SqlBindVariableValidInspector : LocalInspectionTool() {
             private fun isLiteralOrStatic(targetElement: PsiElement): Boolean =
                 (
                     targetElement.firstChild?.elementType == SqlTypes.EL_STRING ||
+                        targetElement.firstChild?.elementType == SqlTypes.EL_CHAR ||
                         targetElement.firstChild?.elementType == SqlTypes.EL_NUMBER ||
                         targetElement.firstChild?.elementType == SqlTypes.EL_NULL ||
                         targetElement.firstChild?.elementType == SqlTypes.EL_BOOLEAN ||

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/EmployeeSummaryDao/bindVariableForEntityAndNonEntityParentClass.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/EmployeeSummaryDao/bindVariableForEntityAndNonEntityParentClass.sql
@@ -7,6 +7,8 @@ INSERT INTO employee_project (employee_name, department, project)
              FROM
                  employee e1
                  JOIN user u1 ON e1.employee_id = u1.user_id
+                              AND e1.user_tag = /*# 't' */'a'
+                              AND e1.user_dept = /*# "development" */'dev'
                   -- Access to parent private field
                    WHERE u1.user_name = /* employee.userName.toLowerCase() */'name'
                    -- Access to non-existent parent field


### PR DESCRIPTION
When checking the SQL bind variable definition, the CHAR type was causing an error.
Added SqlTypes.EL_CHAR as a literal element and fixed the issue so that the error is not highlighted.

Check that the string does not cause an error in the test.