### PR TITLE
Add For Item Element Documentation

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/document/ForItemElementDocumentationProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/document/ForItemElementDocumentationProvider.kt
@@ -1,0 +1,214 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.document
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElement
+import org.domaframework.doma.intellij.common.dao.findDaoMethod
+import org.domaframework.doma.intellij.common.psi.PsiParentClass
+import org.domaframework.doma.intellij.common.sql.PsiClassTypeUtil
+import org.domaframework.doma.intellij.common.sql.foritem.ForItem
+import org.domaframework.doma.intellij.common.sql.validator.SqlElForItemFieldAccessorChildElementValidator
+import org.domaframework.doma.intellij.common.sql.validator.result.ValidationCompleteResult
+import org.domaframework.doma.intellij.common.sql.validator.result.ValidationResult
+import org.domaframework.doma.intellij.extension.psi.getForItem
+import org.domaframework.doma.intellij.extension.psi.getForItemDeclaration
+import org.domaframework.doma.intellij.inspection.ForDirectiveInspection
+import org.domaframework.doma.intellij.psi.SqlElForDirective
+import org.domaframework.doma.intellij.psi.SqlElIdExpr
+import org.domaframework.doma.intellij.psi.SqlTypes
+import org.toml.lang.psi.ext.elementType
+import java.util.LinkedList
+
+class ForItemElementDocumentationProvider : AbstractDocumentationProvider() {
+    override fun generateDoc(
+        element: PsiElement?,
+        originalElement: PsiElement?,
+    ): String? {
+        val result: MutableList<String?> = LinkedList<String?>()
+        if (originalElement !is SqlElIdExpr && originalElement?.elementType != SqlTypes.EL_IDENTIFIER) {
+            return super.generateDoc(
+                element,
+                originalElement,
+            )
+        }
+
+        val file = originalElement.containingFile
+        val daoMethod = findDaoMethod(file) ?: return ""
+        val forDirectiveInspection = ForDirectiveInspection(daoMethod, "")
+
+        val currentForItem = ForItem(originalElement)
+        val forDirectiveExpr = currentForItem.getParentForDirectiveExpr()
+        if (forDirectiveExpr != null) {
+            if (forDirectiveExpr.getForItem()?.textOffset != originalElement.textOffset) {
+                val declarationClassType =
+                    forDirectiveInspection.validateFieldAccessByForItem(
+                        listOf(originalElement),
+                        skipSelf = false,
+                    )
+                if (declarationClassType != null) {
+                    generateDocumentInForDirective(
+                        declarationClassType,
+                        forDirectiveExpr,
+                        originalElement,
+                        result,
+                    )
+                }
+            } else {
+                val declarationSide = forDirectiveExpr.getForItemDeclaration() ?: return ""
+                val children = declarationSide.getDeclarationChildren()
+                generateDocumentInForItem(
+                    forDirectiveInspection,
+                    originalElement,
+                    children,
+                    result,
+                )
+            }
+        } else {
+            generateDocumentInBindVariable(forDirectiveInspection, originalElement, result)
+        }
+        return result.joinToString("\n")
+    }
+
+    private fun generateDocumentInForItem(
+        forDirectiveInspection: ForDirectiveInspection,
+        originalElement: PsiElement,
+        declarationChildren: List<SqlElIdExpr>,
+        result: MutableList<String?>,
+    ) {
+        val declarationClassType =
+            forDirectiveInspection.validateFieldAccessByForItem(listOf(originalElement), false)
+        if (declarationClassType is ValidationCompleteResult) {
+            val parentClass = declarationClassType.parentClass
+            val forItemValidator =
+                SqlElForItemFieldAccessorChildElementValidator(
+                    declarationChildren,
+                    parentClass,
+                )
+            val declarationClassTypeResult = forItemValidator.validateChildren()
+            if (declarationClassTypeResult is ValidationCompleteResult) {
+                var resultParent = declarationClassTypeResult.parentClass
+                var classType: PsiClassType? = resultParent.type as? PsiClassType
+                if (classType != null &&
+                    PsiClassTypeUtil.isIterableType(classType, originalElement.project)
+                ) {
+                    classType = classType.parameters.firstOrNull() as? PsiClassType
+                }
+                if (classType != null) {
+                    resultParent = PsiParentClass(classType)
+                    result.add("${generateTypeLink(resultParent)} ${originalElement.text}")
+                }
+            }
+        }
+    }
+
+    private fun generateDocumentInBindVariable(
+        forDirectiveInspection: ForDirectiveInspection,
+        originalElement: PsiElement,
+        result: MutableList<String?>,
+    ) {
+        val declarationClassType =
+            forDirectiveInspection.validateFieldAccessByForItem(listOf(originalElement))
+        if (declarationClassType != null) {
+            val parentClass = declarationClassType.parentClass
+            result.add("${generateTypeLink(parentClass)} ${originalElement.text}")
+        }
+    }
+
+    private fun generateDocumentInForDirective(
+        declarationClassType: ValidationResult,
+        forDirectiveExpr: SqlElForDirective,
+        originalElement: PsiElement,
+        result: MutableList<String?>,
+    ) {
+        val parentClass = declarationClassType.parentClass
+        val parentType = parentClass?.type as? PsiClassType
+
+        if (forDirectiveExpr.getForItem()?.textOffset == originalElement.textOffset) {
+            generateDocumentForItemSelf(parentType, originalElement, result)
+        } else {
+            result.add("${generateTypeLink(parentClass)} ${originalElement.text}")
+        }
+    }
+
+    private fun generateDocumentForItemSelf(
+        parentType: PsiClassType?,
+        originalElement: PsiElement,
+        result: MutableList<String?>,
+    ) {
+        val targetClassType =
+            if (parentType != null &&
+                PsiClassTypeUtil.isIterableType(parentType, originalElement.project)
+            ) {
+                parentType.parameters.firstOrNull()
+            } else {
+                null
+            }
+
+        if (targetClassType != null) {
+            val forItemParentClassType = PsiParentClass(targetClassType)
+            result.add("${generateTypeLink(forItemParentClassType)} ${originalElement.text}")
+        }
+    }
+
+    override fun generateHoverDoc(
+        element: PsiElement,
+        originalElement: PsiElement?,
+    ): String? = generateDoc(element, originalElement)
+
+    override fun getQuickNavigateInfo(
+        element: PsiElement,
+        originalElement: PsiElement?,
+    ): String? {
+        val result: MutableList<String?> = LinkedList<String?>()
+        val typeDocument = generateDoc(element, originalElement)
+        result.add(typeDocument)
+        return result.joinToString("\n")
+    }
+
+    private fun generateTypeLink(parentClass: PsiParentClass?): String {
+        if (parentClass?.type != null) {
+            return generateTypeLinkFromCanonicalText(parentClass.type.canonicalText)
+        }
+        return ""
+    }
+
+    private fun generateTypeLinkFromCanonicalText(canonicalText: String): String {
+        val regex = Regex("([a-zA-Z0-9_]+\\.)*([a-zA-Z0-9_]+)")
+        val result = StringBuilder()
+        var lastIndex = 0
+
+        for (match in regex.findAll(canonicalText)) {
+            val fullMatch = match.value
+            val typeName = match.groups[2]?.value ?: fullMatch
+            val startIndex = match.range.first
+            val endIndex = match.range.last + 1
+
+            if (lastIndex < startIndex) {
+                result.append(canonicalText.substring(lastIndex, startIndex))
+            }
+            result.append("<a href=\"psi_element://$fullMatch\">$typeName</a>")
+            lastIndex = endIndex
+        }
+
+        if (lastIndex < canonicalText.length) {
+            result.append(canonicalText.substring(lastIndex))
+        }
+
+        return result.toString()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -24,13 +24,17 @@
         instance="org.domaframework.doma.intellij.setting.DomaToolsConfigurable"
         displayName="Doma Tools" />
 
+    <!-- Reference -->
     <psi.referenceContributor
       implementation="org.domaframework.doma.intellij.reference.SqlReferenceContributor"
       language="DomaSql"
     />
-
     <lang.elementManipulator forClass="org.domaframework.doma.intellij.psi.SqlCustomElExpr"
       implementationClass="org.domaframework.doma.intellij.reference.SqlElExprManipulator" />
+
+    <!-- Document -->
+    <lang.documentationProvider language="DomaSql"
+      implementationClass="org.domaframework.doma.intellij.document.ForItemElementDocumentationProvider" />
 
     <!-- Gutter -->
     <codeInsight.lineMarkerProvider language="JAVA"

--- a/src/test/kotlin/org/domaframework/doma/intellij/document/SqlSymbolDocumentTestCase.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/document/SqlSymbolDocumentTestCase.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.document
+
+import com.intellij.psi.PsiElement
+import org.domaframework.doma.intellij.DomaSqlTest
+import org.domaframework.doma.intellij.psi.SqlElIdExpr
+
+class SqlSymbolDocumentTestCase : DomaSqlTest() {
+    val testPackage = "document"
+    val testDaoName = "DocumentTestDao"
+    val myDocumentationProvider: ForItemElementDocumentationProvider = ForItemElementDocumentationProvider()
+
+    override fun setUp() {
+        super.setUp()
+        addDaoJavaFile("$testPackage/$testDaoName.java")
+        addSqlFile("$testPackage/$testDaoName/documentForItemDaoParam.sql")
+        addSqlFile("$testPackage/$testDaoName/documentForItemDeclaration.sql")
+        addSqlFile("$testPackage/$testDaoName/documentForItemElement.sql")
+        addSqlFile("$testPackage/$testDaoName/documentForItemElementInBindVariable.sql")
+        addSqlFile("$testPackage/$testDaoName/documentForItemElementInIfDirective.sql")
+        addSqlFile("$testPackage/$testDaoName/documentForItemElementByFieldAccess.sql")
+    }
+
+    fun testDocumentForItemDaoParam() {
+        val sqlName = "documentForItemDaoParam"
+        val result: String? = null
+
+        documentationTest(sqlName, result)
+    }
+
+    fun testDocumentForItemDeclaration() {
+        val sqlName = "documentForItemDeclaration"
+        val result =
+            "<a href=\"psi_element://java.util.List\">List</a><<a href=\"psi_element://java.util.List\">" +
+                "List</a><<a href=\"psi_element://java.lang.Integer\">Integer</a>>> employeeIds"
+
+        documentationTest(sqlName, result)
+    }
+
+    fun testDocumentForItemElement() {
+        val sqlName = "documentForItemElement"
+        val result =
+            "<a href=\"psi_element://java.util.List\">List</a><<a href=\"psi_element://java.util.List\">" +
+                "List</a><<a href=\"psi_element://java.lang.Integer\">Integer</a>>> employeeIds"
+
+        documentationFindTextTest(sqlName, "employeeIds", result)
+    }
+
+    fun testDocumentForItemElementInBindVariable() {
+        val sqlName = "documentForItemElementInBindVariable"
+        val result =
+            "<a href=\"psi_element://java.util.List\">List</a><" +
+                "<a href=\"psi_element://java.lang.Integer\">Integer</a>> ids"
+
+        documentationTest(sqlName, result)
+    }
+
+    fun testDocumentForItemElementInIfDirective() {
+        val sqlName = "documentForItemElementInIfDirective"
+        val result =
+            "<a href=\"psi_element://java.util.List\">List</a><" +
+                "<a href=\"psi_element://java.lang.Integer\">Integer</a>> ids"
+
+        documentationTest(sqlName, result)
+    }
+
+    fun testDocumentForItemElementByFieldAccess() {
+        val sqlName = "documentForItemElementByFieldAccess"
+        val result =
+            "<a href=\"psi_element://doma.example.entity.Project\">Project</a> project"
+
+        documentationTest(sqlName, result)
+    }
+
+    private fun documentationTest(
+        sqlName: String,
+        result: String?,
+    ) {
+        val sqlFile = findSqlFile("$testPackage/$testDaoName/$sqlName.sql")
+        assertNotNull("Not Found SQL File", sqlFile)
+        if (sqlFile == null) return
+
+        myFixture.configureFromExistingVirtualFile(sqlFile)
+        var originalElement: PsiElement = myFixture.elementAtCaret
+        println("originalElement: ${originalElement.text}")
+
+        val resultDocument = myDocumentationProvider.generateDoc(originalElement, originalElement)
+        assertEquals("Documentation should contain expected text", result, resultDocument)
+    }
+
+    private fun documentationFindTextTest(
+        sqlName: String,
+        originalElementName: String,
+        result: String?,
+    ) {
+        val sqlFile = findSqlFile("$testPackage/$testDaoName/$sqlName.sql")
+        assertNotNull("Not Found SQL File", sqlFile)
+        if (sqlFile == null) return
+
+        myFixture.configureFromExistingVirtualFile(sqlFile)
+        var originalElement: PsiElement = myFixture.findElementByText(originalElementName, SqlElIdExpr::class.java)
+        println("originalElement: ${originalElement.text}")
+
+        val resultDocument = myDocumentationProvider.generateDoc(originalElement, originalElement)
+        assertEquals("Documentation should contain expected text", result, resultDocument)
+    }
+}

--- a/src/test/testData/src/main/java/doma/example/dao/document/DocumentTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/document/DocumentTestDao.java
@@ -1,0 +1,29 @@
+package doma.example.dao.document;
+
+import java.util.List;
+import java.util.HashSet;
+import doma.example.entity.*;
+import org.seasar.doma.*;
+
+@Dao
+public interface DocumentTestDao {
+
+  @Select
+  List<Employee> documentForItemDaoParam(HashSet<List<List<Integer>>> employeeIdsList);
+
+  @Select
+  List<Employee> documentForItemDeclaration(HashSet<List<List<Integer>>> employeeIdsList);
+
+  @Select
+  List<Employee> documentForItemElement(HashSet<List<List<Integer>>> employeeIdsList);
+
+  @Select
+  List<Employee> documentForItemElementInBindVariable(HashSet<List<List<Integer>>> employeeIdsList);
+
+  @Select
+  List<Employee> documentForItemElementInIfDirective(HashSet<List<List<Integer>>> employeeIdsList);
+
+  @Select
+  List<Employee> documentForItemElementByFieldAccess(List<List<Employee>> employeesList);
+
+}

--- a/src/test/testData/src/main/java/doma/example/dao/reference/ReferenceTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/reference/ReferenceTestDao.java
@@ -20,6 +20,6 @@ public interface ReferenceTestDao {
   List<Employee> referenceListFieldMethod(List<Employee> employeesList);
 
   @Select
-  List<Employee> referenceForItem(List<List<List<Employee>>> employeesList);
+  List<Employee> referenceForItem(List<List<Employee>> employeesList);
 
 }

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemDaoParam.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemDaoParam.sql
@@ -1,0 +1,18 @@
+SELECT *
+FROM employees
+WHERE 1=1
+-- employeeIdsList -> HashSet<List<List<Integer>>>
+/*%for employeeIds : employee<caret>IdsList */
+ -- employeeIds -> List<List<Integer>>
+  /*%for ids : employeeIds */
+    -- ids -> List<Integer>
+    /*%if ids.size < 100 */
+      -- id -> Integer
+      /*%for id : ids */
+       AND department = /* id */
+      /*%end */
+    /*%else*/
+       AND departments = /* ids */(1,2,3)
+    /*%end */
+  /*%end */
+/*%end */

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemDeclaration.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemDeclaration.sql
@@ -1,0 +1,18 @@
+SELECT *
+FROM employees
+WHERE 1=1
+-- employeeIdsList -> HashSet<List<List<Integer>>>
+/*%for employeeIds : employeeIdsList */
+ -- employeeIds -> List<List<Integer>>
+  /*%for ids : <caret>employeeIds */
+    -- ids -> List<Integer>
+    /*%if ids.size < 100 */
+      -- id -> Integer
+      /*%for id : ids */
+       AND department = /* id */
+      /*%end */
+    /*%else*/
+       AND departments = /* ids */(1,2,3)
+    /*%end */
+  /*%end */
+/*%end */

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemElement.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemElement.sql
@@ -1,0 +1,17 @@
+SELECT *
+FROM employees
+WHERE 1=1
+/*%for employ<caret>eeIds : employeeIdsList */
+ -- employeeIds -> List<List<Integer>>
+  /*%for ids : employeeIds */
+    -- ids -> List<Integer>
+    /*%if ids.size < 100 */
+      -- id -> Integer
+      /*%for id : ids */
+       OR department = /* id */
+      /*%end */
+    /*%else*/
+       OR departments = /* ids */(1,2,3)
+    /*%end */
+  /*%end */
+/*%end */

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemElementByFieldAccess.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemElementByFieldAccess.sql
@@ -1,0 +1,21 @@
+SELECT id
+  FROM project_detail
+ WHERE category = 'category'
+ -- employeesList -> List<List<Employee>>
+/*%for employees : employeesList */
+   -- employees_has_next -> -> List<Employee>
+  /*%if employees_has_next */
+      /*# "OR" */
+  /*%end */
+   -- employees -> -> List<Employee>
+  /*%for employee : employees */
+    /*%for project : employee.projects */
+     -- project -> Project
+      project_id = /* pr<caret>oject.projectId */
+    /*%end */
+      number >= /* employee.projects.get(0).projectNumber */9999
+    /*%if employee_has_next */
+        /*# "AND" */
+    /*%end */
+  /*%end */
+/*%end */ 

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemElementInBindVariable.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemElementInBindVariable.sql
@@ -1,0 +1,18 @@
+SELECT *
+FROM employees
+WHERE 1=1
+-- employeeIdsList -> HashSet<List<List<Integer>>>
+/*%for employeeIds : employeeIdsList */
+ -- employeeIds -> List<List<Integer>>
+  /*%for ids : employeeIds */
+    -- ids -> List<Integer>
+    /*%if ids.size < 100 */
+      -- id -> Integer
+      /*%for id : ids */
+       AND department = /* id */
+      /*%end */
+    /*%else*/
+       AND departments = /* id<caret>s */(1,2,3)
+    /*%end */
+  /*%end */
+/*%end */

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemElementInIfDirective.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemElementInIfDirective.sql
@@ -1,0 +1,18 @@
+SELECT *
+FROM employees
+WHERE 1=1
+-- employeeIdsList -> HashSet<List<List<Integer>>>
+/*%for employeeIds : employeeIdsList */
+ -- employeeIds -> List<List<Integer>>
+  /*%for ids : employeeIds */
+    -- ids -> List<Integer>
+    /*%if id<caret>s.size < 100 */
+      -- id -> Integer
+      /*%for id : ids */
+       AND department = /* id */
+      /*%end */
+    /*%else*/
+       AND departments = /* ids */(1,2,3)
+    /*%end */
+  /*%end */
+/*%end */

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/reference/ReferenceTestDao/referenceForItem.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/reference/ReferenceTestDao/referenceForItem.sql
@@ -1,11 +1,14 @@
 SELECT id
   FROM project_detail
- WHERE category = /* employeesList.get(0).get(0).get(0).projects.get(0).projectCategory */'category'
+  -- List<List<Employee>> employeesList
+ WHERE category = /* employeesList.get(0).get(0).projects.get(0).projectCategory */'category'
 /*%for employees : employeesList */
   /*%if employees_has_next */
     /*# "OR" */
   /*%end */
+   -- List<Employee> employees
   /*%for employee : employees */
+      -- Employee employee
      /*%for project : employee.projects */
         project_id = /* project.projectId */
      /*%end */


### PR DESCRIPTION
Display documentation when you hover over an element name defined in the For directory.
The documentation will show what types the element is recognized as.

ex)
```SQL
/*%for employeeIds : employeeIdsList */
 -- employeeIds -> List<List<Integer>>
  /*%for ids : employeeIds */
    -- ids -> List<Integer>
    /*%if ids.size < 100 */
      -- id -> Integer
      /*%for id : ids */
       OR department = /* id */
      /*%end */
    /*%else*/
       OR departments = /* ids */(1,2,3)
    /*%end */
  /*%end */
/*%end */
```
![{A9E8DEEF-21F6-4475-BA9A-BBD0209F3848}](https://github.com/user-attachments/assets/86c9c450-2ac7-4bf0-8c06-ebf6a93513f3)
