### PR TITLE
File jump in jar

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/FileTypeCheck.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/FileTypeCheck.kt
@@ -28,6 +28,7 @@ fun getExtension(type: String): String =
         "JAVA" -> "java"
         "Kotlin" -> "kt"
         "SQL" -> "sql"
+        "CLASS" -> "class"
         else -> {
             ""
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/FileTypeCheck.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/FileTypeCheck.kt
@@ -40,7 +40,7 @@ fun isJavaOrKotlinFileType(daoFile: PsiFile): Boolean {
     if (daoFile.virtualFile == null) return false
     val fileType = FileTypeManager.getInstance().getFileTypeByFile(daoFile.virtualFile)
     return when (fileType.name) {
-        "JAVA", "Kotlin" -> true
+        "JAVA", "Kotlin", "CLASS" -> true
         else -> false
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/JarFileSearch.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/JarFileSearch.kt
@@ -1,0 +1,35 @@
+package org.domaframework.doma.intellij.common
+
+import com.intellij.openapi.vfs.StandardFileSystems
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import org.domaframework.doma.intellij.common.CommonPathParameter.Companion.RESOURCES_META_INF_PATH
+
+fun getJarRoot(
+    virtualFile: VirtualFile,
+    originalFile: PsiFile,
+): VirtualFile? {
+    val jarRootPath = virtualFile.path.substringBefore("jar!").plus("jar!")
+    val jarRoot =
+        StandardFileSystems
+            .jar()
+            .findFileByPath("$jarRootPath/")
+    val methodDaoFilePath =
+        getMethodDaoFilePath(virtualFile, jarRootPath, originalFile)
+    return jarRoot?.findFileByRelativePath(methodDaoFilePath)
+}
+
+fun getMethodDaoFilePath(
+    virtualFile: VirtualFile,
+    jarRootPath: String,
+    originalFile: PsiFile,
+): String {
+    val methodDaoFilePath =
+        virtualFile.path
+            .substringAfter(
+                jarRootPath,
+            ).replace("/$RESOURCES_META_INF_PATH", "")
+            .replace("/${originalFile.name}", "")
+            .plus(".class")
+    return methodDaoFilePath
+}

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/JarFileSearch.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/JarFileSearch.kt
@@ -31,7 +31,12 @@ fun getJarRoot(
             .findFileByPath("$jarRootPath/")
     val methodDaoFilePath =
         getMethodDaoFilePath(virtualFile, jarRootPath, originalFile)
-    return jarRoot?.findFileByRelativePath(methodDaoFilePath)
+
+    val jarRootFile =
+        jarRoot?.findFileByRelativePath(methodDaoFilePath.plus(".class"))
+            ?: jarRoot?.findFileByRelativePath(methodDaoFilePath.plus(".java"))
+
+    return jarRootFile
 }
 
 fun getMethodDaoFilePath(
@@ -45,6 +50,6 @@ fun getMethodDaoFilePath(
                 jarRootPath,
             ).replace("/$RESOURCES_META_INF_PATH", "")
             .replace("/${originalFile.name}", "")
-            .plus(".class")
+
     return methodDaoFilePath
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/JarFileSearch.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/JarFileSearch.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.domaframework.doma.intellij.common
 
 import com.intellij.openapi.vfs.StandardFileSystems

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
@@ -85,6 +85,7 @@ fun findDaoMethod(
                 return daoMethod
             }
         } else {
+            val fileType = getExtension(daoFile.fileType.name)
             val jarRootPath = virtualFile.path.substringBefore("jar!").plus("jar!")
             val methodDaoFilePath = getMethodDaoFilePath(virtualFile, jarRootPath, originalFile)
             val daoClassName = getDaoClassName(methodDaoFilePath, "CLASS")
@@ -98,7 +99,7 @@ fun findDaoMethod(
                         val fqn =
                             methodDaoFilePath
                                 .trimStart('/')
-                                .removeSuffix(".class")
+                                .removeSuffix(".$fileType")
                                 .replace('/', '.')
                         JavaPsiFacade
                             .getInstance(project)

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
@@ -67,6 +67,7 @@ fun findDaoMethod(
                     project.getContentRoot(virtualFile)?.path ?: "",
                     fileTypeName,
                 )
+            // get ClassPath with package name
             val daoClassName: String =
                 relativePath
                     .substringBefore(".")
@@ -88,7 +89,7 @@ fun findDaoMethod(
             val fileType = getExtension(daoFile.fileType.name)
             val jarRootPath = virtualFile.path.substringBefore("jar!").plus("jar!")
             val methodDaoFilePath = getMethodDaoFilePath(virtualFile, jarRootPath, originalFile)
-            val daoClassName = getDaoClassName(methodDaoFilePath, "CLASS")
+            val daoClassName = getDaoClassName(methodDaoFilePath, fileType)
             val daoFile = getJarRoot(virtualFile, originalFile) ?: return null
             val psiClassFile = PsiManager.getInstance(originalFile.project).findFile(daoFile)
             val psiClassOwner = psiClassFile as? PsiClassOwner ?: return null
@@ -114,7 +115,7 @@ fun findDaoMethod(
 private fun getDaoClassName(
     methodDaoFilePath: String,
     extensionName: String,
-): String = methodDaoFilePath.substringBefore(".${extensionName.lowercase()}").substringAfter("dao/")
+): String = methodDaoFilePath.substringBefore(".$extensionName").substringAfter("dao/")
 
 /**
  * Get jump destination Dao method file from SQL file

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/expr/SqlElExtensions.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/expr/SqlElExtensions.kt
@@ -26,7 +26,6 @@ import org.domaframework.doma.intellij.psi.SqlElIfDirective
 import org.domaframework.doma.intellij.psi.SqlElPrimaryExpr
 import org.domaframework.doma.intellij.psi.SqlElStaticFieldAccessExpr
 import org.domaframework.doma.intellij.psi.SqlTypes
-import kotlin.invoke
 
 val SqlElStaticFieldAccessExpr.accessElements: List<PsiElement>
     get() {

--- a/src/main/kotlin/org/domaframework/doma/intellij/gutter/sql/SqlLineMakerProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/gutter/sql/SqlLineMakerProvider.kt
@@ -56,7 +56,7 @@ class SqlLineMakerProvider : RelatedItemLineMarkerProvider() {
         val identifier = e.firstChild ?: e
         val daoFile =
             findDaoFile(project, file)?.let {
-                if (findDaoMethod(e.containingFile) == null) return
+                if (findDaoMethod(e.containingFile, it) == null) return
                 it
             } ?: return
 


### PR DESCRIPTION
Added jump-to-DAO and SQL‑file functionality within JARs.

Enabled gutter icons and jump actions in both the binary JAR and its corresponding source JAR.
(The source JAR must be linked to the binary JAR.)