### PR TITLE
Fix:Prevent log file archives from being output to IDEA installation directory

### DIFF
--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -16,7 +16,7 @@
   <appender name="DOMATOOLS" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${LOG_FILE_BASE_DIR:-/domatoolslog}/${LOG_FILE_BASENAME:-doma-tools}-${LOG_FILE_VERSION:-0.3.1}.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_FILE_BASENAME:-doma-tools}-${LOG_FILE_VERSION:-0.3.1}-%d{yyyy-MM-dd}.log</fileNamePattern>
+      <fileNamePattern>${LOG_FILE_BASE_DIR:-/domatoolslog}/${LOG_FILE_BASENAME:-doma-tools}-${LOG_FILE_VERSION:-0.3.1}-%d{yyyy-MM-dd}.log</fileNamePattern>
       <maxHistory>30</maxHistory>
     </rollingPolicy>
     <encoder>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,7 +16,7 @@
   <appender name="DOMATOOLS" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${LOG_FILE_BASE_DIR:-/domatoolslog}/${LOG_FILE_BASENAME:-doma-tools}-${LOG_FILE_VERSION:-0.3.1}.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_FILE_BASENAME:-doma-tools}-${LOG_FILE_VERSION:-0.3.1}-%d{yyyy-MM-dd}.log</fileNamePattern>
+      <fileNamePattern>${LOG_FILE_BASE_DIR:-/domatoolslog}/${LOG_FILE_BASENAME:-doma-tools}-${LOG_FILE_VERSION:-0.3.1}-%d{yyyy-MM-dd}.log</fileNamePattern>
       <maxHistory>30</maxHistory>
     </rollingPolicy>
     <encoder>


### PR DESCRIPTION
Log file archives are output to the IDEA installation directory. Fixed by specifying the output path so that the latest log is archived to the same directory as the output destination.