### PR TITLE
Execute the required processing within `doLast`.

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,11 +25,11 @@ jobs:
 
   update_version:
     needs: update_release_draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
 
     steps:
       - name: Get latest draft release title


### PR DESCRIPTION
When a function defined outside the task is called from `doLast`, an error occurs when writing to the GIT_ENV file. 
```
Task :replaceDraftVersion of type org.gradle.api.DefaultTask: cannot serialize Gradle script object references as these are not supported with the configuration cache
```
Modify the code so that all processing is completed within `doLast`.