### PR TITLE
Fix: StringIndexOutOfBoundsException: Range In FileTypeCheck

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/FileTypeCheck.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/FileTypeCheck.kt
@@ -79,6 +79,11 @@ fun searchDaoFile(
     if (projectRootPath.endsWith(SRC_MAIN_PATH)) {
         return contentRoot.findFileByRelativePath(relativeDaoFilePath)
     }
+
+    if (projectRootPath.length > originFilePath.length) {
+        return null
+    }
+
     val subProject =
         originFilePath.substring(projectRootPath.length, originFilePath.indexOf(SRC_MAIN_PATH))
     return contentRoot


### PR DESCRIPTION
Check the file path length in advance to avoid errors