### PR TITLE
Fix:sql formatter second option indent

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockBuilder.kt
@@ -76,8 +76,8 @@ open class SqlBlockBuilder {
             ).clear()
     }
 
-    fun getGroupTopNodeIndexByIndentType(indentType: IndentType): Int =
+    fun getGroupTopNodeIndex(condition: (SqlBlock) -> Boolean): Int =
         groupTopNodeIndexHistory.indexOfLast {
-            it.second.indent.indentLevel == indentType
+            condition(it.second)
         }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockBuilder.kt
@@ -16,13 +16,17 @@
 package org.domaframework.doma.intellij.formatter
 
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.SqlCommentBlock
 import org.domaframework.doma.intellij.formatter.block.expr.SqlElBlockCommentBlock
+import org.domaframework.doma.intellij.formatter.block.expr.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 
 open class SqlBlockBuilder {
     private val groupTopNodeIndexHistory = mutableListOf<Pair<Int, SqlBlock>>()
 
-    private val commentBlocks = mutableListOf<SqlBlock>()
+    private val commentBlocks = mutableListOf<SqlCommentBlock>()
+
+    private val conditionOrLoopBlocks = mutableListOf<SqlElConditionLoopCommentBlock>()
 
     fun getGroupTopNodeIndexHistory(): List<Pair<Int, SqlBlock>> = groupTopNodeIndexHistory
 
@@ -32,7 +36,7 @@ open class SqlBlockBuilder {
         groupTopNodeIndexHistory.add(block)
     }
 
-    fun addCommentBlock(block: SqlBlock) {
+    fun addCommentBlock(block: SqlCommentBlock) {
         commentBlocks.add(block)
     }
 
@@ -41,22 +45,28 @@ open class SqlBlockBuilder {
             var index = 0
             commentBlocks.forEach { block ->
                 if (block !is SqlElBlockCommentBlock) {
-                    val indentLen =
-                        if (index == 0 &&
-                            baseIndent.parentBlock is SqlSubGroupBlock &&
-                            baseIndent.parentBlock?.childBlocks?.size == 1
-                        ) {
-                            1
-                        } else {
-                            baseIndent.indent.indentLen
-                        }
-                    block.indent.indentLevel = IndentType.NONE
-                    block.indent.indentLen = indentLen
-                    block.indent.groupIndentLen = 0
+                    if (index == 0 &&
+                        baseIndent.parentBlock is SqlSubGroupBlock &&
+                        baseIndent.parentBlock?.childBlocks?.size == 1
+                    ) {
+                        block.indent.indentLevel = IndentType.NONE
+                        block.indent.indentLen = 1
+                        block.indent.groupIndentLen = 0
+                    } else {
+                        block.setParentGroupBlock(baseIndent)
+                    }
                     index++
                 }
             }
             commentBlocks.clear()
+        }
+        if (conditionOrLoopBlocks.isNotEmpty()) {
+            conditionOrLoopBlocks.forEach { block ->
+                println("Update ParentGroup:${block.getNodeText()}")
+                if (block.parentBlock == null) {
+                    block.setParentGroupBlock(baseIndent)
+                }
+            }
         }
     }
 
@@ -80,4 +90,19 @@ open class SqlBlockBuilder {
         groupTopNodeIndexHistory.indexOfLast {
             condition(it.second)
         }
+
+    fun getConditionOrLoopBlocksLast(): SqlElConditionLoopCommentBlock? = conditionOrLoopBlocks.lastOrNull()
+
+    fun addConditionOrLoopBlock(block: SqlElConditionLoopCommentBlock) {
+        if (!block.conditionType.isInvalid() && !block.conditionType.isEnd()
+        ) {
+            conditionOrLoopBlocks.add(block)
+        }
+    }
+
+    fun removeConditionOrLoopBlockLast() {
+        if (conditionOrLoopBlocks.isNotEmpty()) {
+            conditionOrLoopBlocks.removeLast()
+        }
+    }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockBuilder.kt
@@ -62,7 +62,6 @@ open class SqlBlockBuilder {
         }
         if (conditionOrLoopBlocks.isNotEmpty()) {
             conditionOrLoopBlocks.forEach { block ->
-                println("Update ParentGroup:${block.getNodeText()}")
                 if (block.parentBlock == null) {
                     block.setParentGroupBlock(baseIndent)
                 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlBlockUtil.kt
@@ -110,7 +110,7 @@ class SqlBlockUtil(
             IndentType.INLINE -> {
                 if (!SqlKeywordUtil.isSetLineKeyword(
                         child.text,
-                        lastGroupBlock?.node?.text ?: "",
+                        lastGroupBlock?.getNodeText() ?: "",
                     )
                 ) {
                     return SqlInlineGroupBlock(child, wrap, alignment, spacingBuilder)
@@ -152,8 +152,8 @@ class SqlBlockUtil(
             is SqlKeywordGroupBlock -> {
                 val lastKeyword =
                     lastGroup.childBlocks
-                        .lastOrNull { SqlKeywordUtil.isOptionSqlKeyword(it.node.text) }
-                if (lastKeyword != null && lastKeyword.node.text.lowercase() == "in") {
+                        .lastOrNull { SqlKeywordUtil.isOptionSqlKeyword(it.getNodeText()) }
+                if (lastKeyword != null && lastKeyword.getNodeText().lowercase() == "in") {
                     return SqlParallelListBlock(child, wrap, alignment, spacingBuilder)
                 }
                 if (lastGroup is SqlCreateKeywordGroupBlock) {
@@ -213,7 +213,7 @@ class SqlBlockUtil(
         when (lastGroup) {
             is SqlKeywordGroupBlock -> {
                 when {
-                    SqlKeywordUtil.isBeforeTableKeyword(lastGroup.node.text) ->
+                    SqlKeywordUtil.isBeforeTableKeyword(lastGroup.getNodeText()) ->
                         SqlTableBlock(
                             child,
                             wrap,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlCustomSpacingBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlCustomSpacingBuilder.kt
@@ -21,6 +21,7 @@ import com.intellij.formatting.Spacing
 import com.intellij.psi.tree.IElementType
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlColumnBlock
+import org.domaframework.doma.intellij.formatter.block.SqlOtherBlock
 import org.domaframework.doma.intellij.formatter.block.SqlRightPatternBlock
 import org.domaframework.doma.intellij.formatter.block.SqlWhitespaceBlock
 import org.domaframework.doma.intellij.formatter.block.group.SqlColumnDefinitionRawGroupBlock
@@ -30,6 +31,7 @@ import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlDataTyp
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlParallelListBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateValueGroupBlock
+import org.domaframework.doma.intellij.psi.SqlTypes
 
 class SqlCustomSpacingBuilder {
     companion object {
@@ -147,4 +149,11 @@ class SqlCustomSpacingBuilder {
             else -> nonSpacing
         }
     }
+
+    fun getSpacingOther(block: SqlOtherBlock): Spacing? =
+        when {
+            listOf("=", "-", "+", "*", "/", "%").contains(block.getNodeText()) -> normalSpacing
+            listOf(SqlTypes.LE, SqlTypes.GE, SqlTypes.LT, SqlTypes.GT).contains(block.node.elementType) -> normalSpacing
+            else -> nonSpacing
+        }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlCustomSpacingBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlCustomSpacingBuilder.kt
@@ -21,7 +21,6 @@ import com.intellij.formatting.Spacing
 import com.intellij.psi.tree.IElementType
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlColumnBlock
-import org.domaframework.doma.intellij.formatter.block.SqlOtherBlock
 import org.domaframework.doma.intellij.formatter.block.SqlRightPatternBlock
 import org.domaframework.doma.intellij.formatter.block.SqlWhitespaceBlock
 import org.domaframework.doma.intellij.formatter.block.group.SqlColumnDefinitionRawGroupBlock
@@ -31,7 +30,6 @@ import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlDataTyp
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlParallelListBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateValueGroupBlock
-import org.domaframework.doma.intellij.psi.SqlTypes
 
 class SqlCustomSpacingBuilder {
     companion object {
@@ -149,11 +147,4 @@ class SqlCustomSpacingBuilder {
             else -> nonSpacing
         }
     }
-
-    fun getSpacingOther(block: SqlOtherBlock): Spacing? =
-        when {
-            listOf("=", "-", "+", "*", "/", "%").contains(block.getNodeText()) -> normalSpacing
-            listOf(SqlTypes.LE, SqlTypes.GE, SqlTypes.LT, SqlTypes.GT).contains(block.node.elementType) -> normalSpacing
-            else -> nonSpacing
-        }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlCustomSpacingBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlCustomSpacingBuilder.kt
@@ -82,8 +82,8 @@ class SqlCustomSpacingBuilder {
             null -> return nonSpacing
             is SqlWhitespaceBlock -> {
                 val indentLen: Int = child2.indent.indentLen
-                val afterNewLine = child1.node.text.substringAfterLast("\n", "")
-                if (child1.node.text.contains("\n")) {
+                val afterNewLine = child1.getNodeText().substringAfterLast("\n", "")
+                if (child1.getNodeText().contains("\n")) {
                     val currentIndent = afterNewLine.length
                     val newIndent =
                         if (currentIndent != indentLen) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlFormattingModelBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/SqlFormattingModelBuilder.kt
@@ -78,6 +78,8 @@ class SqlFormattingModelBuilder : FormattingModelBuilder {
             .spacing(0, 0, 0, false, 0)
             .around(SqlTypes.WORD)
             .spacing(1, 1, 0, false, 0)
+            .around(SqlTypes.NUMBER)
+            .spacing(1, 1, 0, false, 0)
             .before(SqlTypes.RIGHT_PAREN)
             .spacing(0, 0, 0, false, 0)
             .around(SqlTypes.PLUS)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
@@ -637,7 +637,7 @@ open class SqlBlock(
         }
 
         // Do not leave a space after the comment block of the bind variable
-        if (child1 is SqlElBlockCommentBlock && child2 !is SqlCommentBlock) {
+        if (child1 is SqlElBlockCommentBlock && child1 !is SqlElConditionLoopCommentBlock && child2 !is SqlCommentBlock) {
             return SqlCustomSpacingBuilder.nonSpacing
         }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlColumnBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlColumnBlock.kt
@@ -57,7 +57,7 @@ class SqlColumnBlock(
             if (parentGroupDefinition == null) return 1
 
             val groupMaxAlimentLen = parentGroupDefinition.alignmentColumnName.length
-            val diffColumnName = groupMaxAlimentLen.minus(node.text.length)
+            val diffColumnName = groupMaxAlimentLen.minus(getNodeText().length)
             return diffColumnName.plus(1)
         }
         return 1

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlCommaBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlCommaBlock.kt
@@ -54,7 +54,7 @@ open class SqlCommaBlock(
         super.setParentGroupBlock(block)
         indent.indentLevel = IndentType.COMMA
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = indent.indentLen.plus(node.text.length)
+        indent.groupIndentLen = indent.indentLen.plus(getNodeText().length)
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
@@ -85,7 +85,7 @@ open class SqlCommaBlock(
                     if (grand is SqlColumnGroupBlock) {
                         val grandIndentLen = grand.indent.groupIndentLen
                         var prevTextLen = 1
-                        parent.prevChildren?.dropLast(1)?.forEach { prev -> prevTextLen = prevTextLen.plus(prev.node.text.length) }
+                        parent.prevChildren?.dropLast(1)?.forEach { prev -> prevTextLen = prevTextLen.plus(prev.getNodeText().length) }
                         return grandIndentLen.plus(prevTextLen).plus(1)
                     }
                 }
@@ -97,7 +97,9 @@ open class SqlCommaBlock(
                     .forEach { prev ->
                         prevLen =
                             prevLen.plus(
-                                prev.node.text.length
+                                prev
+                                    .getNodeText()
+                                    .length
                                     .plus(1),
                             )
                     }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlCommentBlock.kt
@@ -21,6 +21,7 @@ import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.IndentType
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 
 abstract class SqlCommentBlock(
     node: ASTNode,
@@ -44,11 +45,22 @@ abstract class SqlCommentBlock(
     override fun setParentGroupBlock(block: SqlBlock?) {
         super.setParentGroupBlock(block)
         indent.indentLevel = IndentType.NONE
-        indent.indentLen = 0
+        indent.indentLen = createBlockIndentLen()
         indent.groupIndentLen = 0
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
 
     override fun isLeaf(): Boolean = true
+
+    override fun createBlockIndentLen(): Int {
+        parentBlock?.let { parent ->
+            if (parent.parentBlock !is SqlSubGroupBlock ||
+                parent.parentBlock?.childBlocks?.size != 1
+            ) {
+                return parent.indent.indentLen
+            }
+        }
+        return 1
+    }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlKeywordBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlKeywordBlock.kt
@@ -48,7 +48,7 @@ open class SqlKeywordBlock(
 
         indent.indentLevel = indentLevel
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = indent.indentLen.plus(node.text.length)
+        indent.groupIndentLen = indent.indentLen.plus(getNodeText().length)
         // updateParentIndentLen()
     }
 
@@ -76,15 +76,15 @@ open class SqlKeywordBlock(
             IndentType.SECOND -> {
                 parentBlock?.let {
                     it.indent.groupIndentLen
-                        .plus(it.node.text.length)
-                        .minus(this.node.text.length)
+                        .plus(it.getNodeText().length)
+                        .minus(this.getNodeText().length)
                 } ?: 1
             }
 
             IndentType.INLINE_SECOND -> {
                 parentBlock?.let {
                     it.indent.groupIndentLen
-                        .plus(it.node.text.length)
+                        .plus(it.getNodeText().length)
                         .plus(1)
                 } ?: 1
             }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
@@ -48,21 +48,22 @@ open class SqlRightPatternBlock(
     var preSpaceRight = false
 
     fun enableLastRight() {
-        parentBlock?.let {
-            if (it.node.treePrev.elementType == SqlTypes.WORD) {
+        parentBlock?.let { parent ->
+
+            if (parent.node.treePrev.elementType == SqlTypes.WORD) {
                 preSpaceRight = false
                 return
             }
-            if (it is SqlInsertColumnGroupBlock) {
+            if (parent is SqlInsertColumnGroupBlock) {
                 preSpaceRight = false
                 return
             }
-            it.parentBlock?.let {
+            parent.parentBlock?.let { grand ->
                 preSpaceRight = (
-                    it.indent.indentLevel <= IndentType.SECOND &&
-                        it.parentBlock !is SqlInsertKeywordGroupBlock
+                    grand.indent.indentLevel <= IndentType.SECOND &&
+                        grand.parentBlock !is SqlInsertKeywordGroupBlock
                 ) ||
-                    it.indent.indentLevel == IndentType.JOIN
+                    grand.indent.indentLevel == IndentType.JOIN
                 return
             }
         }
@@ -81,6 +82,7 @@ open class SqlRightPatternBlock(
         indent.indentLevel = IndentType.NONE
         indent.indentLen = createBlockIndentLen()
         indent.groupIndentLen = indent.indentLen
+        enableLastRight()
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
@@ -23,12 +23,14 @@ import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.block.group.SqlColumnDefinitionRawGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlInsertKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlUpdateKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlColumnDefinitionGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlFunctionParamBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlInsertColumnGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlUpdateValueGroupBlock
-import org.domaframework.doma.intellij.psi.SqlTypes
 
 /**
  * Parent is always a subclass of a subgroup
@@ -49,8 +51,8 @@ open class SqlRightPatternBlock(
 
     fun enableLastRight() {
         parentBlock?.let { parent ->
-
-            if (parent.node.treePrev.elementType == SqlTypes.WORD) {
+            // TODO:Customize indentation
+            if (parent is SqlFunctionParamBlock) {
                 preSpaceRight = false
                 return
             }
@@ -58,6 +60,18 @@ open class SqlRightPatternBlock(
                 preSpaceRight = false
                 return
             }
+
+            if (parent is SqlSubQueryGroupBlock) {
+                val prevKeywordBlock =
+                    parent.childBlocks
+                        .filter { it.node.startOffset < node.startOffset }
+                        .find { it is SqlKeywordGroupBlock && it.indent.indentLevel == IndentType.TOP }
+                if (prevKeywordBlock != null) {
+                    preSpaceRight = true
+                    return
+                }
+            }
+
             parent.parentBlock?.let { grand ->
                 preSpaceRight = (
                     grand.indent.indentLevel <= IndentType.SECOND &&

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlWordBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlWordBlock.kt
@@ -59,7 +59,7 @@ open class SqlWordBlock(
                 is SqlSubQueryGroupBlock -> {
                     val parentIndentLen = it.indent.groupIndentLen
                     val grand = it.parentBlock
-                    if (grand != null && grand.node.text.lowercase() == "create") {
+                    if (grand != null && grand.getNodeText().lowercase() == "create") {
                         val grandIndentLen = grand.indent.groupIndentLen
                         return grandIndentLen.plus(parentIndentLen).plus(1)
                     }
@@ -67,7 +67,7 @@ open class SqlWordBlock(
                 }
 
                 else -> {
-                    val parentLen = it.node.text.length
+                    val parentLen = it.getNodeText().length
                     return it.indent.groupIndentLen.plus(parentLen.plus(1))
                 }
             }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElBlockCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElBlockCommentBlock.kt
@@ -21,11 +21,8 @@ import com.intellij.formatting.Spacing
 import com.intellij.formatting.SpacingBuilder
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.formatter.common.AbstractBlock
-import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.psi.util.elementType
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.SqlCustomSpacingBuilder
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
@@ -34,19 +31,7 @@ import org.domaframework.doma.intellij.formatter.block.SqlCommentBlock
 import org.domaframework.doma.intellij.formatter.block.SqlOperationBlock
 import org.domaframework.doma.intellij.formatter.block.SqlUnknownBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
-import org.domaframework.doma.intellij.psi.SqlElElseifDirective
-import org.domaframework.doma.intellij.psi.SqlElForDirective
-import org.domaframework.doma.intellij.psi.SqlElIfDirective
 import org.domaframework.doma.intellij.psi.SqlTypes
-
-enum class SqlDirectiveType {
-    IF,
-    ELSEIF,
-    ELSE,
-    FOR,
-    END,
-    Variable,
-}
 
 open class SqlElBlockCommentBlock(
     node: ASTNode,
@@ -60,8 +45,6 @@ open class SqlElBlockCommentBlock(
         alignment,
         spacingBuilder,
     ) {
-    // open var isConditionLoopBlock = getConditionOrLoopBlock(node)
-
     override val indent =
         ElementIndent(
             IndentType.NONE,
@@ -128,47 +111,6 @@ open class SqlElBlockCommentBlock(
 
             else -> SqlUnknownBlock(child, wrap, alignment, spacingBuilder)
         }
-
-    private fun getConditionOrLoopBlock(node: ASTNode): Boolean {
-        val directiveType =
-            when {
-                PsiTreeUtil.getChildOfType(node.psi, SqlElIfDirective::class.java) != null -> {
-                    SqlDirectiveType.IF
-                }
-
-                PsiTreeUtil.getChildOfType(node.psi, SqlElElseifDirective::class.java) != null -> {
-                    SqlDirectiveType.ELSEIF
-                }
-
-                PsiTreeUtil.getChildOfType(node.psi, SqlElForDirective::class.java) != null -> {
-                    SqlDirectiveType.FOR
-                }
-
-                PsiTreeUtil.getChildOfType(node.psi, SqlElElseifDirective::class.java) != null -> {
-                    SqlDirectiveType.ELSE
-                }
-
-                PsiTreeUtil.getChildOfType(node.psi, SqlElForDirective::class.java) != null -> {
-                    SqlDirectiveType.END
-                }
-
-                else -> {
-                    val children =
-                        PsiTreeUtil
-                            .getChildrenOfType(node.psi, PsiElement::class.java)
-                            ?.firstOrNull { it.elementType == SqlTypes.EL_ELSE || it.elementType == SqlTypes.EL_END }
-                    children?.let {
-                        when (it.elementType) {
-                            SqlTypes.EL_ELSE -> SqlDirectiveType.ELSE
-                            SqlTypes.EL_END -> SqlDirectiveType.END
-                            else -> SqlDirectiveType.Variable
-                        }
-                    } ?: SqlDirectiveType.Variable
-                }
-            }
-
-        return directiveType != SqlDirectiveType.Variable
-    }
 
     private fun createFieldAccessSpacingBuilder(): SqlCustomSpacingBuilder =
         SqlCustomSpacingBuilder()

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElConditionLoopCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElConditionLoopCommentBlock.kt
@@ -100,7 +100,6 @@ class SqlElConditionLoopCommentBlock(
         indent.indentLevel = IndentType.NONE
         indent.indentLen = createBlockIndentLen()
         indent.groupIndentLen = 0
-        println("setParentGroupBlock:${block?.getNodeText()}")
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElConditionLoopCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElConditionLoopCommentBlock.kt
@@ -23,16 +23,24 @@ import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.formatter.common.AbstractBlock
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.elementType
+import org.domaframework.doma.intellij.extension.expr.isConditionOrLoopDirective
 import org.domaframework.doma.intellij.formatter.IndentType
 import org.domaframework.doma.intellij.formatter.SqlCustomSpacingBuilder
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlockCommentBlock
+import org.domaframework.doma.intellij.formatter.block.SqlCommaBlock
 import org.domaframework.doma.intellij.formatter.block.SqlOperationBlock
 import org.domaframework.doma.intellij.formatter.block.SqlUnknownBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlCreateKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlInsertKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
+import org.domaframework.doma.intellij.psi.SqlCustomElCommentExpr
+import org.domaframework.doma.intellij.psi.SqlElForDirective
+import org.domaframework.doma.intellij.psi.SqlElIfDirective
 import org.domaframework.doma.intellij.psi.SqlTypes
 
 class SqlElConditionLoopCommentBlock(
@@ -48,6 +56,38 @@ class SqlElConditionLoopCommentBlock(
         customSpacingBuilder,
         spacingBuilder,
     ) {
+    enum class SqlConditionLoopCommentBlockType {
+        CONDITION,
+        LOOP,
+        END,
+        UNKNOWN,
+        ;
+
+        fun isEnd(): Boolean = this == END
+
+        fun isInvalid(): Boolean = this == UNKNOWN
+    }
+
+    val conditionType: SqlConditionLoopCommentBlockType = initConditionOrLoopType(node)
+
+    private fun initConditionOrLoopType(node: ASTNode): SqlConditionLoopCommentBlockType {
+        val psi = node.psi
+        if (psi is SqlCustomElCommentExpr && psi.isConditionOrLoopDirective()) {
+            if (PsiTreeUtil.getChildOfType(psi, SqlElForDirective::class.java) != null) {
+                return SqlConditionLoopCommentBlockType.LOOP
+            }
+            if (PsiTreeUtil.getChildOfType(psi, SqlElIfDirective::class.java) != null ||
+                psi.findElementAt(2)?.elementType == SqlTypes.EL_ELSE
+            ) {
+                return SqlConditionLoopCommentBlockType.CONDITION
+            }
+            if (psi.findElementAt(2)?.elementType == SqlTypes.EL_END) {
+                return SqlConditionLoopCommentBlockType.END
+            }
+        }
+        return SqlConditionLoopCommentBlockType.UNKNOWN
+    }
+
     override val indent =
         ElementIndent(
             IndentType.NONE,
@@ -60,6 +100,7 @@ class SqlElConditionLoopCommentBlock(
         indent.indentLevel = IndentType.NONE
         indent.indentLen = createBlockIndentLen()
         indent.groupIndentLen = 0
+        println("setParentGroupBlock:${block?.getNodeText()}")
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> {
@@ -169,41 +210,38 @@ class SqlElConditionLoopCommentBlock(
 
     override fun createBlockIndentLen(): Int {
         parentBlock?.let { parent ->
-            if (parent is SqlSubGroupBlock) {
-                val parentIndentLen = parent.indent.groupIndentLen
-                val grand = parent.parentBlock
-                grand?.let { grand ->
-                    if (grand is SqlCreateKeywordGroupBlock) {
-                        val grandIndentLen = grand.indent.groupIndentLen
-                        return grandIndentLen.plus(parentIndentLen).minus(1)
+            when (parent) {
+                is SqlSubGroupBlock -> {
+                    val parentGroupIndentLen = parent.indent.groupIndentLen
+                    val grand = parent.parentBlock
+                    grand?.let { grand ->
+                        if (grand is SqlCreateKeywordGroupBlock) {
+                            val grandIndentLen = grand.indent.groupIndentLen
+                            return grandIndentLen.plus(parentGroupIndentLen).minus(1)
+                        }
+                        if (grand is SqlInsertKeywordGroupBlock) {
+                            return parentGroupIndentLen
+                        }
+                        if (grand is SqlColumnGroupBlock) {
+                            val grandIndentLen = grand.indent.groupIndentLen
+                            var prevTextLen = 1
+                            parent.prevChildren?.dropLast(1)?.forEach { prev ->
+                                prevTextLen = prevTextLen.plus(prev.getNodeText().length)
+                            }
+                            return grandIndentLen.plus(prevTextLen).plus(1)
+                        }
                     }
-                    if (grand is SqlInsertKeywordGroupBlock) {
-                        return parentIndentLen
-                    }
-                    if (grand is SqlColumnGroupBlock) {
-                        val grandIndentLen = grand.indent.groupIndentLen
-                        var prevTextLen = 1
-                        parent.prevChildren?.dropLast(1)?.forEach { prev -> prevTextLen = prevTextLen.plus(prev.getNodeText().length) }
-                        return grandIndentLen.plus(prevTextLen).plus(1)
-                    }
+                    return parentGroupIndentLen
                 }
-                return parentIndentLen
-            } else {
-                var prevLen = 0
-                parent.childBlocks
-                    .filter { it.node.elementType == SqlTypes.KEYWORD }
-                    .forEach { prev ->
-                        prevLen =
-                            prevLen.plus(
-                                prev
-                                    .getNodeText()
-                                    .length
-                                    .plus(1),
-                            )
-                    }
-                return parent.indent.groupIndentLen
-                    .plus(prevLen)
-                    .plus(1)
+
+                is SqlKeywordGroupBlock, is SqlCommaBlock -> {
+                    return parent.indent.indentLen
+                }
+
+                // Parent of End Block is SqlElConditionLoopCommentBlock
+                is SqlElConditionLoopCommentBlock -> {
+                    return parent.indent.indentLen
+                }
             }
         }
         return 1

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElConditionLoopCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElConditionLoopCommentBlock.kt
@@ -183,7 +183,7 @@ class SqlElConditionLoopCommentBlock(
                     if (grand is SqlColumnGroupBlock) {
                         val grandIndentLen = grand.indent.groupIndentLen
                         var prevTextLen = 1
-                        parent.prevChildren?.dropLast(1)?.forEach { prev -> prevTextLen = prevTextLen.plus(prev.node.text.length) }
+                        parent.prevChildren?.dropLast(1)?.forEach { prev -> prevTextLen = prevTextLen.plus(prev.getNodeText().length) }
                         return grandIndentLen.plus(prevTextLen).plus(1)
                     }
                 }
@@ -195,7 +195,9 @@ class SqlElConditionLoopCommentBlock(
                     .forEach { prev ->
                         prevLen =
                             prevLen.plus(
-                                prev.node.text.length
+                                prev
+                                    .getNodeText()
+                                    .length
                                     .plus(1),
                             )
                     }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/SqlColumnDefinitionRawGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/SqlColumnDefinitionRawGroupBlock.kt
@@ -45,7 +45,7 @@ class SqlColumnDefinitionRawGroupBlock(
     val defaultOffset = 5
     val isFirstColumnRaw = node.elementType != SqlTypes.COMMA
 
-    var columnName = node.text
+    var columnName = getNodeText()
 
     override fun setParentGroupBlock(block: SqlBlock?) {
         super.setParentGroupBlock(block)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlCreateKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlCreateKeywordGroupBlock.kt
@@ -43,7 +43,7 @@ open class SqlCreateKeywordGroupBlock(
         super.setParentGroupBlock(block)
         indent.indentLevel = IndentType.TOP
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = indent.indentLen.plus(node.text.length)
+        indent.groupIndentLen = indent.indentLen.plus(getNodeText().length)
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlInlineGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlInlineGroupBlock.kt
@@ -47,7 +47,7 @@ open class SqlInlineGroupBlock(
         super.setParentGroupBlock(block)
         indent.indentLevel = IndentType.INLINE
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = indent.indentLen.plus(node.text.length)
+        indent.groupIndentLen = indent.indentLen.plus(getNodeText().length)
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
@@ -62,7 +62,7 @@ open class SqlInlineGroupBlock(
     override fun createBlockIndentLen(): Int =
         parentBlock?.let {
             it.indent.groupIndentLen
-                .plus(it.node.text.length)
+                .plus(it.getNodeText().length)
                 .plus(1)
         } ?: 1
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlInlineSecondGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlInlineSecondGroupBlock.kt
@@ -36,7 +36,7 @@ open class SqlInlineSecondGroupBlock(
         alignment,
         spacingBuilder,
     ) {
-    val isEndCase = node.text.lowercase() == "end"
+    val isEndCase = getNodeText().lowercase() == "end"
 
     override val indent =
         ElementIndent(
@@ -63,7 +63,7 @@ open class SqlInlineSecondGroupBlock(
                 it.indent.indentLen
             } else {
                 it.indent.groupIndentLen
-                    .plus(it.node.text.length)
+                    .plus(it.getNodeText().length)
             }
         } ?: 1
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlInsertKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlInsertKeywordGroupBlock.kt
@@ -40,7 +40,7 @@ open class SqlInsertKeywordGroupBlock(
         super.setParentGroupBlock(block)
         indent.indentLevel = IndentType.TOP
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = indent.indentLen.plus(node.text.length)
+        indent.groupIndentLen = indent.indentLen.plus(getNodeText().length)
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlJoinGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlJoinGroupBlock.kt
@@ -48,7 +48,7 @@ open class SqlJoinGroupBlock(
         parentBlock?.childBlocks?.add(this)
         indent.indentLevel = IndentType.JOIN
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = indent.indentLen.plus(node.text.length)
+        indent.groupIndentLen = indent.indentLen.plus(getNodeText().length)
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlKeywordGroupBlock.kt
@@ -153,7 +153,6 @@ open class SqlKeywordGroupBlock(
                         return 0
                     }
                     val subGroupBlock = parent.parentBlock as? SqlSubGroupBlock
-                    // val isSubGroupChildParent = parent.isTopParentInSubGroup()
                     val newIndent =
                         if (parent is SqlSubQueryGroupBlock) {
                             return if (getNodeText() == "and") {
@@ -167,9 +166,13 @@ open class SqlKeywordGroupBlock(
                             groupLen
                         } else {
                             var parentLen = 0
+                            val removeStartOffsetLess =
+                                parent.childBlocks.dropLast(1).filter {
+                                    it.node.startOffset >
+                                        parent.node.startOffset
+                                }
                             val keywords =
-                                parent.childBlocks
-                                    .dropLast(1)
+                                removeStartOffsetLess
                                     .takeWhile { it.node.elementType == SqlTypes.KEYWORD }
                             keywords.forEach { keyword ->
                                 parentLen = parentLen.plus(keyword.getNodeText().length).plus(1)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlKeywordGroupBlock.kt
@@ -55,7 +55,7 @@ open class SqlKeywordGroupBlock(
         indent.indentLevel = indentLevel
 
         val baseIndentLen = getBaseIndentLen(preChildBlock, block)
-        indent.groupIndentLen = baseIndentLen.plus(node.text.length)
+        indent.groupIndentLen = baseIndentLen.plus(getNodeText().length)
         indent.indentLen = adjustIndentIfFirstChildIsLineComment(baseIndentLen)
         createGroupIndentLen()
     }
@@ -69,13 +69,13 @@ open class SqlKeywordGroupBlock(
         }
         if (preChildBlock != null &&
             preChildBlock.indent.indentLevel == this.indent.indentLevel &&
-            !SqlKeywordUtil.isSetLineKeyword(preChildBlock.node.text, block.node.text)
+            !SqlKeywordUtil.isSetLineKeyword(preChildBlock.getNodeText(), block.getNodeText())
         ) {
             if (indent.indentLevel == IndentType.SECOND) {
-                val diffPreBlockTextLen = node.text.length.minus(preChildBlock.node.text.length)
+                val diffPreBlockTextLen = getNodeText().length.minus(preChildBlock.getNodeText().length)
                 return preChildBlock.indent.indentLen.minus(diffPreBlockTextLen)
             } else {
-                val diffPretextLen = node.text.length.minus(preChildBlock.node.text.length)
+                val diffPretextLen = getNodeText().length.minus(preChildBlock.getNodeText().length)
                 return preChildBlock.indent.indentLen.minus(diffPretextLen)
             }
         } else {
@@ -100,7 +100,7 @@ open class SqlKeywordGroupBlock(
             if (indent.indentLevel == IndentType.TOP) {
                 return if (it is SqlSubGroupBlock) {
                     return if (it.isFirstLineComment) {
-                        it.indent.groupIndentLen.minus(it.node.text.length)
+                        it.indent.groupIndentLen.minus(it.getNodeText().length)
                     } else {
                         val newIndentLen = baseIndent.minus(1)
                         return if (newIndentLen >= 0) newIndentLen else 0
@@ -135,37 +135,47 @@ open class SqlKeywordGroupBlock(
                     } else {
                         parent.parentBlock?.let { grand ->
                             return if (grand is SqlViewGroupBlock) {
-                                groupLen.minus(this.node.text.length)
+                                groupLen.minus(this.getNodeText().length)
                             } else if (grand is SqlSubGroupBlock) {
-                                groupLen.minus(node.text.length).plus(1)
+                                groupLen.minus(getNodeText().length).plus(1)
                             } else {
-                                groupLen.minus(this.node.text.length)
+                                groupLen.minus(this.getNodeText().length)
                             }
-                        } ?: return groupLen.minus(this.node.text.length)
+                        } ?: return groupLen.minus(this.getNodeText().length)
                     }
                 } ?: return 1
             }
 
             IndentType.SECOND_OPTION -> {
-                parentBlock?.let {
-                    val groupLen = it.indent.groupIndentLen.plus(1)
-                    if (it.indent.indentLevel == IndentType.FILE) {
+                parentBlock?.let { parent ->
+                    val groupLen = parent.indent.groupIndentLen
+                    if (parent.indent.indentLevel == IndentType.FILE) {
                         return 0
                     }
-                    val subGroupBlock = it.parentBlock as? SqlSubGroupBlock
+                    val subGroupBlock = parent.parentBlock as? SqlSubGroupBlock
+                    // val isSubGroupChildParent = parent.isTopParentInSubGroup()
                     val newIndent =
-                        if (it is SqlSubQueryGroupBlock) {
-                            groupLen
-                        } else if (it is SqlKeywordGroupBlock && subGroupBlock != null && subGroupBlock.isFirstLineComment) {
+                        if (parent is SqlSubQueryGroupBlock) {
+                            return if (getNodeText() == "and") {
+                                groupLen
+                            } else {
+                                groupLen.plus(1)
+                            }
+                        } else if (getNodeText() == "and" && parent.getNodeText() == "or") {
+                            return groupLen.plus(1)
+                        } else if (parent is SqlKeywordGroupBlock && subGroupBlock != null && subGroupBlock.isFirstLineComment) {
                             groupLen
                         } else {
                             var parentLen = 0
-                            val keywords = it.childBlocks.dropLast(1).takeWhile { it.node.elementType == SqlTypes.KEYWORD }
+                            val keywords =
+                                parent.childBlocks
+                                    .dropLast(1)
+                                    .takeWhile { it.node.elementType == SqlTypes.KEYWORD }
                             keywords.forEach { keyword ->
-                                parentLen = parentLen.plus(keyword.node.text.length).plus(1)
+                                parentLen = parentLen.plus(keyword.getNodeText().length).plus(1)
                             }
-                            val parentTextLen = it.indent.groupIndentLen.plus(parentLen)
-                            return parentTextLen.minus(node.text.length)
+                            val parentTextLen = parent.indent.groupIndentLen.plus(parentLen)
+                            return parentTextLen.minus(getNodeText().length)
                         }
                     return newIndent
                 } ?: 1
@@ -190,11 +200,11 @@ open class SqlKeywordGroupBlock(
                 var parentLen = 0
                 val keywords = it.childBlocks.dropLast(1).filter { it.node.elementType == SqlTypes.KEYWORD }
                 keywords.forEach { keyword ->
-                    parentLen = parentLen.plus(keyword.node.text.length).plus(1)
+                    parentLen = parentLen.plus(keyword.getNodeText().length).plus(1)
                 }
                 it.indent.groupIndentLen
                     .plus(parentLen)
-                    .minus(node.text.length)
+                    .minus(getNodeText().length)
             }
         } ?: 1
         return 1

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlUpdateKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlUpdateKeywordGroupBlock.kt
@@ -40,7 +40,7 @@ open class SqlUpdateKeywordGroupBlock(
         super.setParentGroupBlock(block)
         indent.indentLevel = IndentType.SECOND
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = indent.indentLen.plus(node.text.length)
+        indent.groupIndentLen = indent.indentLen.plus(getNodeText().length)
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
@@ -52,8 +52,8 @@ open class SqlUpdateKeywordGroupBlock(
             if (it.indent.indentLevel == IndentType.SUB) {
                 it.indent.groupIndentLen.plus(1)
             } else {
-                val parentTextLen = it.node.text.length
-                val diffTextLen = parentTextLen.minus(node.text.length)
+                val parentTextLen = it.getNodeText().length
+                val diffTextLen = parentTextLen.minus(getNodeText().length)
                 it.indent.indentLen.plus(diffTextLen)
             }
         } ?: 0

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlColumnGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlColumnGroupBlock.kt
@@ -39,7 +39,7 @@ class SqlColumnGroupBlock(
         alignment,
         spacingBuilder,
     ) {
-    var isFirstColumnGroup = node.text != ","
+    var isFirstColumnGroup = getNodeText() != ","
 
     override val indent =
         ElementIndent(
@@ -63,7 +63,7 @@ class SqlColumnGroupBlock(
     override fun createBlockIndentLen(): Int =
         parentBlock?.let {
             if (it is SqlKeywordGroupBlock) {
-                val parentIndentLen = it.indent.indentLen.plus(it.node.text.length)
+                val parentIndentLen = it.indent.indentLen.plus(it.getNodeText().length)
                 val subGroup = it.parentBlock as? SqlSubGroupBlock
                 if (subGroup is SqlSubGroupBlock && !subGroup.isFirstLineComment) {
                     parentIndentLen.plus(3)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlInsertColumnGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlInsertColumnGroupBlock.kt
@@ -57,10 +57,10 @@ class SqlInsertColumnGroupBlock(
                 val keywords =
                     it.childBlocks.dropLast(1).takeWhile { it.node.elementType == SqlTypes.KEYWORD }
                 keywords.forEach { keyword ->
-                    parentLen = parentLen.plus(keyword.node.text.length).plus(1)
+                    parentLen = parentLen.plus(keyword.getNodeText().length).plus(1)
                 }
                 return it.indent.indentLen
-                    .plus(it.node.text.length)
+                    .plus(it.getNodeText().length)
                     .plus(1)
                     .plus(parentLen)
             }
@@ -76,11 +76,11 @@ class SqlInsertColumnGroupBlock(
                 val keywords =
                     it.childBlocks.dropLast(1).takeWhile { it.node.elementType == SqlTypes.KEYWORD }
                 keywords.forEach { keyword ->
-                    parentLen = parentLen.plus(keyword.node.text.length).plus(1)
+                    parentLen = parentLen.plus(keyword.getNodeText().length).plus(1)
                 }
                 it.indent.groupIndentLen =
                     it.indent.indentLen
-                        .plus(it.node.text.length)
+                        .plus(it.getNodeText().length)
                         .plus(parentLen)
             }
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubGroupBlock.kt
@@ -52,7 +52,7 @@ abstract class SqlSubGroupBlock(
         prevChildren = parentBlock?.childBlocks?.toList()
         indent.indentLevel = indent.indentLevel
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = indent.indentLen.plus(node.text.length)
+        indent.groupIndentLen = indent.indentLen.plus(getNodeText().length)
     }
 
     override fun addChildBlock(childBlock: SqlBlock) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubQueryGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubQueryGroupBlock.kt
@@ -56,10 +56,10 @@ open class SqlSubQueryGroupBlock(
                 val keywords =
                     it.childBlocks.dropLast(1).takeWhile { it.node.elementType == SqlTypes.KEYWORD }
                 keywords.forEach { keyword ->
-                    parentLen = parentLen.plus(keyword.node.text.length).plus(1)
+                    parentLen = parentLen.plus(keyword.getNodeText().length).plus(1)
                 }
                 return it.indent.indentLen
-                    .plus(it.node.text.length)
+                    .plus(it.getNodeText().length)
                     .plus(2)
                     .plus(parentLen)
             } else {
@@ -68,7 +68,7 @@ open class SqlSubQueryGroupBlock(
                     prevChildren
                         ?.dropLast(1)
                         ?.forEach { prev ->
-                            parentLen = parentLen.plus(prev.node.text.length).plus(1)
+                            parentLen = parentLen.plus(prev.getNodeText().length).plus(1)
                         }
                 }
                 return it.indent.groupIndentLen

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlUpdateColumnGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlUpdateColumnGroupBlock.kt
@@ -58,10 +58,10 @@ class SqlUpdateColumnGroupBlock(
                 val keywords =
                     it.childBlocks.dropLast(1).takeWhile { it.node.elementType == SqlTypes.KEYWORD }
                 keywords.forEach { keyword ->
-                    parentLen = parentLen.plus(keyword.node.text.length).plus(1)
+                    parentLen = parentLen.plus(keyword.getNodeText().length).plus(1)
                 }
                 return it.indent.indentLen
-                    .plus(it.node.text.length)
+                    .plus(it.getNodeText().length)
                     .plus(1)
                     .plus(parentLen)
             }
@@ -77,11 +77,11 @@ class SqlUpdateColumnGroupBlock(
                 val keywords =
                     it.childBlocks.dropLast(1).takeWhile { it.node.elementType == SqlTypes.KEYWORD }
                 keywords.forEach { keyword ->
-                    parentLen = parentLen.plus(keyword.node.text.length).plus(1)
+                    parentLen = parentLen.plus(keyword.getNodeText().length).plus(1)
                 }
                 it.indent.groupIndentLen =
                     it.indent.indentLen
-                        .plus(it.node.text.length)
+                        .plus(it.getNodeText().length)
                         .plus(parentLen)
             }
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlUpdateValueGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlUpdateValueGroupBlock.kt
@@ -58,7 +58,7 @@ class SqlUpdateValueGroupBlock(
                         .dropLast(1)
                         .takeWhile { parent.node.elementType == SqlTypes.KEYWORD }
                 return parent.indent.indentLen
-                    .plus(parent.node.text.length)
+                    .plus(parent.getNodeText().length)
                     .plus(3)
             }
             // TODO:Customize indentation

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlViewGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlViewGroupBlock.kt
@@ -48,7 +48,7 @@ open class SqlViewGroupBlock(
         super.setParentGroupBlock(block)
         indent.indentLevel = IndentType.SUB
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = node.text.length
+        indent.groupIndentLen = getNodeText().length
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()

--- a/src/test/testData/sql/formatter/FormattedSelect.sql
+++ b/src/test/testData/sql/formatter/FormattedSelect.sql
@@ -24,23 +24,29 @@ SELECT COUNT(DISTINCT (x))
                             AND p.plate = s.plate
           /** Where */
           WHERE p.TYPE = DBO.FPHOTOTYPE('Star')
-            AND (p.flags & DBO.FPHOTOFLAGS('EDGE')) = 0
-            AND (p.psfmag_g - p.extinction_g) BETWEEN 15 AND 20
-            AND u.propermotion > 2.
-            /** And  Group */
-            AND (p.psfmag_g - p.extinction_g + 5 * LOG(u.propermotion / 100.) + 5 > 16.136 + 2.727 * (p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i))
-                  OR p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i) < 0.) ) AS o
+             OR (p.flags & DBO.FPHOTOFLAGS('EDGE') = 0
+                 AND (p.psfmag_g - p.extinction_g) BETWEEN 15 AND 20)
+                /*%if status == 2 */
+                AND u.propermotion > 2.
+                /** And  Group */
+                AND (p.psfmag_g - p.extinction_g + 5 * LOG(u.propermotion / 100.) + 5 > 16.136 + 2.727 * (p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i))
+                      OR p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i) < 0.)
+                /*%end*/ ) AS o
        LEFT OUTER JOIN ( SELECT n.objid
                                 , MIN(n.distance) AS nearest
                            FROM neighbors n
                                 JOIN phototag x
                                   ON n.neighborobjid = x.objid
+                                 AND n.neighbormode = DBO.FPHOTOMODE('Primary')
+                                  OR n.MODE = /*# "active" */'mode'
+                                     AND n.status = 2
+                                     AND n.flag = true
                           WHERE n.TYPE = DBO.FPHOTOTYPE('Star')
                             AND n.MODE = DBO.FPHOTOMODE('Primary')
-                            AND n.neighbormode = DBO.FPHOTOMODE('Primary')
-                            AND (x.TYPE = DBO.FPHOTOTYPE('Star')
-                                  OR x.TYPE = DBO.FPHOTOTYPE('Galaxy'))
-                            AND x.modelmag_g BETWEEN 10 AND 21
+                             OR n.neighbormode = DBO.FPHOTOMODE('Primary')
+                                AND (x.TYPE = DBO.FPHOTOTYPE('Star')
+                                     AND x.TYPE = DBO.FPHOTOTYPE('Galaxy'))
+                             OR x.modelmag_g BETWEEN 10 AND 21
                           GROUP BY n.objid ) AS nbor
                     ON o.objid = nbor.objid
- WHERE p.list IN /* params */(1, 2, 3) 
+ WHERE p.params IN /* params */(1, 2, 3) 

--- a/src/test/testData/sql/formatter/Select.sql
+++ b/src/test/testData/sql/formatter/Select.sql
@@ -25,14 +25,16 @@ SELECT COUNT( DISTINCT (x)),o.*
                              ON p.objid = s.bestobjid AND p.plate = s.plate
           /** Where */
           WHERE p.TYPE = DBO.FPHOTOTYPE('Star')
-            AND (p.flags & DBO.FPHOTOFLAGS('EDGE')) = 0
+         
+            OR (p.flags & DBO.FPHOTOFLAGS('EDGE') = 0
 
-            AND (p.psfmag_g - p.extinction_g) BETWEEN 15 AND 20
+            AND (p.psfmag_g - p.extinction_g) BETWEEN 15 AND 20)
+/*%if status == 2 */
             AND u.propermotion > 2.
             /** And  Group */
             AND (p.psfmag_g - p.extinction_g + 5 * LOG(u.propermotion / 100.) + 5 > 16.136 + 2.727 * (p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i))
 
-                  OR p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i) < 0.) ) AS o
+                  OR p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i) < 0.)/*%end*/) AS o
 
        LEFT OUTER JOIN ( SELECT n.objid
                                 , MIN(n.distance) AS nearest
@@ -40,18 +42,21 @@ SELECT COUNT( DISTINCT (x)),o.*
                            FROM neighbors n
                                 JOIN phototag x
                                   ON n.neighborobjid = x.objid
-
+                                  AND n.neighbormode = DBO.FPHOTOMODE('Primary')
+                                  OR n.MODE = /*# "active" */'mode'
+                                  AND n.status =2
+                                  AND n.flag = true
                           WHERE n.TYPE = DBO.FPHOTOTYPE('Star')
 
                             AND n.MODE = DBO.FPHOTOMODE('Primary')
-                            AND n.neighbormode = DBO.FPHOTOMODE('Primary')
+                            OR n.neighbormode = DBO.FPHOTOMODE('Primary')
                             AND (x.TYPE = DBO.FPHOTOTYPE('Star')
 
-                                  OR x.TYPE = DBO.FPHOTOTYPE('Galaxy'))
-                            AND x.modelmag_g BETWEEN 10 AND 21
+                                  AND x.TYPE = DBO.FPHOTOTYPE('Galaxy'))
+                            OR x.modelmag_g BETWEEN 10 AND 21
 
                           GROUP BY n.objid ) AS nbor
                     ON o.objid = nbor.objid
-                WHERE p.list IN /* params */(1
+                WHERE p.params IN /* params */(1
                                             ,2
                                             ,3)


### PR DESCRIPTION
I adjusted the indentation of AND and OR blocks based on the sequence of keywords:

- When an AND follows an OR, it should be indented further than the OR.  
- If the same keyword appears consecutively, align them so that the keywords line up on the right.  
- If conditions are grouped in a subgroup, the OR is indented by one additional space compared to the AND.  

```SQL
AND status = 1
OR id =3
   AND name = /* name */'test'
```

```SQL
AND status = 1
OR id =3
OR name = /* name */'test'
```

I also adjusted the indentation of comment blocks that indicate condition directives or loop directives to match the indentation of the block directly below them:

- Comment blocks placed before or after AND/OR should have the same indentation as AND/OR.  
- The end block should be aligned with its corresponding comment block.  
- Loop blocks should be aligned at the same indentation level as other columns/lines (e.g., within INSERT or UPDATE).

```SQL
AND status = 1
/*%if div== 2*/
OR id =3
   AND name = /* name */'test'
/*%end*/
```

```SQL
INSERT INTO /*# tableName */
            (x1
             , x2
             /*%for entity : entities */
             , /*# entity.itemIdentifier */
             /*%end*/
             , x3
             , x4)
```

Finally, I refined where spaces are added:

- Always insert a space before the closing parenthesis of a subgroup representing a subquery.  
- Insert spaces before and after conditional expressions.  