### PR TITLE
Add option --no-configuration-cache

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./gradlew replaceDraftVersion -PdraftVersion=$RELEASE_VERSION
+          ./gradlew replaceDraftVersion -PdraftVersion=$RELEASE_VERSION --no-configuration-cache
 
       - name: Commit New Version
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Update Version
         run: |
-          ./gradlew replaceNewVersion -PnewVersion=${{ github.event.release.tag_name }}
+          ./gradlew replaceNewVersion -PnewVersion=${{ github.event.release.tag_name }} --no-configuration-cache
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -648,7 +648,7 @@ tasks.register("replaceDraftVersion") {
             println("Set Replace version in GITHUB_ENV: $draftVersion")
         } catch (e: NullPointerException) {
             println("GITHUB_ENV not found")
-            println(e.stackTrace)
+            println(e.printStackTrace())
         }
     }
 }


### PR DESCRIPTION
Fix the following error that occurs after passing the `doLast` phase in the Gradle task.
```
Task `:replaceDraftVersion` of type `org.gradle.api.DefaultTask`: cannot serialize Gradle script object references as these are not supported with the configuration cache.
```

