### PR TITLE
Overwriting a development version with a release version

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,8 +16,19 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      skip_job: ${{ steps.check.outputs.SKIP_JOB }}
 
     steps:
+      - name: Check Commit Message
+        id: check
+        run: |
+          if [[ "${{ github.event.head_commit.message }}" =~ ^Merge\ pull\ request\ #[0-9]+\ from\ ${{ github.repository_owner }}/doc/changelog-update-.*$ ]]; then
+            echo "This commit is not target. Skip the workflow."
+            echo "SKIP_JOB=true" >> $GITHUB_OUTPUT
+          else
+            echo "SKIP_JOB=false" >> $GITHUB_OUTPUT
+          fi
       - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -26,7 +37,7 @@ jobs:
 
   update_version:
     needs: update_release_draft
-    if: ${{ !contains(github.head_ref, 'doc/changelog-update-') }}
+    if: ${{ needs.update_release_draft.outputs.skip_job != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update_release_draft:
-    if: "! (github.head_ref =~ '^doc/changelog-update-\\d+\\.\\d+\\.\\d+$')"
+    if: ${{ !contains(github.head_ref, 'doc/changelog-update-') }}
     permissions:
       contents: write
       pull-requests: write
@@ -26,7 +26,7 @@ jobs:
 
   update_version:
     needs: update_release_draft
-    if: "! (github.head_ref =~ '^doc/changelog-update-\\d+\\.\\d+\\.\\d+$')"
+    if: ${{ !contains(github.head_ref, 'doc/changelog-update-') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   update_release_draft:
+    if: "! (github.head_ref =~ '^doc/changelog-update-\\d+\\.\\d+\\.\\d+$')"
     permissions:
       contents: write
       pull-requests: write
@@ -25,6 +26,7 @@ jobs:
 
   update_version:
     needs: update_release_draft
+    if: "! (github.head_ref =~ '^doc/changelog-update-\\d+\\.\\d+\\.\\d+$')"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Check Commit Message
         id: check
         run: |
-          if [[ "${{ github.event.head_commit.message }}" =~ ^Merge\ pull\ request\ #[0-9]+\ from\ ${{ github.repository_owner }}/doc/changelog-update-.*$ ]]; then
+          # Define a regex pattern to match commit messages for changelog updates
+          CHANGELOG_UPDATE_PATTERN="^Merge pull request #[0-9]+ from ${{ github.repository_owner }}/doc/changelog-update-.*$"
+          
+          if [[ "${{ github.event.head_commit.message }}" =~ $CHANGELOG_UPDATE_PATTERN ]]; then
             echo "This commit is not target. Skip the workflow."
             echo "SKIP_JOB=true" >> $GITHUB_OUTPUT
           else

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -543,7 +543,7 @@ fun replaceVersionInPluginUtil(ver: String) {
     ant.withGroovyBuilder {
         "replaceregexp"(
             "match" to """(const val PLUGIN_VERSION = ")(\d+\.\d+\.\d+)((?:-\S+)*)""",
-            "replace" to "\\1$ver",
+            "replace" to "\\1$ver\"",
             "encoding" to encoding,
             "flags" to "g",
         ) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -542,7 +542,7 @@ spotless {
 fun replaceVersionInPluginUtil(ver: String) {
     ant.withGroovyBuilder {
         "replaceregexp"(
-            "match" to """(const val PLUGIN_VERSION = ")(\d+\.\d+\.\d+)((?:-\S+)*)""",
+            "match" to """(const val PLUGIN_VERSION = ")(\d+\.\d+\.\d+)((?:-\S+)*)(")""",
             "replace" to "\\1$ver\"",
             "encoding" to encoding,
             "flags" to "g",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -387,11 +387,11 @@ tasks.register("updateChangelog") {
             }
         }
 
-        val newVersion = versionInfo.getNewVersion()
+        val releaseVersion = versionInfo.getNewVersion()
         val prLinks = mutableListOf<String>()
         val newEntry = StringBuilder()
 
-        newEntry.append("## [$newVersion] - $releaseDate\n\n")
+        newEntry.append("## [$releaseVersion] - $releaseDate\n\n")
         categories.keys.forEach { category ->
             val hitItems = categorized[category]
             if (!hitItems.isNullOrEmpty()) {
@@ -415,18 +415,18 @@ tasks.register("updateChangelog") {
             }
         val repoUrl = "https://github.com/domaframework/doma-tools-for-intellij"
         changelogFile.writeText(updatedContent)
-        changelogFile.appendText("[$newVersion]: $repoUrl/compare/$lastTag...$newVersion\n")
+        changelogFile.appendText("[$releaseVersion]: $repoUrl/compare/$lastTag...$releaseVersion\n")
 
         // Update Version Gradle pluginVersion
-        replaceVersionGradleProperty(newVersion)
-        println("Update Gradle Property: $newVersion")
+        replaceVersion(releaseVersion)
+        println("Update Version Pre Release: $releaseVersion")
 
         val githubEnv = System.getenv("GITHUB_ENV")
         val envFile = File(githubEnv)
-        envFile.appendText("NEW_VERSION=$newVersion\n")
-        envFile.appendText("BRANCH=doc/changelog-update-$newVersion\n")
+        envFile.appendText("NEW_VERSION=$releaseVersion\n")
+        envFile.appendText("BRANCH=doc/changelog-update-$releaseVersion\n")
 
-        println("Update newVersion: $newVersion")
+        println("Update newVersion: $releaseVersion")
     }
 }
 
@@ -542,7 +542,7 @@ spotless {
 fun replaceVersionInPluginUtil(ver: String) {
     ant.withGroovyBuilder {
         "replaceregexp"(
-            "match" to """(const val PLUGIN_VERSION = ")(\d+\.\d+\.\d+)((?:-beta)*)""",
+            "match" to """(const val PLUGIN_VERSION = ")(\d+\.\d+\.\d+)((?:-\S+)*)""",
             "replace" to "\\1$ver",
             "encoding" to encoding,
             "flags" to "g",
@@ -557,7 +557,7 @@ fun replaceVersionInPluginUtil(ver: String) {
 fun replaceVersionGradleProperty(ver: String) {
     ant.withGroovyBuilder {
         "replaceregexp"(
-            "match" to """(pluginVersion = )(\d+\.\d+\.\d+)((?:-beta)*)""",
+            "match" to """(pluginVersion = )(\d+\.\d+\.\d+)((?:-\S+)*)""",
             "replace" to "\\1$ver",
             "encoding" to encoding,
             "flags" to "g",
@@ -572,7 +572,7 @@ fun replaceVersionGradleProperty(ver: String) {
 fun replaceVersionInLogSetting(ver: String) {
     ant.withGroovyBuilder {
         "replaceregexp"(
-            "match" to """(org.domaframework.doma.intellij.plugin.version:-)(\d+\.\d+\.\d+)((?:-beta)*)(})""",
+            "match" to """(org.domaframework.doma.intellij.plugin.version:-)(\d+\.\d+\.\d+)((?:-\S+)*)(})""",
             "replace" to "\\1$ver\\4",
             "encoding" to encoding,
             "flags" to "g",
@@ -588,7 +588,7 @@ fun replaceVersionInLogSetting(ver: String) {
 fun replaceVersion(ver: String) {
     checkNotNull(ver)
     replaceVersionInPluginUtil(ver)
-    replaceVersionGradleProperty("$ver-beta")
+    replaceVersionGradleProperty(ver)
     replaceVersionInLogSetting(ver)
     println("Replace version in PluginUtil.kt, gradle.properties, logback.xml")
 }
@@ -609,7 +609,7 @@ tasks.register("replaceNewVersion") {
         val minor = lastVersions[1].toInt()
         val patch = lastVersions[2].toInt() + 1
 
-        val newVersion = "$major.$minor.$patch"
+        val newVersion = "$major.$minor.$patch-beta"
         println("Release newVersion: $newVersion")
         replaceVersion(newVersion)
         try {
@@ -634,7 +634,7 @@ tasks.register("replaceDraftVersion") {
 
     doLast {
         println("Release DraftVersion: $draftVersion")
-        replaceVersion(draftVersion)
+        replaceVersion("$draftVersion-beta")
         try {
             val githubEnv = System.getenv("GITHUB_ENV")
             val envFile = File(githubEnv)


### PR DESCRIPTION
Before publishing the release notes, the task of merging the update PR for ```CHANGELOG.md``` needs to be completed.

During this process, not only will gradle.properties be updated to the release version, but the version specified in the log settings will also be updated to match the release version. This ensures that all files are updated to the same version as gradle.properties when setting the release draft or preparing the next development version after the release.