### PR TITLE
Support reference resolution for bind variables that reference classpath resources within JAR files.

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiStaticElement.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiStaticElement.kt
@@ -15,8 +15,10 @@
  */
 package org.domaframework.doma.intellij.common.psi
 
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiFile
+import com.intellij.psi.search.GlobalSearchScope
 import org.domaframework.doma.intellij.extension.getJavaClazz
 import org.domaframework.doma.intellij.psi.SqlElExpr
 import org.jetbrains.kotlin.idea.base.util.module
@@ -26,7 +28,7 @@ import org.jetbrains.kotlin.idea.base.util.module
  */
 class PsiStaticElement(
     elExprList: List<SqlElExpr>? = null,
-    originalFile: PsiFile,
+    private val originalFile: PsiFile,
 ) {
     private var fqdn = elExprList?.joinToString(".") { e -> e.text } ?: ""
     private val module = originalFile.module
@@ -38,5 +40,10 @@ class PsiStaticElement(
                 .substringBefore("@")
     }
 
-    fun getRefClazz(): PsiClass? = module?.getJavaClazz(true, fqdn)
+    fun getRefClazz(): PsiClass? =
+        module?.getJavaClazz(true, fqdn)
+            ?: JavaPsiFacade.getInstance(originalFile.project).findClass(
+                fqdn,
+                GlobalSearchScope.allScope(originalFile.project),
+            )
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/reference/SqlElIdExprReference.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/reference/SqlElIdExprReference.kt
@@ -71,10 +71,10 @@ class SqlElIdExprReference(
         startTime: Long,
         file: PsiFile,
     ): PsiElement? {
-        val targetElement = getBlockCommentElements(element)
-        if (targetElement.isEmpty()) return null
+        val targetElements = getBlockCommentElements(element)
+        if (targetElements.isEmpty()) return null
 
-        val topElm = targetElement.firstOrNull() as? PsiElement ?: return null
+        val topElm = targetElements.firstOrNull() as? PsiElement ?: return null
 
         if (topElm.prevSibling.elementType == SqlTypes.AT_SIGN) return null
 
@@ -92,14 +92,14 @@ class SqlElIdExprReference(
         val daoMethod = findDaoMethod(file) ?: return null
 
         return when (element.textOffset) {
-            targetElement.first().textOffset ->
+            targetElements.first().textOffset ->
                 getReferenceDaoMethodParameter(
                     daoMethod,
                     element,
                     startTime,
                 )
 
-            else -> getReferenceEntity(daoMethod, targetElement, startTime)
+            else -> getReferenceEntity(daoMethod, targetElements, startTime)
         }
     }
 
@@ -124,13 +124,13 @@ class SqlElIdExprReference(
 
     private fun getReferenceDaoMethodParameter(
         daoMethod: PsiMethod,
-        it: PsiElement,
+        bindElement: PsiElement,
         startTime: Long,
     ): PsiElement? {
         daoMethod
             .let { method ->
                 method.methodParameters.firstOrNull { param ->
-                    param.name == it.text
+                    param.name == bindElement.text
                 }
             }?.originalElement
             ?.let { originalElm ->

--- a/src/main/kotlin/org/domaframework/doma/intellij/reference/SqlElStaticFieldReference.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/reference/SqlElStaticFieldReference.kt
@@ -94,7 +94,8 @@ class SqlElStaticFieldReference(
         if (targetElements.isEmpty()) return null
 
         val topElm = targetElements.firstOrNull() as? PsiElement ?: return null
-        if (topElm.prevSibling.elementType != SqlTypes.AT_SIGN) return null
+        val prevSibling = topElm.prevSibling ?: return null
+        if (prevSibling.elementType != SqlTypes.AT_SIGN) return null
         var index = 1
         for (staticFieldAccess in targetElements) {
             if (index >= targetElements.size) {

--- a/src/test/kotlin/org/domaframework/doma/intellij/reference/SqlReferenceTestCase.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/reference/SqlReferenceTestCase.kt
@@ -72,8 +72,11 @@ class SqlReferenceTestCase : DomaSqlTest() {
             "referenceStaticField",
             mapOf(
                 "doma.example.entity.ProjectDetail" to "$classResolve:ProjectDetail",
+                "doma.example.entity.Project" to "$classResolve:Project",
                 "projectCategory" to "$fieldResolve:projectCategory",
                 "getTermNumber" to "$methodResolve:getTermNumber",
+                "getFirstEmployee" to "$methodResolve:getFirstEmployee",
+                "employeeId" to "$fieldResolve:employeeId",
             ),
         )
     }

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/reference/ReferenceTestDao/referenceStaticField.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/reference/ReferenceTestDao/referenceStaticField.sql
@@ -1,4 +1,4 @@
 SELECT *
   FROM project_detail
  WHERE category = /* @doma.example.entity.ProjectDetail@projectCategory */'category'
-   AND number = /* @doma.example.entity.ProjectDetail@getTermNumber() */'9999' 
+   AND number = /* @doma.example.entity.Project@getFirstEmployee().employeeId */'9999'


### PR DESCRIPTION
Introduce a dedicated implementation to retrieve files within JARs, since they cannot be obtained from module information.
Additionally, when bind variables referencing static fields or methods appear consecutively, accurately identify the declaring class and resolve the references.