### PR TITLE
Automating development version updates

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,3 +25,72 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           commitish: main
+
+  update_version:
+    needs: update_release_draft
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Get latest draft release title
+        run: |
+          TITLE=$(gh api repos/${{ github.repository }}/releases \
+            --jq '.[] | select(.draft==true) | .name' | head -n 1)
+          if [[ -z "$TITLE" ]]; then
+            echo "No draft release found."
+            exit 1
+          fi      
+          VERSION=$(echo "$TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [[ -z "$VERSION" ]]; then
+            echo "No version found in version."
+            exit 1
+          fi
+          echo "Extracted version: $VERSION"
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      # Setup Gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+
+      - name: Update Version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew replaceDraftVersion -PdraftVersion=$RELEASE_VERSION
+
+      - name: Commit New Version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git pull
+          git add src/main/kotlin/org/domaframework/doma/intellij/common/PluginUtil.kt
+          git add src/main/resources/logback.xml
+          git add src/main/resources/logback-test.xml
+          git add gradle.properties 
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -am "Update Version With Release Draft - $REPLACE_VERSION"
+          git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   # Prepare and publish the plugin to JetBrains Marketplace repository
   release:
     name: Publish Plugin
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
@@ -58,3 +58,40 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
+
+      - name: Update Version
+        run: |
+          ./gradlew replaceNewVersion -PnewVersion=${{ github.event.release.tag_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit New Version
+        run: |
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git fetch
+          git checkout main
+          git add src/main/kotlin/org/domaframework/doma/intellij/common/PluginUtil.kt
+          git add src/main/resources/logback.xml
+          git add src/main/resources/logback-test.xml
+          git add gradle.properties 
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -am "Update Version With Release - $REPLACE_VERSION"
+          git push origin main
+
+  create_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitish: main

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,5 @@ org.gradle.configuration-cache = true
 org.gradle.caching = true
 
 updateSinceUntilBuild  = false
+
+encoding = UTF-8


### PR DESCRIPTION
After a release and whenever the release draft is updated, 
this PR updates the files in the main branch that hard-code the plugin version. 

It automates the previously manual task of updating the development version.

Because files other than ```gradle.properties``` cannot be updated before the release tag is issued, we will not add the "beta" designation.