### PR TITLE
SQL format call log

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
@@ -120,6 +120,12 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
                     originalFile,
                     result,
                 )
+                PluginLoggerUtil.countLogging(
+                    this::class.java.simpleName,
+                    "CompletionDirectiveByVariable",
+                    "Completion",
+                    startTime,
+                )
             }
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
Since it is difficult to measure the processing time of the processor and the format processing itself, a log that measures only the number of times it is called is output.

Outputs a log when the execution conditions are met within the preprocessor.

When code formatting is called on a directory, logs are output for the number of files.