### PR TITLE
Fix: Exclude java.stream.Collector type arguments from code inspection

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
@@ -92,6 +92,11 @@ class PsiDaoMethod(
 
     private fun getSqlAnnotation(): PsiAnnotation? = DomaAnnotationType.Sql.getPsiAnnotation(psiMethod)
 
+    fun isSelectTypeCollect(): Boolean {
+        val selectAnnotation = DomaAnnotationType.Select.getPsiAnnotation(psiMethod) ?: return false
+        return daoType.isSelectTypeCollect(selectAnnotation)
+    }
+
     fun useSqlAnnotation(): Boolean = getSqlAnnotation() != null
 
     private fun setSqlFilePath() {

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/DomaAnnotationType.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/DomaAnnotationType.kt
@@ -18,6 +18,10 @@ package org.domaframework.doma.intellij.extension.psi
 import com.intellij.codeInsight.AnnotationUtil
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiNameValuePair
+import com.intellij.psi.PsiReferenceExpression
+import com.intellij.psi.util.PsiTreeUtil
+import kotlin.jvm.java
 
 enum class DomaAnnotationType(
     val fqdn: String,
@@ -59,4 +63,19 @@ enum class DomaAnnotationType(
             true -> AnnotationUtil.getBooleanAttributeValue(element, "sqlFile") == true
             false -> false
         }
+
+    fun isSelectTypeCollect(element: PsiAnnotation): Boolean {
+        val strategyPair =
+            PsiTreeUtil
+                .getChildrenOfTypeAsList(element.parameterList, PsiNameValuePair::class.java)
+                .firstOrNull {
+                    it.text.startsWith("strategy")
+                } ?: return false
+
+        return PsiTreeUtil
+            .getChildOfType(
+                strategyPair,
+                PsiReferenceExpression::class.java,
+            )?.text == "SelectType.COLLECT"
+    }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiParameterExtension.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiParameterExtension.kt
@@ -48,3 +48,9 @@ val PsiParameter.isSelectOption: Boolean
         (this.typeElement?.type as? PsiClassReferenceType)
             ?.resolve()
             ?.qualifiedName == "org.seasar.doma.jdbc.SelectOptions"
+
+val PsiParameter.isCollector: Boolean
+    get() =
+        (this.typeElement?.type as? PsiClassReferenceType)
+            ?.resolve()
+            ?.qualifiedName == "java.util.stream.Collector"

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/inspector/DaoMethodVariableInspector.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/inspector/DaoMethodVariableInspector.kt
@@ -32,6 +32,7 @@ import org.domaframework.doma.intellij.common.dao.getDaoClass
 import org.domaframework.doma.intellij.common.isJavaOrKotlinFileType
 import org.domaframework.doma.intellij.common.psi.PsiDaoMethod
 import org.domaframework.doma.intellij.extension.findFile
+import org.domaframework.doma.intellij.extension.psi.isCollector
 import org.domaframework.doma.intellij.extension.psi.isFunctionClazz
 import org.domaframework.doma.intellij.extension.psi.isSelectOption
 import org.domaframework.doma.intellij.extension.psi.methodParameters
@@ -66,7 +67,7 @@ class DaoMethodVariableInspector : AbstractBaseJavaLocalInspectionTool() {
 
                 val methodParameters =
                     method.methodParameters
-                        .filter { !it.isFunctionClazz && !it.isSelectOption }
+                        .filter { !it.isFunctionClazz && !it.isSelectOption && !(it.isCollector && psiDaoMethod.isSelectTypeCollect()) }
                 val sqlFileManager =
                     psiDaoMethod.sqlFile?.let {
                         method.project.findFile(it)

--- a/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/DomaUseVariableTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/DomaUseVariableTest.kt
@@ -32,6 +32,8 @@ class DomaUseVariableTest : DomaSqlTest() {
         addSqlFile(
             "$testDaoName/biFunctionDoesNotCauseError.sql",
             "$testDaoName/selectOptionDoesNotCauseError.sql",
+            "$testDaoName/collectDoesNotCauseError.sql",
+            "$testDaoName/collectDoesCauseError.sql",
         )
         myFixture.enableInspections(DaoMethodVariableInspector())
     }

--- a/src/test/testData/src/main/java/doma/example/dao/DaoMethodVariableInspectionTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/DaoMethodVariableInspectionTestDao.java
@@ -16,6 +16,8 @@ import org.seasar.doma.Update;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.PreparedSql;
 import org.seasar.doma.jdbc.SelectOptions;
+import org.seasar.doma.SelectType;
+import java.util.stream.Collector;
 
 import java.util.List;
 import java.util.function.BiFunction;
@@ -38,5 +40,12 @@ interface DaoMethodVariableInspectionTestDao {
 
   @Select
   Project selectOptionDoesNotCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,String searchName,SelectOptions options);
+
+  @Select(strategy = SelectType.COLLECT)
+  Project collectDoesNotCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,Integer id,Collector<Project, ?, Project> collector);
+
+  @Select
+  Project collectDoesCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,String searchName,Collector<Project, ?, Project> <error descr="There are unused parameters in the SQL [collector]">collector</error>);
+
 
 }

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/DaoMethodVariableInspectionTestDao/collectDoesCauseError.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/DaoMethodVariableInspectionTestDao/collectDoesCauseError.sql
@@ -1,0 +1,8 @@
+-- Using Dao arguments other than SelectOption as bind variables
+select
+ p.project_id
+ , p.project_name
+ , p.project_number
+from project p
+where p.project_id = /* id */0
+ and p. project_name = /* searchName */'search'

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/DaoMethodVariableInspectionTestDao/collectDoesNotCauseError.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/DaoMethodVariableInspectionTestDao/collectDoesNotCauseError.sql
@@ -1,0 +1,7 @@
+-- Using Dao arguments other than SelectOption as bind variables
+select
+ p.project_id
+ , p.project_name
+ , p.project_number
+from project p
+where p.project_id = /* id */0


### PR DESCRIPTION
Exclude java.stream.Collector type arguments from code inspection if the Select annotation has the "strategy = SelectType.COLLECT" option
https://doma.readthedocs.io/en/stable/query/select/#collector-search