### PR TITLE
Update changelog and improve version handling

### DIFF
--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -77,6 +77,7 @@ jobs:
           git config user.name "GitHub Action"
           git checkout -b $BRANCH
           git add CHANGELOG.md
+          git add gradle.properties
           git commit -am "Changelog update - $NEW_VERSION"
           git push --set-upstream --force-with-lease origin $BRANCH
 


### PR DESCRIPTION
Set the plugin version to build when updating ```CHANGELOG.md```.

When updating CHANGELOG.md, the PR replaces the temporary development version set in gradle.properties with the release version.

When using the publishPlugin, the version is referenced directly from the Gradle configuration file.
