### PR TITLE
Move PluginUtil.kt to the util package in release configuration files

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -95,7 +95,7 @@ jobs:
           git config user.email "action@github.com"
           git config user.name "GitHub Action"
           git pull
-          git add src/main/kotlin/org/domaframework/doma/intellij/common/PluginUtil.kt
+          git add src/main/kotlin/org/domaframework/doma/intellij/common/util/PluginUtil.kt
           git add src/main/resources/logback.xml
           git add src/main/resources/logback-test.xml
           git add gradle.properties 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           git config user.name "GitHub Action"
           git fetch
           git checkout main
-          git add src/main/kotlin/org/domaframework/doma/intellij/common/PluginUtil.kt
+          git add src/main/kotlin/org/domaframework/doma/intellij/common/util/PluginUtil.kt
           git add src/main/resources/logback.xml
           git add src/main/resources/logback-test.xml
           git add gradle.properties 


### PR DESCRIPTION
Modify the path setting of GitActions that uses PluginUtil that was moved in the following modification.
https://github.com/domaframework/doma-tools-for-intellij/pull/142