### PR TITLE
Fixed Plugin Verifier version to 1.383

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
 
         plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
 
-        pluginVerifier()
+        pluginVerifier(version = "1.383")
         zipSigner()
         testFramework(TestFrameworkType.Platform)
         testFramework(TestFrameworkType.Plugin.Java)


### PR DESCRIPTION
Since OOM occurs in the latest version of Plugin Verifier, 1.384, the version will be fixed to 1.383.
https://platform.jetbrains.com/t/plugin-verifier-1-384-has-been-released/1015