### PR TITLE
Add beta to Build Version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build plugin
-        run: ./gradlew buildPlugin -PpluginVersion=$RELEASE_VERSION-${{ github.run_number }}
+        run: ./gradlew buildPlugin -PpluginVersion=$RELEASE_VERSION-beta-${{ github.run_number }}
 
       - name: Prepare Plugin Artifact
         id: artifact


### PR DESCRIPTION
After release, add "beta" to the build version generated by the development build action so that the release version takes precedence over the development version.