### PR TITLE
Restored the process for obtaining revision history

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.gradle.internal.classpath.Instrumented.systemProperty
+import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import java.net.URL
@@ -112,6 +113,20 @@ intellijPlatform {
                         .let(::markdownToHTML)
                 }
             }
+
+        val changelog = project.changelog
+        changeNotes =
+            version
+                .map { pluginVersion ->
+                    with(changelog) {
+                        renderItem(
+                            (getOrNull(pluginVersion) ?: getUnreleased())
+                                .withHeader(false)
+                                .withEmptySections(false),
+                            Changelog.OutputType.HTML,
+                        )
+                    }
+                }
 
         ideaVersion {
             sinceBuild = providers.gradleProperty("pluginSinceBuild")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup = org.domaframework.doma.intellij
 pluginName = Doma Tools for IntelliJ
 pluginRepositoryUrl = https://github.com/domaframework/doma-tools-for-intellij
-pluginVersion = 0.6.1-beta
+pluginVersion = 0.6.0
 
 pluginSinceBuild=231
 


### PR DESCRIPTION
The process for searching change history information according to the plugin version was deleted, so it will be reverted.
https://github.com/domaframework/doma-tools-for-intellij/commit/a6b718d90b5ca71e1927f406f01201522d288e16