### PR TITLE
Fix/formatter indent

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/expr/SqlElExtensions.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/expr/SqlElExtensions.kt
@@ -18,10 +18,15 @@ package org.domaframework.doma.intellij.extension.expr
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
+import org.domaframework.doma.intellij.psi.SqlCustomElCommentExpr
 import org.domaframework.doma.intellij.psi.SqlElClass
+import org.domaframework.doma.intellij.psi.SqlElElseifDirective
+import org.domaframework.doma.intellij.psi.SqlElForDirective
+import org.domaframework.doma.intellij.psi.SqlElIfDirective
 import org.domaframework.doma.intellij.psi.SqlElPrimaryExpr
 import org.domaframework.doma.intellij.psi.SqlElStaticFieldAccessExpr
 import org.domaframework.doma.intellij.psi.SqlTypes
+import kotlin.invoke
 
 val SqlElStaticFieldAccessExpr.accessElements: List<PsiElement>
     get() {
@@ -43,3 +48,13 @@ val SqlElStaticFieldAccessExpr.fqdn: String
         val fqdn = PsiTreeUtil.getChildrenOfTypeAsList(elClazz, PsiElement::class.java)
         return fqdn.toList().joinToString("") { it.text }
     }
+
+fun SqlCustomElCommentExpr.isConditionOrLoopDirective(): Boolean =
+    PsiTreeUtil.getChildOfType(this, SqlElIfDirective::class.java) != null ||
+        PsiTreeUtil.getChildOfType(this, SqlElForDirective::class.java) != null ||
+        PsiTreeUtil.getChildOfType(
+            this,
+            SqlElElseifDirective::class.java,
+        ) != null ||
+        this.findElementAt(2)?.elementType == SqlTypes.EL_END ||
+        this.findElementAt(2)?.elementType == SqlTypes.EL_ELSE

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockBuilder.kt
@@ -16,7 +16,8 @@
 package org.domaframework.doma.intellij.formatter
 
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.group.SqlSubGroupBlock
+import org.domaframework.doma.intellij.formatter.block.expr.SqlElBlockCommentBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 
 open class SqlBlockBuilder {
     private val groupTopNodeIndexHistory = mutableListOf<Pair<Int, SqlBlock>>()
@@ -24,6 +25,8 @@ open class SqlBlockBuilder {
     private val commentBlocks = mutableListOf<SqlBlock>()
 
     fun getGroupTopNodeIndexHistory(): List<Pair<Int, SqlBlock>> = groupTopNodeIndexHistory
+
+    fun getLastGroup(): SqlBlock? = groupTopNodeIndexHistory.lastOrNull()?.second
 
     fun addGroupTopNodeIndexHistory(block: Pair<Int, SqlBlock>) {
         groupTopNodeIndexHistory.add(block)
@@ -37,19 +40,21 @@ open class SqlBlockBuilder {
         if (commentBlocks.isNotEmpty()) {
             var index = 0
             commentBlocks.forEach { block ->
-                val indentLen =
-                    if (index == 0 &&
-                        baseIndent.parentBlock is SqlSubGroupBlock &&
-                        baseIndent.parentBlock?.childBlocks?.size == 1
-                    ) {
-                        1
-                    } else {
-                        baseIndent.indent.indentLen
-                    }
-                block.indent.indentLevel = IndentType.NONE
-                block.indent.indentLen = indentLen
-                block.indent.groupIndentLen = 0
-                index++
+                if (block !is SqlElBlockCommentBlock) {
+                    val indentLen =
+                        if (index == 0 &&
+                            baseIndent.parentBlock is SqlSubGroupBlock &&
+                            baseIndent.parentBlock?.childBlocks?.size == 1
+                        ) {
+                            1
+                        } else {
+                            baseIndent.indent.indentLen
+                        }
+                    block.indent.indentLevel = IndentType.NONE
+                    block.indent.indentLen = indentLen
+                    block.indent.groupIndentLen = 0
+                    index++
+                }
             }
             commentBlocks.clear()
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockUtil.kt
@@ -1,0 +1,286 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.formatter
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiComment
+import com.intellij.psi.util.PsiTreeUtil
+import org.domaframework.doma.intellij.extension.expr.isConditionOrLoopDirective
+import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.SqlBlockCommentBlock
+import org.domaframework.doma.intellij.formatter.block.SqlColumnBlock
+import org.domaframework.doma.intellij.formatter.block.SqlCommaBlock
+import org.domaframework.doma.intellij.formatter.block.SqlCommentBlock
+import org.domaframework.doma.intellij.formatter.block.SqlKeywordBlock
+import org.domaframework.doma.intellij.formatter.block.SqlTableBlock
+import org.domaframework.doma.intellij.formatter.block.SqlWordBlock
+import org.domaframework.doma.intellij.formatter.block.expr.SqlElBlockCommentBlock
+import org.domaframework.doma.intellij.formatter.block.expr.SqlElConditionLoopCommentBlock
+import org.domaframework.doma.intellij.formatter.block.group.SqlColumnDefinitionRawGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlCreateKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlInlineGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlInlineSecondGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlInsertKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlJoinGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlUpdateKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlColumnDefinitionGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlColumnGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlDataTypeParamBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlFunctionParamBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlInsertColumnGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlParallelListBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateColumnGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateValueGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlViewGroupBlock
+import org.domaframework.doma.intellij.psi.SqlCustomElCommentExpr
+import org.domaframework.doma.intellij.psi.SqlTypes
+
+class SqlBlockUtil(
+    private val sqlBlock: SqlBlock,
+) {
+    val wrap = sqlBlock.wrap
+    val alignment = sqlBlock.alignment
+    val spacingBuilder = sqlBlock.spacingBuilder
+
+    fun getKeywordBlock(
+        child: ASTNode,
+        lastGroupBlock: SqlBlock?,
+    ): SqlBlock {
+        // Because we haven't yet set the parent-child relationship of the block,
+        // the parent group references groupTopNodeIndexHistory.
+        val indentLevel = SqlKeywordUtil.getIndentType(child.text)
+        val keywordText = child.text.lowercase()
+        if (indentLevel.isNewLineGroup()) {
+            when (indentLevel) {
+                IndentType.JOIN -> {
+                    return if (SqlKeywordUtil.isJoinKeyword(child.text)) {
+                        SqlJoinGroupBlock(child, wrap, alignment, spacingBuilder)
+                    } else if (lastGroupBlock is SqlJoinGroupBlock) {
+                        SqlKeywordBlock(child, IndentType.ATTACHED, wrap, alignment, spacingBuilder)
+                    } else {
+                        SqlJoinGroupBlock(child, wrap, alignment, spacingBuilder)
+                    }
+                }
+
+                IndentType.INLINE_SECOND -> {
+                    return SqlInlineSecondGroupBlock(child, wrap, alignment, spacingBuilder)
+                }
+
+                IndentType.TOP -> {
+                    if (keywordText == "create") {
+                        return SqlCreateKeywordGroupBlock(child, wrap, alignment, spacingBuilder)
+                    }
+                    if (keywordText == "insert") {
+                        return SqlInsertKeywordGroupBlock(child, wrap, alignment, spacingBuilder)
+                    }
+
+                    return SqlKeywordGroupBlock(child, indentLevel, wrap, alignment, spacingBuilder)
+                }
+
+                IndentType.SECOND -> {
+                    return if (keywordText == "set") {
+                        SqlUpdateKeywordGroupBlock(child, wrap, alignment, spacingBuilder)
+                    } else {
+                        SqlKeywordGroupBlock(child, indentLevel, wrap, alignment, spacingBuilder)
+                    }
+                }
+
+                else -> {
+                    return SqlKeywordGroupBlock(child, indentLevel, wrap, alignment, spacingBuilder)
+                }
+            }
+        }
+
+        when (indentLevel) {
+            IndentType.INLINE -> {
+                if (!SqlKeywordUtil.isSetLineKeyword(
+                        child.text,
+                        lastGroupBlock?.node?.text ?: "",
+                    )
+                ) {
+                    return SqlInlineGroupBlock(child, wrap, alignment, spacingBuilder)
+                }
+            }
+
+            IndentType.ATTACHED -> {
+                if (lastGroupBlock is SqlCreateKeywordGroupBlock) {
+                    lastGroupBlock.setCreateQueryType(child.text)
+                    return SqlKeywordBlock(child, indentLevel, wrap, alignment, spacingBuilder)
+                }
+            }
+
+            IndentType.OPTIONS -> {
+                if (child.text.lowercase() == "as") {
+                    val parentCreateBlock =
+                        lastGroupBlock as? SqlCreateKeywordGroupBlock
+                            ?: lastGroupBlock?.parentBlock as? SqlCreateKeywordGroupBlock
+                    if (parentCreateBlock != null && parentCreateBlock.createType == CreateQueryType.VIEW) {
+                        return SqlViewGroupBlock(child, wrap, alignment, spacingBuilder)
+                    }
+                }
+            }
+
+            else -> return SqlKeywordBlock(child, indentLevel, wrap, alignment, spacingBuilder)
+        }
+        return SqlKeywordBlock(child, indentLevel, wrap, alignment, spacingBuilder)
+    }
+
+    fun getSubGroupBlock(
+        lastGroup: SqlBlock?,
+        child: ASTNode,
+    ): SqlBlock {
+        if (child.treePrev.elementType == SqlTypes.WORD) {
+            return SqlFunctionParamBlock(child, wrap, alignment, spacingBuilder)
+        }
+
+        when (lastGroup) {
+            is SqlKeywordGroupBlock -> {
+                val lastKeyword =
+                    lastGroup.childBlocks
+                        .lastOrNull { SqlKeywordUtil.isOptionSqlKeyword(it.node.text) }
+                if (lastKeyword != null && lastKeyword.node.text.lowercase() == "in") {
+                    return SqlParallelListBlock(child, wrap, alignment, spacingBuilder)
+                }
+                if (lastGroup is SqlCreateKeywordGroupBlock) {
+                    return SqlColumnDefinitionGroupBlock(child, wrap, alignment, spacingBuilder)
+                }
+                if (lastGroup is SqlInsertKeywordGroupBlock) {
+                    return SqlInsertColumnGroupBlock(child, wrap, alignment, spacingBuilder)
+                }
+                if (lastGroup is SqlUpdateKeywordGroupBlock) {
+                    return if (lastGroup.childBlocks.firstOrNull { it is SqlUpdateColumnGroupBlock } == null) {
+                        SqlUpdateColumnGroupBlock(child, wrap, alignment, spacingBuilder)
+                    } else if (lastGroup.childBlocks.lastOrNull { it is SqlUpdateColumnGroupBlock } != null) {
+                        SqlUpdateValueGroupBlock(child, wrap, alignment, spacingBuilder)
+                    } else {
+                        SqlSubQueryGroupBlock(child, wrap, alignment, spacingBuilder)
+                    }
+                }
+                return SqlSubQueryGroupBlock(child, wrap, alignment, spacingBuilder)
+            }
+
+            is SqlColumnDefinitionRawGroupBlock ->
+                return SqlDataTypeParamBlock(child, wrap, alignment, spacingBuilder)
+
+            else ->
+                return SqlSubQueryGroupBlock(child, wrap, alignment, spacingBuilder)
+        }
+    }
+
+    fun getCommaGroupBlock(
+        lastGroup: SqlBlock?,
+        child: ASTNode,
+    ): SqlBlock =
+        when (lastGroup) {
+            is SqlColumnDefinitionGroupBlock, is SqlColumnDefinitionRawGroupBlock ->
+                SqlColumnDefinitionRawGroupBlock(
+                    child,
+                    wrap,
+                    alignment,
+                    spacingBuilder,
+                )
+
+            is SqlColumnGroupBlock, is SqlKeywordGroupBlock -> {
+                if (lastGroup.indent.indentLevel == IndentType.SECOND) {
+                    SqlCommaBlock(child, wrap, alignment, spacingBuilder)
+                } else {
+                    SqlColumnGroupBlock(child, wrap, alignment, spacingBuilder)
+                }
+            }
+
+            else -> SqlCommaBlock(child, wrap, alignment, spacingBuilder)
+        }
+
+    fun getWordBlock(
+        lastGroup: SqlBlock?,
+        child: ASTNode,
+    ): SqlBlock =
+        when (lastGroup) {
+            is SqlKeywordGroupBlock -> {
+                when {
+                    SqlKeywordUtil.isBeforeTableKeyword(lastGroup.node.text) ->
+                        SqlTableBlock(
+                            child,
+                            wrap,
+                            alignment,
+                            spacingBuilder,
+                        )
+
+                    else -> SqlWordBlock(child, wrap, alignment, spacingBuilder)
+                }
+            }
+
+            is SqlColumnDefinitionGroupBlock -> {
+                lastGroup.alignmentColumnName = child.text
+                SqlColumnDefinitionRawGroupBlock(
+                    child,
+                    wrap,
+                    alignment,
+                    spacingBuilder,
+                )
+            }
+
+            is SqlColumnDefinitionRawGroupBlock -> {
+                if (lastGroup.childBlocks.isEmpty()) {
+                    lastGroup.columnName = child.text
+                    SqlColumnBlock(
+                        child,
+                        wrap,
+                        alignment,
+                        spacingBuilder,
+                    )
+                } else {
+                    SqlWordBlock(child, wrap, alignment, spacingBuilder)
+                }
+            }
+
+            else -> SqlWordBlock(child, wrap, alignment, spacingBuilder)
+        }
+
+    fun getBlockCommentBlock(
+        child: ASTNode,
+        blockCommentSpacingBuilder: SqlCustomSpacingBuilder?,
+    ): SqlCommentBlock {
+        if (PsiTreeUtil.getChildOfType(child.psi, PsiComment::class.java) != null) {
+            return SqlBlockCommentBlock(
+                child,
+                wrap,
+                alignment,
+                spacingBuilder,
+            )
+        }
+        if (child.psi is SqlCustomElCommentExpr &&
+            (child.psi as SqlCustomElCommentExpr).isConditionOrLoopDirective()
+        ) {
+            return SqlElConditionLoopCommentBlock(
+                child,
+                wrap,
+                alignment,
+                blockCommentSpacingBuilder,
+                spacingBuilder,
+            )
+        }
+        return SqlElBlockCommentBlock(
+            child,
+            wrap,
+            alignment,
+            blockCommentSpacingBuilder,
+            spacingBuilder,
+        )
+    }
+}

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlCustomSpacingBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlCustomSpacingBuilder.kt
@@ -21,7 +21,6 @@ import com.intellij.formatting.Spacing
 import com.intellij.psi.tree.IElementType
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlColumnBlock
-import org.domaframework.doma.intellij.formatter.block.SqlRightPatternBlock
 import org.domaframework.doma.intellij.formatter.block.SqlWhitespaceBlock
 import org.domaframework.doma.intellij.formatter.block.group.SqlColumnDefinitionRawGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.SqlNewGroupBlock
@@ -109,11 +108,6 @@ class SqlCustomSpacingBuilder {
 
     fun getSpacingColumnDefinitionRaw(child: SqlColumnDefinitionRawGroupBlock): Spacing? {
         val indentLen = child.createBlockIndentLen()
-        return Spacing.createSpacing(indentLen, indentLen, 0, false, 0, 0)
-    }
-
-    fun getSpacingColumnDefinitionRawEndRight(child: SqlRightPatternBlock): Spacing? {
-        val indentLen = child.indent.indentLen
         return Spacing.createSpacing(indentLen, indentLen, 0, false, 0, 0)
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlFormattingModelBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlFormattingModelBuilder.kt
@@ -86,16 +86,18 @@ class SqlFormattingModelBuilder : FormattingModelBuilder {
             .spacing(1, 1, 0, false, 0)
             .around(SqlTypes.ASTERISK)
             .spacing(1, 1, 0, false, 0)
+            .before(SqlTypes.LEFT_PAREN)
+            .spacing(1, 1, 0, false, 0)
 
     private fun createCustomSpacingBuilder(): SqlCustomSpacingBuilder =
         SqlCustomSpacingBuilder()
             .withSpacing(
-                TokenType.WHITE_SPACE,
-                SqlTypes.KEYWORD,
+                SqlTypes.NUMBER,
+                SqlTypes.COMMA,
                 SqlCustomSpacingBuilder.nonSpacing,
             ).withSpacing(
-                SqlTypes.WORD,
-                TokenType.WHITE_SPACE,
+                SqlTypes.STRING,
+                SqlTypes.COMMA,
                 SqlCustomSpacingBuilder.nonSpacing,
             ).withSpacing(
                 SqlTypes.WORD,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlFormattingModelBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlFormattingModelBuilder.kt
@@ -110,10 +110,6 @@ class SqlFormattingModelBuilder : FormattingModelBuilder {
                 SqlTypes.RIGHT_PAREN,
                 SqlCustomSpacingBuilder.nonSpacing,
             ).withSpacing(
-                SqlTypes.OTHER,
-                TokenType.WHITE_SPACE,
-                SqlCustomSpacingBuilder.nonSpacing,
-            ).withSpacing(
                 SqlTypes.ASTERISK,
                 TokenType.WHITE_SPACE,
                 SqlCustomSpacingBuilder.nonSpacing,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlKeywordUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlKeywordUtil.kt
@@ -81,6 +81,7 @@ class SqlKeywordUtil {
 
         private val SECOND_KEYWORD =
             setOf(
+                "set",
                 "from",
                 "where",
                 "order",

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlCommaBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlCommaBlock.kt
@@ -25,6 +25,7 @@ import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlCreateKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlInsertKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlColumnGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlParallelListBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateValueGroupBlock
@@ -42,6 +43,13 @@ open class SqlCommaBlock(
         null,
         spacingBuilder,
     ) {
+    override val indent =
+        ElementIndent(
+            IndentType.COMMA,
+            0,
+            0,
+        )
+
     override fun setParentGroupBlock(block: SqlBlock?) {
         super.setParentGroupBlock(block)
         indent.indentLevel = IndentType.COMMA
@@ -56,6 +64,10 @@ open class SqlCommaBlock(
     override fun createBlockIndentLen(): Int {
         parentBlock?.let { parent ->
             if (parent is SqlSubGroupBlock) {
+                if (parent is SqlParallelListBlock) {
+                    return 0
+                }
+
                 val parentIndentLen = parent.indent.groupIndentLen
                 if (parent is SqlUpdateColumnGroupBlock || parent is SqlUpdateValueGroupBlock) {
                     return parentIndentLen

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlLineCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlLineCommentBlock.kt
@@ -21,7 +21,7 @@ import com.intellij.formatting.SpacingBuilder
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
-import org.domaframework.doma.intellij.formatter.block.group.SqlSubQueryGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
 
 open class SqlLineCommentBlock(
     node: ASTNode,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlOtherBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlOtherBlock.kt
@@ -49,7 +49,7 @@ open class SqlOtherBlock(
     override fun setParentGroupBlock(block: SqlBlock?) {
         super.setParentGroupBlock(block)
         indent.indentLevel = IndentType.NONE
-        indent.indentLen = createIntendLen()
+        indent.indentLen = createIndentLen()
         indent.groupIndentLen = 0
     }
 
@@ -57,7 +57,7 @@ open class SqlOtherBlock(
 
     override fun getIndent(): Indent? = Indent.getSpaceIndent(indent.indentLen)
 
-    private fun createIntendLen(): Int {
+    private fun createIndentLen(): Int {
         if (isUpdateColumnSubstitutions) {
             parentBlock?.let { return it.indent.groupIndentLen.plus(1) }
                 ?: return indent.indentLen

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
@@ -21,10 +21,13 @@ import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.IndentType
-import org.domaframework.doma.intellij.formatter.block.group.SqlColumnDefinitionGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.SqlColumnDefinitionRawGroupBlock
-import org.domaframework.doma.intellij.formatter.block.group.SqlInsertColumnGroupBlock
-import org.domaframework.doma.intellij.formatter.block.group.SqlInsertKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlInsertKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlUpdateKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlColumnDefinitionGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlInsertColumnGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateColumnGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateValueGroupBlock
 import org.domaframework.doma.intellij.psi.SqlTypes
 
 /**
@@ -82,11 +85,21 @@ open class SqlRightPatternBlock(
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
 
-    override fun createBlockIndentLen(): Int = parentBlock?.indent?.groupIndentLen ?: 1
+    override fun createBlockIndentLen(): Int =
+        if (parentBlock is SqlUpdateColumnGroupBlock || parentBlock is SqlUpdateValueGroupBlock) {
+            parentBlock?.indent?.indentLen ?: 1
+        } else {
+            parentBlock?.indent?.groupIndentLen ?: 1
+        }
 
     override fun isLeaf(): Boolean = true
 
-    fun isNeedBeforeWhiteSpace(lastGroup: SqlBlock?): Boolean =
+    fun isNewLine(lastGroup: SqlBlock?): Boolean =
         lastGroup is SqlColumnDefinitionGroupBlock ||
-            lastGroup is SqlColumnDefinitionRawGroupBlock
+            lastGroup is SqlColumnDefinitionRawGroupBlock ||
+            lastGroup?.parentBlock is SqlUpdateKeywordGroupBlock ||
+            lastGroup?.parentBlock is SqlUpdateColumnGroupBlock ||
+            lastGroup is SqlUpdateColumnGroupBlock ||
+            lastGroup is SqlUpdateValueGroupBlock ||
+            lastGroup?.parentBlock is SqlUpdateValueGroupBlock
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlWordBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlWordBlock.kt
@@ -22,7 +22,7 @@ import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.IndentType
-import org.domaframework.doma.intellij.formatter.block.group.SqlSubQueryGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
 
 open class SqlWordBlock(
     node: ASTNode,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElConditionLoopCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElConditionLoopCommentBlock.kt
@@ -21,47 +21,33 @@ import com.intellij.formatting.Spacing
 import com.intellij.formatting.SpacingBuilder
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.formatter.common.AbstractBlock
-import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.psi.util.elementType
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.SqlCustomSpacingBuilder
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlockCommentBlock
-import org.domaframework.doma.intellij.formatter.block.SqlCommentBlock
 import org.domaframework.doma.intellij.formatter.block.SqlOperationBlock
 import org.domaframework.doma.intellij.formatter.block.SqlUnknownBlock
-import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
-import org.domaframework.doma.intellij.psi.SqlElElseifDirective
-import org.domaframework.doma.intellij.psi.SqlElForDirective
-import org.domaframework.doma.intellij.psi.SqlElIfDirective
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlCreateKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlInsertKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlColumnGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 import org.domaframework.doma.intellij.psi.SqlTypes
 
-enum class SqlDirectiveType {
-    IF,
-    ELSEIF,
-    ELSE,
-    FOR,
-    END,
-    Variable,
-}
-
-open class SqlElBlockCommentBlock(
+class SqlElConditionLoopCommentBlock(
     node: ASTNode,
     wrap: Wrap?,
     alignment: Alignment?,
-    open val customSpacingBuilder: SqlCustomSpacingBuilder?,
+    override val customSpacingBuilder: SqlCustomSpacingBuilder?,
     spacingBuilder: SpacingBuilder,
-) : SqlCommentBlock(
+) : SqlElBlockCommentBlock(
         node,
         wrap,
         alignment,
+        customSpacingBuilder,
         spacingBuilder,
     ) {
-    // open var isConditionLoopBlock = getConditionOrLoopBlock(node)
-
     override val indent =
         ElementIndent(
             IndentType.NONE,
@@ -129,47 +115,6 @@ open class SqlElBlockCommentBlock(
             else -> SqlUnknownBlock(child, wrap, alignment, spacingBuilder)
         }
 
-    private fun getConditionOrLoopBlock(node: ASTNode): Boolean {
-        val directiveType =
-            when {
-                PsiTreeUtil.getChildOfType(node.psi, SqlElIfDirective::class.java) != null -> {
-                    SqlDirectiveType.IF
-                }
-
-                PsiTreeUtil.getChildOfType(node.psi, SqlElElseifDirective::class.java) != null -> {
-                    SqlDirectiveType.ELSEIF
-                }
-
-                PsiTreeUtil.getChildOfType(node.psi, SqlElForDirective::class.java) != null -> {
-                    SqlDirectiveType.FOR
-                }
-
-                PsiTreeUtil.getChildOfType(node.psi, SqlElElseifDirective::class.java) != null -> {
-                    SqlDirectiveType.ELSE
-                }
-
-                PsiTreeUtil.getChildOfType(node.psi, SqlElForDirective::class.java) != null -> {
-                    SqlDirectiveType.END
-                }
-
-                else -> {
-                    val children =
-                        PsiTreeUtil
-                            .getChildrenOfType(node.psi, PsiElement::class.java)
-                            ?.firstOrNull { it.elementType == SqlTypes.EL_ELSE || it.elementType == SqlTypes.EL_END }
-                    children?.let {
-                        when (it.elementType) {
-                            SqlTypes.EL_ELSE -> SqlDirectiveType.ELSE
-                            SqlTypes.EL_END -> SqlDirectiveType.END
-                            else -> SqlDirectiveType.Variable
-                        }
-                    } ?: SqlDirectiveType.Variable
-                }
-            }
-
-        return directiveType != SqlDirectiveType.Variable
-    }
-
     private fun createFieldAccessSpacingBuilder(): SqlCustomSpacingBuilder =
         SqlCustomSpacingBuilder()
             .withSpacing(
@@ -223,14 +168,40 @@ open class SqlElBlockCommentBlock(
     override fun isLeaf(): Boolean = false
 
     override fun createBlockIndentLen(): Int {
-        parentBlock?.let {
-            if (it is SqlSubQueryGroupBlock) {
-                if (it.childBlocks.dropLast(1).isEmpty()) {
-                    return 1
+        parentBlock?.let { parent ->
+            if (parent is SqlSubGroupBlock) {
+                val parentIndentLen = parent.indent.groupIndentLen
+                val grand = parent.parentBlock
+                grand?.let { grand ->
+                    if (grand is SqlCreateKeywordGroupBlock) {
+                        val grandIndentLen = grand.indent.groupIndentLen
+                        return grandIndentLen.plus(parentIndentLen).minus(1)
+                    }
+                    if (grand is SqlInsertKeywordGroupBlock) {
+                        return parentIndentLen
+                    }
+                    if (grand is SqlColumnGroupBlock) {
+                        val grandIndentLen = grand.indent.groupIndentLen
+                        var prevTextLen = 1
+                        parent.prevChildren?.dropLast(1)?.forEach { prev -> prevTextLen = prevTextLen.plus(prev.node.text.length) }
+                        return grandIndentLen.plus(prevTextLen).plus(1)
+                    }
                 }
-                if (it.isFirstLineComment) {
-                    return it.indent.groupIndentLen.minus(2)
-                }
+                return parentIndentLen
+            } else {
+                var prevLen = 0
+                parent.childBlocks
+                    .filter { it.node.elementType == SqlTypes.KEYWORD }
+                    .forEach { prev ->
+                        prevLen =
+                            prevLen.plus(
+                                prev.node.text.length
+                                    .plus(1),
+                            )
+                    }
+                return parent.indent.groupIndentLen
+                    .plus(prevLen)
+                    .plus(1)
             }
         }
         return 1

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlCreateKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlCreateKeywordGroupBlock.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group
+package org.domaframework.doma.intellij.formatter.block.group.keyword
 
 import com.intellij.formatting.Alignment
 import com.intellij.formatting.Indent
@@ -21,10 +21,11 @@ import com.intellij.formatting.SpacingBuilder
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
+import org.domaframework.doma.intellij.formatter.CreateQueryType
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 
-open class SqlInsertKeywordGroupBlock(
+open class SqlCreateKeywordGroupBlock(
     node: ASTNode,
     wrap: Wrap?,
     alignment: Alignment?,
@@ -36,6 +37,8 @@ open class SqlInsertKeywordGroupBlock(
         alignment,
         spacingBuilder,
     ) {
+    var createType: CreateQueryType = CreateQueryType.NONE
+
     override fun setParentGroupBlock(block: SqlBlock?) {
         super.setParentGroupBlock(block)
         indent.indentLevel = IndentType.TOP
@@ -45,7 +48,12 @@ open class SqlInsertKeywordGroupBlock(
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
 
-    override fun getIndent(): Indent? = Indent.getSpaceIndent(indent.indentLen)
+    override fun getIndent(): Indent? {
+        if (parentBlock?.indent?.indentLevel == IndentType.SUB) {
+            return Indent.getSpaceIndent(0)
+        }
+        return Indent.getNoneIndent()
+    }
 
     override fun createBlockIndentLen(): Int =
         parentBlock?.let {
@@ -55,4 +63,8 @@ open class SqlInsertKeywordGroupBlock(
                 0
             }
         } ?: 0
+
+    fun setCreateQueryType(nextKeyword: String) {
+        createType = CreateQueryType.getCreateTableType(nextKeyword)
+    }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlInlineSecondGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlInlineSecondGroupBlock.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group
+package org.domaframework.doma.intellij.formatter.block.group.keyword
 
 import com.intellij.formatting.Alignment
 import com.intellij.formatting.Indent
@@ -23,36 +23,33 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.group.SqlNewGroupBlock
 
-/**
- * Group blocks when generating columns with subqueries
- */
-class SqlColumnGroupBlock(
+open class SqlInlineSecondGroupBlock(
     node: ASTNode,
     wrap: Wrap?,
     alignment: Alignment?,
     spacingBuilder: SpacingBuilder,
-) : SqlSubGroupBlock(
+) : SqlNewGroupBlock(
         node,
         wrap,
         alignment,
         spacingBuilder,
     ) {
-    var isFirstColumnGroup = node.text != ","
+    val isEndCase = node.text.lowercase() == "end"
 
     override val indent =
         ElementIndent(
-            IndentType.COLUMN,
+            IndentType.INLINE_SECOND,
             0,
             0,
         )
 
     override fun setParentGroupBlock(block: SqlBlock?) {
         super.setParentGroupBlock(block)
-        indent.indentLevel = IndentType.COLUMN
+        indent.indentLevel = IndentType.INLINE_SECOND
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen =
-            if (isFirstColumnGroup) indent.indentLen else indent.indentLen.plus(1)
+        indent.groupIndentLen = indent.indentLen
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
@@ -61,16 +58,12 @@ class SqlColumnGroupBlock(
 
     override fun createBlockIndentLen(): Int =
         parentBlock?.let {
-            if (it is SqlKeywordGroupBlock) {
-                val parentIndentLen = it.indent.indentLen.plus(it.node.text.length)
-                val subGroup = it.parentBlock as? SqlSubGroupBlock
-                if (subGroup is SqlSubGroupBlock && !subGroup.isFirstLineComment) {
-                    parentIndentLen.plus(3)
-                } else {
-                    parentIndentLen.plus(1)
-                }
+            // TODO:Customize indentation within an inline group
+            if (isEndCase) {
+                it.indent.indentLen
             } else {
-                it.indent.groupIndentLen.plus(1)
+                it.indent.groupIndentLen
+                    .plus(it.node.text.length)
             }
         } ?: 1
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlInsertKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlInsertKeywordGroupBlock.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group
+package org.domaframework.doma.intellij.formatter.block.group.keyword
 
 import com.intellij.formatting.Alignment
 import com.intellij.formatting.Indent
@@ -24,44 +24,35 @@ import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 
-open class SqlInlineGroupBlock(
+open class SqlInsertKeywordGroupBlock(
     node: ASTNode,
     wrap: Wrap?,
     alignment: Alignment?,
     spacingBuilder: SpacingBuilder,
-) : SqlNewGroupBlock(
+) : SqlKeywordGroupBlock(
         node,
+        IndentType.TOP,
         wrap,
         alignment,
         spacingBuilder,
     ) {
-    override val indent =
-        ElementIndent(
-            IndentType.INLINE,
-            0,
-            0,
-        )
-
     override fun setParentGroupBlock(block: SqlBlock?) {
         super.setParentGroupBlock(block)
-        indent.indentLevel = IndentType.INLINE
+        indent.indentLevel = IndentType.TOP
         indent.indentLen = createBlockIndentLen()
         indent.groupIndentLen = indent.indentLen.plus(node.text.length)
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
 
-    override fun getIndent(): Indent? {
-        if (parentBlock?.indent?.indentLevel == IndentType.SUB) {
-            return Indent.getSpaceIndent(0)
-        }
-        return Indent.getNoneIndent()
-    }
+    override fun getIndent(): Indent? = Indent.getSpaceIndent(indent.indentLen)
 
     override fun createBlockIndentLen(): Int =
         parentBlock?.let {
-            it.indent.groupIndentLen
-                .plus(it.node.text.length)
-                .plus(1)
-        } ?: 1
+            if (it.indent.indentLevel == IndentType.SUB) {
+                it.indent.groupIndentLen.plus(1)
+            } else {
+                0
+            }
+        } ?: 0
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlJoinGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlJoinGroupBlock.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group
+package org.domaframework.doma.intellij.formatter.block.group.keyword
 
 import com.intellij.formatting.Alignment
 import com.intellij.formatting.Indent
@@ -21,50 +21,43 @@ import com.intellij.formatting.SpacingBuilder
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
-import org.domaframework.doma.intellij.formatter.CreateQueryType
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 
-open class SqlCreateKeywordGroupBlock(
+open class SqlJoinGroupBlock(
     node: ASTNode,
     wrap: Wrap?,
     alignment: Alignment?,
     spacingBuilder: SpacingBuilder,
 ) : SqlKeywordGroupBlock(
         node,
-        IndentType.TOP,
+        IndentType.JOIN,
         wrap,
         alignment,
         spacingBuilder,
     ) {
-    var createType: CreateQueryType = CreateQueryType.NONE
+    override val indent =
+        ElementIndent(
+            IndentType.JOIN,
+            0,
+            0,
+        )
 
     override fun setParentGroupBlock(block: SqlBlock?) {
-        super.setParentGroupBlock(block)
-        indent.indentLevel = IndentType.TOP
+        parentBlock = block
+        parentBlock?.childBlocks?.add(this)
+        indent.indentLevel = IndentType.JOIN
         indent.indentLen = createBlockIndentLen()
         indent.groupIndentLen = indent.indentLen.plus(node.text.length)
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
 
-    override fun getIndent(): Indent? {
-        if (parentBlock?.indent?.indentLevel == IndentType.SUB) {
-            return Indent.getSpaceIndent(0)
-        }
-        return Indent.getNoneIndent()
-    }
+    override fun getIndent(): Indent? = Indent.getSpaceIndent(indent.indentLen)
 
     override fun createBlockIndentLen(): Int =
-        parentBlock?.let {
-            if (it.indent.indentLevel == IndentType.SUB) {
-                it.indent.groupIndentLen.plus(1)
-            } else {
-                0
-            }
-        } ?: 0
-
-    fun setCreateQueryType(nextKeyword: String) {
-        createType = CreateQueryType.getCreateTableType(nextKeyword)
-    }
+        parentBlock
+            ?.indent
+            ?.groupIndentLen
+            ?.plus(1) ?: 1
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlKeywordGroupBlock.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group
+package org.domaframework.doma.intellij.formatter.block.group.keyword
 
 import com.intellij.formatting.Alignment
 import com.intellij.formatting.Indent
@@ -24,6 +24,10 @@ import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.SqlKeywordUtil
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.group.SqlNewGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlViewGroupBlock
 import org.domaframework.doma.intellij.psi.SqlTypes
 
 open class SqlKeywordGroupBlock(
@@ -71,7 +75,8 @@ open class SqlKeywordGroupBlock(
                 val diffPreBlockTextLen = node.text.length.minus(preChildBlock.node.text.length)
                 return preChildBlock.indent.indentLen.minus(diffPreBlockTextLen)
             } else {
-                return preChildBlock.indent.indentLen
+                val diffPretextLen = node.text.length.minus(preChildBlock.node.text.length)
+                return preChildBlock.indent.indentLen.minus(diffPretextLen)
             }
         } else {
             return createBlockIndentLen()

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlUpdateKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlUpdateKeywordGroupBlock.kt
@@ -13,42 +13,48 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group
+package org.domaframework.doma.intellij.formatter.block.group.keyword
 
 import com.intellij.formatting.Alignment
+import com.intellij.formatting.Indent
 import com.intellij.formatting.SpacingBuilder
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
+import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 
-/**
- * The parent must be [SqlColumnDefinitionRawGroupBlock]
- */
-class SqlDataTypeParamBlock(
+open class SqlUpdateKeywordGroupBlock(
     node: ASTNode,
     wrap: Wrap?,
     alignment: Alignment?,
     spacingBuilder: SpacingBuilder,
-) : SqlSubGroupBlock(
+) : SqlKeywordGroupBlock(
         node,
+        IndentType.SECOND,
         wrap,
         alignment,
         spacingBuilder,
     ) {
-    override val indent =
-        ElementIndent(
-            IndentType.PARAM,
-            0,
-            0,
-        )
-
     override fun setParentGroupBlock(block: SqlBlock?) {
         super.setParentGroupBlock(block)
-        indent.indentLevel = IndentType.PARAM
-        indent.indentLen = 0
-        indent.groupIndentLen = 0
+        indent.indentLevel = IndentType.SECOND
+        indent.indentLen = createBlockIndentLen()
+        indent.groupIndentLen = indent.indentLen.plus(node.text.length)
     }
 
-    override fun createBlockIndentLen(): Int = 0
+    override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
+
+    override fun getIndent(): Indent? = Indent.getSpaceIndent(indent.indentLen)
+
+    override fun createBlockIndentLen(): Int =
+        parentBlock?.let {
+            if (it.indent.indentLevel == IndentType.SUB) {
+                it.indent.groupIndentLen.plus(1)
+            } else {
+                val parentTextLen = it.node.text.length
+                val diffTextLen = parentTextLen.minus(node.text.length)
+                it.indent.indentLen.plus(diffTextLen)
+            }
+        } ?: 0
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlColumnDefinitionGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlColumnDefinitionGroupBlock.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group
+package org.domaframework.doma.intellij.formatter.block.group.subgroup
 
 import com.intellij.formatting.Alignment
 import com.intellij.formatting.Indent

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlDataTypeParamBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlDataTypeParamBlock.kt
@@ -13,22 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block
+package org.domaframework.doma.intellij.formatter.block.group.subgroup
 
 import com.intellij.formatting.Alignment
 import com.intellij.formatting.SpacingBuilder
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
-import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.IndentType
-import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlColumnDefinitionGroupBlock
+import org.domaframework.doma.intellij.formatter.block.SqlBlock
 
-class SqlColumnBlock(
+/**
+ * The parent must be [org.domaframework.doma.intellij.formatter.block.group.SqlColumnDefinitionRawGroupBlock]
+ */
+class SqlDataTypeParamBlock(
     node: ASTNode,
     wrap: Wrap?,
     alignment: Alignment?,
     spacingBuilder: SpacingBuilder,
-) : SqlWordBlock(
+) : SqlSubGroupBlock(
         node,
         wrap,
         alignment,
@@ -36,30 +38,17 @@ class SqlColumnBlock(
     ) {
     override val indent =
         ElementIndent(
-            IndentType.NONE,
+            IndentType.PARAM,
             0,
             0,
         )
 
     override fun setParentGroupBlock(block: SqlBlock?) {
         super.setParentGroupBlock(block)
-        indent.indentLevel = IndentType.NONE
-        // Calculate right justification space during indentation after getting all column rows
-        indent.indentLen = 1
+        indent.indentLevel = IndentType.PARAM
+        indent.indentLen = 0
         indent.groupIndentLen = 0
     }
 
-    override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
-
-    override fun createBlockIndentLen(): Int {
-        parentBlock?.let {
-            val parentGroupDefinition = it.parentBlock as? SqlColumnDefinitionGroupBlock
-            if (parentGroupDefinition == null) return 1
-
-            val groupMaxAlimentLen = parentGroupDefinition.alignmentColumnName.length
-            val diffColumnName = groupMaxAlimentLen.minus(node.text.length)
-            return diffColumnName.plus(1)
-        }
-        return 1
-    }
+    override fun createBlockIndentLen(): Int = 0
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlFunctionParamBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlFunctionParamBlock.kt
@@ -13,55 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group
+package org.domaframework.doma.intellij.formatter.block.group.subgroup
 
 import com.intellij.formatting.Alignment
-import com.intellij.formatting.Indent
 import com.intellij.formatting.SpacingBuilder
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
-import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.SqlCommentBlock
 
-abstract class SqlSubGroupBlock(
+class SqlFunctionParamBlock(
     node: ASTNode,
     wrap: Wrap?,
     alignment: Alignment?,
     spacingBuilder: SpacingBuilder,
-) : SqlNewGroupBlock(
+) : SqlSubGroupBlock(
         node,
         wrap,
         alignment,
         spacingBuilder,
     ) {
-    var isFirstLineComment = false
-    var prevChildren: List<SqlBlock>? = emptyList<SqlBlock>()
-
     override val indent =
         ElementIndent(
-            IndentType.SUB,
+            IndentType.PARAM,
             0,
             0,
         )
 
     override fun setParentGroupBlock(block: SqlBlock?) {
         super.setParentGroupBlock(block)
-        prevChildren = parentBlock?.childBlocks?.toList()
-        indent.indentLevel = indent.indentLevel
-        indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = indent.indentLen.plus(node.text.length)
+        indent.indentLevel = IndentType.PARAM
+        indent.indentLen = 0
+        indent.groupIndentLen = 0
     }
 
-    override fun addChildBlock(childBlock: SqlBlock) {
-        childBlocks.add(childBlock)
-        if (!isFirstLineComment) {
-            isFirstLineComment = childBlock is SqlCommentBlock
-        }
-    }
-
-    override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
-
-    override fun getIndent(): Indent? = Indent.getSpaceIndent(indent.indentLen)
+    override fun createBlockIndentLen(): Int = 0
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlParallelListBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlParallelListBlock.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.formatter.block.group.subgroup
+
+import com.intellij.formatting.Alignment
+import com.intellij.formatting.SpacingBuilder
+import com.intellij.formatting.Wrap
+import com.intellij.lang.ASTNode
+import org.domaframework.doma.intellij.formatter.IndentType
+import org.domaframework.doma.intellij.formatter.block.SqlBlock
+
+/**
+ * A class that represents the List type test data after the IN clause.
+ * If the child element is a [org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock],
+ * it controls the indentation in the same way as a [SqlSubQueryGroupBlock].
+ * If the direct child element is a comma, it controls the line break.
+ */
+class SqlParallelListBlock(
+    node: ASTNode,
+    wrap: Wrap?,
+    alignment: Alignment?,
+    spacingBuilder: SpacingBuilder,
+) : SqlSubQueryGroupBlock(
+        node,
+        wrap,
+        alignment,
+        spacingBuilder,
+    ) {
+    override val indent =
+        ElementIndent(
+            IndentType.SUB,
+            0,
+            0,
+        )
+
+    override fun setParentGroupBlock(block: SqlBlock?) {
+        super.setParentGroupBlock(block)
+    }
+}

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubQueryGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubQueryGroupBlock.kt
@@ -26,7 +26,7 @@ import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlJoinGroupBlock
 import org.domaframework.doma.intellij.psi.SqlTypes
 
-class SqlSubQueryGroupBlock(
+open class SqlSubQueryGroupBlock(
     node: ASTNode,
     wrap: Wrap?,
     alignment: Alignment?,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlUpdateColumnGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlUpdateColumnGroupBlock.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.formatter.block.group.subgroup
+
+import com.intellij.formatting.Alignment
+import com.intellij.formatting.Indent
+import com.intellij.formatting.SpacingBuilder
+import com.intellij.formatting.Wrap
+import com.intellij.lang.ASTNode
+import com.intellij.psi.formatter.common.AbstractBlock
+import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlUpdateKeywordGroupBlock
+import org.domaframework.doma.intellij.psi.SqlTypes
+
+/**
+ * In an UPDATE statement using the row value constructor,
+ * a group representing the column list
+ */
+class SqlUpdateColumnGroupBlock(
+    node: ASTNode,
+    wrap: Wrap?,
+    alignment: Alignment?,
+    spacingBuilder: SpacingBuilder,
+) : SqlSubGroupBlock(
+        node,
+        wrap,
+        alignment,
+        spacingBuilder,
+    ) {
+    override fun setParentGroupBlock(block: SqlBlock?) {
+        super.setParentGroupBlock(block)
+        indent.indentLen = createBlockIndentLen()
+        indent.groupIndentLen = indent.indentLen.plus(1)
+        updateParentGroupIndentLen()
+    }
+
+    override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
+
+    override fun getIndent(): Indent? = Indent.getSpaceIndent(indent.indentLen)
+
+    override fun createBlockIndentLen(): Int {
+        parentBlock?.let {
+            if (it is SqlUpdateKeywordGroupBlock) {
+                var parentLen = 0
+                val keywords =
+                    it.childBlocks.dropLast(1).takeWhile { it.node.elementType == SqlTypes.KEYWORD }
+                keywords.forEach { keyword ->
+                    parentLen = parentLen.plus(keyword.node.text.length).plus(1)
+                }
+                return it.indent.indentLen
+                    .plus(it.node.text.length)
+                    .plus(1)
+                    .plus(parentLen)
+            }
+            // TODO:Customize indentation
+            return 2
+        } ?: return 2
+    }
+
+    private fun updateParentGroupIndentLen() {
+        parentBlock?.let {
+            if (it is SqlUpdateKeywordGroupBlock) {
+                var parentLen = 0
+                val keywords =
+                    it.childBlocks.dropLast(1).takeWhile { it.node.elementType == SqlTypes.KEYWORD }
+                keywords.forEach { keyword ->
+                    parentLen = parentLen.plus(keyword.node.text.length).plus(1)
+                }
+                it.indent.groupIndentLen =
+                    it.indent.indentLen
+                        .plus(it.node.text.length)
+                        .plus(parentLen)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlViewGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlViewGroupBlock.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group
+package org.domaframework.doma.intellij.formatter.block.group.subgroup
 
 import com.intellij.formatting.Alignment
 import com.intellij.formatting.Indent
@@ -23,37 +23,39 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 
-open class SqlJoinGroupBlock(
+open class SqlViewGroupBlock(
     node: ASTNode,
     wrap: Wrap?,
     alignment: Alignment?,
     spacingBuilder: SpacingBuilder,
 ) : SqlKeywordGroupBlock(
         node,
-        IndentType.JOIN,
+        IndentType.SECOND,
         wrap,
         alignment,
         spacingBuilder,
     ) {
     override val indent =
         ElementIndent(
-            IndentType.JOIN,
+            IndentType.SECOND,
             0,
             0,
         )
 
     override fun setParentGroupBlock(block: SqlBlock?) {
-        parentBlock = block
-        parentBlock?.childBlocks?.add(this)
-        indent.indentLevel = IndentType.JOIN
+        super.setParentGroupBlock(block)
+        indent.indentLevel = IndentType.SUB
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = indent.indentLen.plus(node.text.length)
+        indent.groupIndentLen = node.text.length
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
 
     override fun getIndent(): Indent? = Indent.getSpaceIndent(indent.indentLen)
 
-    override fun createBlockIndentLen(): Int = parentBlock?.indent?.groupIndentLen?.plus(1) ?: 1
+    override fun createBlockIndentLen(): Int = parentBlock?.indent?.indentLen ?: 0
+
+    override fun isLeaf(): Boolean = true
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/gutter/sql/SqlLineMakerProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/gutter/sql/SqlLineMakerProvider.kt
@@ -47,7 +47,7 @@ class SqlLineMakerProvider : RelatedItemLineMarkerProvider() {
         val file = e.containingFile ?: return
         if (!isSupportFileType(file) || isInjectionSqlFile(file)) return
         // Display only on the first line
-        if (e.originalElement.parent.originalElement !is PsiFile ||
+        if (e.originalElement?.parent?.originalElement !is PsiFile ||
             e.textRange.startOffset != file.textRange.startOffset
         ) {
             return

--- a/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
@@ -57,6 +57,22 @@ class SqlFormatterTest : BasePlatformTestCase() {
         formatSqlFime("Insert.sql", "FormattedInsert.sql")
     }
 
+    fun testInsertWithBindVariableFormatter() {
+        formatSqlFime("InsertWithBindVariable.sql", "FormattedInsertWithBindVariable.sql")
+    }
+
+    fun testUpdateFormatter() {
+        formatSqlFime("Update.sql", "FormattedUpdate.sql")
+    }
+
+    fun testUpdateBindVariableFormatter() {
+        formatSqlFime("UpdateBindVariable.sql", "FormattedUpdateBindVariable.sql")
+    }
+
+    fun testUpdateTupleAssignmentFormatter() {
+        formatSqlFime("UpdateTupleAssignment.sql", "FormattedUpdateTupleAssignment.sql")
+    }
+
     fun testDeleteFormatter() {
         formatSqlFime("Delete.sql", "FormattedDelete.sql")
     }

--- a/src/test/testData/sql/formatter/FormattedInsertWithBindVariable.sql
+++ b/src/test/testData/sql/formatter/FormattedInsertWithBindVariable.sql
@@ -1,0 +1,19 @@
+INSERT INTO /*# tableName */
+            (x1
+             , x2
+             /*%for entity : entities */
+             , /*# entity.itemIdentifier */
+             /*%end*/
+             , x3
+             , x4)
+     VALUES ( /* reportId */1
+             , /* @tenantId() */1
+             /*%for entity : entities */
+             , /* entity.value */'abc'
+             /*%end*/
+             , /* @userId() */1
+             , x5
+             , /* @userId() */1
+             , x6
+             , 1
+             , /* @maxDateTime() */'9999-12-31') 

--- a/src/test/testData/sql/formatter/FormattedSelect.sql
+++ b/src/test/testData/sql/formatter/FormattedSelect.sql
@@ -1,5 +1,6 @@
 /** TopBlock */
-SELECT o.*
+SELECT COUNT(DISTINCT (x))
+       , o.*
        , ISNULL(nbor.nearest
                 , 999) AS nearest -- column Line comment
   /** From */
@@ -20,6 +21,7 @@ SELECT o.*
                 LEFT OUTER JOIN specobj s
                              /** ON */
                              ON p.objid = s.bestobjid
+                            AND p.plate = s.plate
           /** Where */
           WHERE p.TYPE = DBO.FPHOTOTYPE('Star')
             AND (p.flags & DBO.FPHOTOFLAGS('EDGE')) = 0
@@ -40,4 +42,5 @@ SELECT o.*
                                   OR x.TYPE = DBO.FPHOTOTYPE('Galaxy'))
                             AND x.modelmag_g BETWEEN 10 AND 21
                           GROUP BY n.objid ) AS nbor
-                    ON o.objid = nbor.objid 
+                    ON o.objid = nbor.objid
+ WHERE p.list IN /* params */(1, 2, 3) 

--- a/src/test/testData/sql/formatter/FormattedUpdate.sql
+++ b/src/test/testData/sql/formatter/FormattedUpdate.sql
@@ -1,4 +1,4 @@
-UPDATE USER
+UPDATE user
    SET name = /* user.name */'name'
        , rank = /*user.rank */3
  WHERE id = /* user.id */1 

--- a/src/test/testData/sql/formatter/FormattedUpdateBindVariable.sql
+++ b/src/test/testData/sql/formatter/FormattedUpdateBindVariable.sql
@@ -1,0 +1,8 @@
+UPDATE /*# tableName */
+   SET X1 = 1
+       , X2 = 2
+       , X3 = 3
+       /*%for entity : entities */
+       , /*# entity.itemIdentifier */= /* entity.value */'abc'
+       /*%end*/
+ WHERE X = /* reportId */1 

--- a/src/test/testData/sql/formatter/FormattedUpdateTupleAssignment.sql
+++ b/src/test/testData/sql/formatter/FormattedUpdateTupleAssignment.sql
@@ -1,0 +1,16 @@
+UPDATE /*# tableName */
+   SET (x1
+        , x2
+        , x3
+        /*%for entity : entities */
+        , /*# entity.itemIdentifier */
+        /*%end*/
+       )
+       = ( /* @userId() */1
+          , x
+          , x + 1
+          /*%for entity : entities */
+          , /* entity.value */'abc'
+          /*%end*/
+         )
+ WHERE x = /* reportId */1 

--- a/src/test/testData/sql/formatter/InsertWithBindVariable.sql
+++ b/src/test/testData/sql/formatter/InsertWithBindVariable.sql
@@ -1,0 +1,16 @@
+INSERT INTO /*# tableName */
+            (x1
+            , x2
+       /*%for entity : entities */
+             , /*# entity.itemIdentifier */
+       /*%end*/
+             , x3
+             , x4)
+     VALUES ( /* reportId */1, /* @tenantId() */1 /*%for entity : entities */, /* entity.value */'abc'
+             /*%end*/
+             , /* @userId() */1
+             , x5
+             , /* @userId() */1
+             , x6
+             , 1
+             , /* @maxDateTime() */'9999-12-31')

--- a/src/test/testData/sql/formatter/Select.sql
+++ b/src/test/testData/sql/formatter/Select.sql
@@ -1,5 +1,5 @@
 /** TopBlock */
-SELECT o.*
+SELECT COUNT( DISTINCT (x)),o.*
        , ISNULL(nbor.nearest
                 , 999) AS nearest -- column Line comment
   /** From */
@@ -22,7 +22,7 @@ SELECT o.*
                 /** Join */
                 LEFT OUTER JOIN specobj s
                              /** ON */
-                             ON p.objid = s.bestobjid
+                             ON p.objid = s.bestobjid AND p.plate = s.plate
           /** Where */
           WHERE p.TYPE = DBO.FPHOTOTYPE('Star')
             AND (p.flags & DBO.FPHOTOFLAGS('EDGE')) = 0
@@ -52,3 +52,6 @@ SELECT o.*
 
                           GROUP BY n.objid ) AS nbor
                     ON o.objid = nbor.objid
+                WHERE p.list IN /* params */(1
+                                            ,2
+                                            ,3)

--- a/src/test/testData/sql/formatter/UpdateBindVariable.sql
+++ b/src/test/testData/sql/formatter/UpdateBindVariable.sql
@@ -1,0 +1,8 @@
+UPDATE /*# tableName */
+ SET X1 = 1
+       , X2 = 2
+       , X3 = 3
+       /*%for entity : entities */
+       , /*# entity.itemIdentifier */= /* entity.value */'abc'
+ /*%end*/
+ WHERE X = /* reportId */1

--- a/src/test/testData/sql/formatter/UpdateTupleAssignment.sql
+++ b/src/test/testData/sql/formatter/UpdateTupleAssignment.sql
@@ -1,0 +1,12 @@
+UPDATE /*# tableName */
+ SET (x1
+      , x2
+      , x3
+      /*%for entity : entities */
+      , /*# entity.itemIdentifier */ 
+      /*%end*/) = ( /* @userId() */1
+         , x
+         , x + 1
+         /*%for entity : entities */
+         , /* entity.value */'abc'
+         /*%end*/) WHERE x = /* reportId */1 


### PR DESCRIPTION
Fixed unintended SQL formatting behavior
- Remove the space before keyword elements within functions.
- Remove line breaks from test data of List type.
- Prevent increased indentation when multiple columns are specified in Create or Update queries.
- Make block comments in conditional and loop directives subject to line breaks.
- Adjust the indentation level for bulk multi-column updates in Update queries.
- Relocate the package for the format block
- Delegate some processing to another class