### PR TITLE
Strengthen checks when referencing nullable objects.

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/action/sql/JumpToDeclarationFromSqlAction.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/action/sql/JumpToDeclarationFromSqlAction.kt
@@ -203,7 +203,7 @@ class JumpToDeclarationFromSqlAction : AnAction() {
      */
     private fun isNotBindVariable(it: PsiElement) =
         (
-            it.parent.elementType is IFileElementType &&
+            it.parent?.elementType is IFileElementType &&
                 it.elementType != SqlTypes.EL_IDENTIFIER &&
                 it !is SqlElPrimaryExpr &&
                 !it.isNotWhiteSpace()

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
@@ -149,7 +149,7 @@ class PsiDaoMethod(
             val rootDir = psiProject.getContentRoot(daoFile) ?: return@runReadAction
             val sqlFile = File(sqlFilePath)
             val sqlFileName = sqlFile.name
-            val parentDir = "${RESOURCES_PATH}/${sqlFile.parent.replace("\\", "/")}"
+            val parentDir = "${RESOURCES_PATH}/${sqlFile.parent?.replace("\\", "/")}"
             val parenDirPathSpirit = parentDir.split("/").toTypedArray()
 
             WriteCommandAction.runWriteCommandAction(psiProject) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiPatternUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiPatternUtil.kt
@@ -59,8 +59,9 @@ object PsiPatternUtil {
                             (element.elementType == SqlTypes.EL_IDENTIFIER && element.prevLeaf()?.text == it) ||
                             (
                                 element.elementType == TokenType.BAD_CHARACTER &&
-                                    element.parent.prevLeafs
-                                        .firstOrNull { p -> p.text == it || p.elementType == SqlTypes.BLOCK_COMMENT_START }
+                                    element.parent
+                                        ?.prevLeafs
+                                        ?.firstOrNull { p -> p.text == it || p.elementType == SqlTypes.BLOCK_COMMENT_START }
                                         ?.text == it
                             )
                     }
@@ -75,7 +76,11 @@ object PsiPatternUtil {
                 override fun accepts(
                     element: PsiElement,
                     context: ProcessingContext?,
-                ): Boolean = element.containingFile.originalFile.virtualFile.extension == extension
+                ): Boolean =
+                    element.containingFile
+                        ?.originalFile
+                        ?.virtualFile
+                        ?.extension == extension
             },
         )
 
@@ -88,7 +93,7 @@ object PsiPatternUtil {
         element: PsiElement,
         symbol: String,
     ): String {
-        val text = originalFile.containingFile.text
+        val text = originalFile.containingFile?.text ?: " "
         val offset = element.textOffset
         val builder = StringBuilder()
         for (i in offset - 1 downTo 0) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
@@ -258,7 +258,7 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
             setFieldsAndMethodsCompletionResultSet(matchFields, matchMethod, result)
             return
         }
-        if (top.parent !is PsiFile && top.parent.parent !is PsiDirectory) {
+        if (top.parent !is PsiFile && top.parent?.parent !is PsiDirectory) {
             val staticDirective = top.findNodeParent(SqlTypes.EL_STATIC_FIELD_ACCESS_EXPR)
             staticDirective?.let {
                 topElementType = getElementTypeByStaticFieldAccess(top, it, topText) ?: return

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
@@ -580,16 +580,16 @@ open class SqlBlock(
         }
 
         if (child2 is SqlElBlockCommentBlock) {
-            when (child1) {
+            return when (child1) {
                 is SqlElBlockCommentBlock -> {
-                    return SqlCustomSpacingBuilder().getSpacing(child2)
+                    SqlCustomSpacingBuilder().getSpacing(child2)
                 }
 
                 is SqlWhitespaceBlock -> {
-                    return SqlCustomSpacingBuilder().getSpacing(child2)
+                    SqlCustomSpacingBuilder().getSpacing(child2)
                 }
 
-                else -> return SqlCustomSpacingBuilder.normalSpacing
+                else -> SqlCustomSpacingBuilder.normalSpacing
             }
         }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/gutter/sql/SqlLineMakerProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/gutter/sql/SqlLineMakerProvider.kt
@@ -48,7 +48,7 @@ class SqlLineMakerProvider : RelatedItemLineMarkerProvider() {
         if (!isSupportFileType(file) || isInjectionSqlFile(file)) return
         // Display only on the first line
         if (e.originalElement?.parent?.originalElement !is PsiFile ||
-            e.textRange.startOffset != file.textRange.startOffset
+            e.textRange?.startOffset != file.textRange?.startOffset
         ) {
             return
         }
@@ -66,7 +66,7 @@ class SqlLineMakerProvider : RelatedItemLineMarkerProvider() {
                 identifier.textRange,
                 getIcon(daoFile.toPsiFile(project)),
                 getToolTipTitle(daoFile.toPsiFile(project)),
-                getHandler(daoFile, identifier, file.virtualFile.nameWithoutExtension),
+                getHandler(daoFile, identifier, file.virtualFile?.nameWithoutExtension ?: ""),
                 GutterIconRenderer.Alignment.RIGHT,
             ) {
                 ArrayList<GotoRelatedItem>()


### PR DESCRIPTION
Added a null check to prevent unexpected NPEs from occurring when referencing nullable objects.

The implementation causing this issue has already been merged in a separate PR. Therefore, this PR addresses other locations referencing similar properties.
issue: https://github.com/domaframework/doma-tools-for-intellij/issues/83
PR: https://github.com/domaframework/doma-tools-for-intellij/pull/86