### PR TITLE
Fix: optional dao param type conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The plugin also provides quick fixes for Dao methods where the required SQL file
   ![inspection.png](images/inspection.png)
 - Check the class name and package name for static property calls
   ![inspectionPackageName.png](images/inspectionPackageName.png)
+- Optional types are recognized as their element type (e.g. Optional<String> is treated as String).
 
 ## Completion
 Adds code completion functionality to support indexing of Doma directives and bind variables
@@ -52,6 +53,7 @@ Adds code completion functionality to support indexing of Doma directives and bi
 - Suggest Doma directives
 - Directives such as Condition, Loop, Population are suggested after “%”
 - Suggest built-in functions after “@”
+- Optional types are recognized as their element type (e.g. Optional<String> is treated as String).
 
 ## Refactoring
 Along with the Dao name change, we will refactor the SQL file directory and file name.

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/PsiClassTypeUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/PsiClassTypeUtil.kt
@@ -86,9 +86,13 @@ class PsiClassTypeUtil {
                     )
                 if (resolved != null) {
                     when (resolved.qualifiedName) {
+                        // If the type is java.util.Optional, return its parameter type if available;
+                        // otherwise, return the original daoParamType.
                         "java.util.Optional" -> return daoParamType.parameters.firstOrNull()
                             ?: daoParamType
 
+                        // For primitive Optional types (e.g., OptionalInt, OptionalDouble),
+                        // map them to their corresponding wrapper types (e.g., Integer, Double).
                         else ->
                             optionalTypeMap[resolved.qualifiedName]?.let { optionalType ->
                                 val newType =

--- a/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
@@ -35,6 +35,7 @@ import com.intellij.util.ProcessingContext
 import org.domaframework.doma.intellij.common.dao.findDaoMethod
 import org.domaframework.doma.intellij.common.psi.PsiParentClass
 import org.domaframework.doma.intellij.common.psi.PsiPatternUtil
+import org.domaframework.doma.intellij.common.sql.PsiClassTypeUtil
 import org.domaframework.doma.intellij.common.sql.cleanString
 import org.domaframework.doma.intellij.common.sql.directive.DirectiveCompletion
 import org.domaframework.doma.intellij.common.sql.validator.result.ValidationCompleteResult
@@ -385,7 +386,7 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
             return null
         }
         val immediate = findParam.getIterableClazz(daoMethod.getDomaAnnotationType())
-        return immediate.type
+        return PsiClassTypeUtil.convertOptionalType(immediate.type, originalFile.project)
     }
 
     private fun getRefClazz(

--- a/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
@@ -48,8 +48,6 @@ import org.domaframework.doma.intellij.extension.psi.findNodeParent
 import org.domaframework.doma.intellij.extension.psi.findSelfBlocks
 import org.domaframework.doma.intellij.extension.psi.findStaticField
 import org.domaframework.doma.intellij.extension.psi.findStaticMethod
-import org.domaframework.doma.intellij.extension.psi.getDomaAnnotationType
-import org.domaframework.doma.intellij.extension.psi.getIterableClazz
 import org.domaframework.doma.intellij.extension.psi.isNotWhiteSpace
 import org.domaframework.doma.intellij.extension.psi.searchParameter
 import org.domaframework.doma.intellij.extension.psi.searchStaticField
@@ -370,8 +368,8 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
         if (findParam == null) {
             return null
         }
-        val immediate = findParam.getIterableClazz(daoMethod.getDomaAnnotationType())
-        return PsiClassTypeUtil.convertOptionalType(immediate.type, originalFile.project)
+        val immediate = findParam.type
+        return PsiClassTypeUtil.convertOptionalType(immediate, originalFile.project)
     }
 
     private fun getRefClazz(

--- a/src/main/kotlin/org/domaframework/doma/intellij/document/generator/DocumentDaoParameterGenerator.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/document/generator/DocumentDaoParameterGenerator.kt
@@ -28,9 +28,9 @@ import org.domaframework.doma.intellij.psi.SqlElFieldAccessExpr
 
 class DocumentDaoParameterGenerator(
     val originalElement: PsiElement,
-    val project: Project,
+    override val project: Project,
     val result: MutableList<String?>,
-) : DocumentGenerator() {
+) : DocumentGenerator(project) {
     override fun generateDocument() {
         var topParentType: PsiParentClass? = null
         val selfSkip = isSelfSkip(originalElement)

--- a/src/main/kotlin/org/domaframework/doma/intellij/document/generator/DocumentStaticFieldGenerator.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/document/generator/DocumentStaticFieldGenerator.kt
@@ -29,11 +29,11 @@ import org.domaframework.doma.intellij.psi.SqlElStaticFieldAccessExpr
 
 class DocumentStaticFieldGenerator(
     val originalElement: PsiElement,
-    val project: Project,
+    override val project: Project,
     val result: MutableList<String?>,
     val staticFieldAccessExpr: SqlElStaticFieldAccessExpr,
     val file: PsiFile,
-) : DocumentGenerator() {
+) : DocumentGenerator(project) {
     override fun generateDocument() {
         val fieldAccessBlocks = staticFieldAccessExpr.accessElements
         val staticElement = PsiStaticElement(fieldAccessBlocks, file)

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiParameterExtension.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiParameterExtension.kt
@@ -30,7 +30,8 @@ fun PsiParameter.getIterableClazz(useListParam: Boolean): PsiParentClass {
     val immediate = this.type as? PsiClassType
     val classType = immediate?.let { PsiClassTypeUtil.getPsiTypeByList(it, this.project, useListParam) }
     if (classType != null) {
-        return PsiParentClass(classType)
+        val convertOptional = PsiClassTypeUtil.convertOptionalType(classType, this.project)
+        return PsiParentClass(convertOptional)
     }
     return PsiParentClass(this.type)
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiParameterExtension.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiParameterExtension.kt
@@ -17,24 +17,6 @@ package org.domaframework.doma.intellij.extension.psi
 
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiParameter
-import org.domaframework.doma.intellij.common.psi.PsiParentClass
-import org.domaframework.doma.intellij.common.sql.PsiClassTypeUtil
-
-/**
- * For List type, if the annotation type is Batch type,
- * return the content type.
- */
-fun PsiParameter.getIterableClazz(annotationType: DomaAnnotationType): PsiParentClass = getIterableClazz(annotationType.isBatchAnnotation())
-
-fun PsiParameter.getIterableClazz(useListParam: Boolean): PsiParentClass {
-    val immediate = this.type as? PsiClassType
-    val classType = immediate?.let { PsiClassTypeUtil.getPsiTypeByList(it, this.project, useListParam) }
-    if (classType != null) {
-        val convertOptional = PsiClassTypeUtil.convertOptionalType(classType, this.project)
-        return PsiParentClass(convertOptional)
-    }
-    return PsiParentClass(this.type)
-}
 
 val PsiParameter.isFunctionClazz: Boolean
     get() =

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlInspectionVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlInspectionVisitor.kt
@@ -132,6 +132,7 @@ class SqlInspectionVisitor(
             if (forItem != null) {
                 val result = ForDirectiveUtil.getForDirectiveItemClassType(project, forDirectiveBlocks)
                 if (result == null) {
+                    // TODO Add an error message when the type of element used in the For directory is not a List type.
                     errorHighlight(topElement, daoMethod, holder)
                     return
                 }

--- a/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
@@ -56,6 +56,7 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDapName/completeOptionalDaoParam.sql",
             "$testDapName/completeOptionalStaticProperty.sql",
             "$testDapName/completeOptionalByForItem.sql",
+            "$testDapName/completeOptionalBatchAnnotation.sql",
         )
         myFixture.enableInspections(SqlBindVariableValidInspector())
     }
@@ -353,6 +354,14 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDapName/completeOptionalByForItem.sql",
             listOf("manager", "projectNumber", "getFirstEmployee()"),
             listOf("get()", "orElseGet()", "isPresent()"),
+        )
+    }
+
+    fun testCompleteOptionalBatchAnnotation() {
+        innerDirectiveCompleteTest(
+            "$testDapName/completeOptionalBatchAnnotation.sql",
+            listOf("optionalIds"),
+            listOf("get()", "orElseGet()", "isPresent()", "projectId"),
         )
     }
 

--- a/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
@@ -34,6 +34,7 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDapName/completeInstancePropertyFromDaoArgumentClass.sql",
             "$testDapName/completeJavaPackageClass.sql",
             "$testDapName/completeDirective.sql",
+            "$testDapName/completeBatchInsert.sql",
             "$testDapName/completeStaticPropertyFromStaticPropertyCall.sql",
             "$testDapName/completePropertyAfterStaticPropertyCall.sql",
             "$testDapName/completeBuiltinFunction.sql",
@@ -157,6 +158,21 @@ class SqlCompleteTest : DomaSqlTest() {
                 "populate",
                 "for",
                 "!",
+            ),
+        )
+    }
+
+    fun testCompleteBatchInsert() {
+        innerDirectiveCompleteTest(
+            "$testDapName/completeBatchInsert.sql",
+            listOf(
+                "employeeId",
+                "employeeName",
+            ),
+            listOf(
+                "userId",
+                "get()",
+                "size()",
             ),
         )
     }

--- a/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
@@ -53,6 +53,9 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDapName/completeCallStaticPropertyClass.sql",
             "$testDapName/completeForItemHasNext.sql",
             "$testDapName/completeForItemIndex.sql",
+            "$testDapName/completeOptionalDaoParam.sql",
+            "$testDapName/completeOptionalStaticProperty.sql",
+            "$testDapName/completeOptionalByForItem.sql",
         )
         myFixture.enableInspections(SqlBindVariableValidInspector())
     }
@@ -326,6 +329,30 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDapName/completeParameterSecondProperty.sql",
             listOf("managerId"),
             listOf("employee", "department", "rank"),
+        )
+    }
+
+    fun testCompleteOptionalDaoParam() {
+        innerDirectiveCompleteTest(
+            "$testDapName/completeOptionalDaoParam.sql",
+            listOf("manager", "projectNumber", "getFirstEmployee()"),
+            listOf("get()", "orElseGet()", "isPresent()"),
+        )
+    }
+
+    fun testCompleteOptionalStaticProperty() {
+        innerDirectiveCompleteTest(
+            "$testDapName/completeOptionalStaticProperty.sql",
+            listOf("userId", "userName", "email", "getUserNameFormat()"),
+            listOf("get()", "orElseGet()", "isPresent()"),
+        )
+    }
+
+    fun testCompleteOptionalByForItem() {
+        innerDirectiveCompleteTest(
+            "$testDapName/completeOptionalByForItem.sql",
+            listOf("manager", "projectNumber", "getFirstEmployee()"),
+            listOf("get()", "orElseGet()", "isPresent()"),
         )
     }
 

--- a/src/test/kotlin/org/domaframework/doma/intellij/document/SqlSymbolDocumentTestCase.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/document/SqlSymbolDocumentTestCase.kt
@@ -15,8 +15,12 @@
  */
 package org.domaframework.doma.intellij.document
 
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import org.domaframework.doma.intellij.DomaSqlTest
+import org.domaframework.doma.intellij.psi.SqlBlockComment
+import org.domaframework.doma.intellij.psi.SqlElFieldAccessExpr
+import org.domaframework.doma.intellij.psi.SqlElForDirective
 import org.domaframework.doma.intellij.psi.SqlElIdExpr
 
 class SqlSymbolDocumentTestCase : DomaSqlTest() {
@@ -37,6 +41,8 @@ class SqlSymbolDocumentTestCase : DomaSqlTest() {
         addSqlFile("$testPackage/$testDaoName/documentForItemStaticProperty.sql")
         addSqlFile("$testPackage/$testDaoName/documentForItemHasNext.sql")
         addSqlFile("$testPackage/$testDaoName/documentForItemIndex.sql")
+        addSqlFile("$testPackage/$testDaoName/documentForItemOptionalForItem.sql")
+        addSqlFile("$testPackage/$testDaoName/documentForItemOptionalProperty.sql")
     }
 
     fun testDocumentForItemDaoParam() {
@@ -53,6 +59,22 @@ class SqlSymbolDocumentTestCase : DomaSqlTest() {
                 "List</a><<a href=\"psi_element://java.lang.Integer\">Integer</a>>> employeeIds"
 
         documentationTest(sqlName, result)
+    }
+
+    fun testDocumentForItemOptionalForItem() {
+        val sqlName = "documentForItemOptionalForItem"
+        val result =
+            "<a href=\"psi_element://java.util.List\">List</a><<a href=\"psi_element://doma.example.entity.Project\">Project</a>> optionalProjects"
+
+        documentationTest(sqlName, result)
+    }
+
+    fun testDocumentForItemOptionalForItemProperty() {
+        val sqlName = "documentForItemOptionalProperty"
+        val result =
+            "<a href=\"psi_element://java.util.List\">List</a><<a href=\"psi_element://java.lang.Integer\">Integer</a>> optionalIds"
+
+        documentationFindTextTest(sqlName, "optionalIds", result)
     }
 
     fun testDocumentForItemElement() {
@@ -146,8 +168,34 @@ class SqlSymbolDocumentTestCase : DomaSqlTest() {
         if (sqlFile == null) return
 
         myFixture.configureFromExistingVirtualFile(sqlFile)
-        var originalElement: PsiElement = myFixture.findElementByText(originalElementName, SqlElIdExpr::class.java)
+        var originalElement: PsiElement? =
+            myFixture.findElementByText(originalElementName, SqlElIdExpr::class.java)
+                ?: fundForDirectiveDeclarationElement(sqlFile, originalElementName)
+        assertNotNull("Not Found Element [$originalElementName]", originalElement)
+        if (originalElement == null) return
+
         val resultDocument = myDocumentationProvider.generateDoc(originalElement, originalElement)
         assertEquals("Documentation should contain expected text", result, resultDocument)
+    }
+
+    private fun fundForDirectiveDeclarationElement(
+        sqlFile: VirtualFile,
+        searchElementName: String,
+    ): PsiElement? {
+        myFixture.configureFromExistingVirtualFile(sqlFile)
+        val topElement = myFixture.findElementByText(searchElementName, PsiElement::class.java)
+        val forDirectiveBlock =
+            topElement.children
+                .firstOrNull { it is SqlBlockComment && it.text.contains(searchElementName) }
+
+        val forDirective =
+            forDirectiveBlock?.children?.find { it is SqlElForDirective } as? SqlElForDirective
+                ?: return null
+        val fieldAccessExpr = forDirective.elExprList[1] as? SqlElFieldAccessExpr
+        if (fieldAccessExpr == null) {
+            return forDirective.elExprList.firstOrNull { it.text == searchElementName }
+        }
+
+        return fieldAccessExpr.elExprList.firstOrNull { it.text == searchElementName }
     }
 }

--- a/src/test/kotlin/org/domaframework/doma/intellij/inspection/sql/ParameterDefinedTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/inspection/sql/ParameterDefinedTest.kt
@@ -38,6 +38,7 @@ class ParameterDefinedTest : DomaSqlTest() {
             "$testDaoName/bindVariableInFunctionParameters.sql",
             "$testDaoName/callStaticPropertyPackageName.sql",
             "$testDaoName/bindVariableForItemHasNextAndIndex.sql",
+            "$testDaoName/optionalDaoParameterFieldAccess.sql",
         )
         myFixture.enableInspections(SqlBindVariableValidInspector())
     }
@@ -64,6 +65,15 @@ class ParameterDefinedTest : DomaSqlTest() {
 
     fun testBindVariableForItemHasNextAndIndex() {
         val sqlFile = findSqlFile("$testDaoName/bindVariableForItemHasNextAndIndex.sql")
+        assertNotNull("Not Found SQL File", sqlFile)
+        if (sqlFile == null) return
+
+        myFixture.testHighlighting(false, false, false, sqlFile)
+    }
+
+    fun testOptionalDaoParameterFieldAccess() {
+        val sqlFile =
+            findSqlFile("$testDaoName/optionalDaoParameterFieldAccess.sql")
         assertNotNull("Not Found SQL File", sqlFile)
         if (sqlFile == null) return
 

--- a/src/test/testData/src/main/java/doma/example/dao/EmployeeSummaryDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/EmployeeSummaryDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.*;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.PreparedSql;
 import org.seasar.doma.jdbc.SelectOptions;
+import java.util.*;
 
 import java.util.List;
 import java.util.function.BiFunction;
@@ -35,4 +36,7 @@ interface EmployeeSummaryDao {
 
   @Select
   List<Employee> bindVariableForItemHasNextAndIndex(List<Employee> employees);
+
+  @Select
+  Project optionalDaoParameterFieldAccess(Optional<Project> project, OptionalInt id, OptionalLong longId, OptionalDouble doubleId);
 }

--- a/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
@@ -91,4 +91,7 @@ interface SqlCompleteTestDao {
   @Select
   Project completeOptionalByForItem(List<Project> projects);
 
+  @BatchDelete(sqlFile = true)
+  int completeOptionalBatchAnnotation(Optional<List<Optional<Project>>> projects);
+
 }

--- a/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
@@ -8,6 +8,7 @@ import org.seasar.doma.jdbc.SelectOptions;
 
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.Optional;
 
 @Dao
 interface SqlCompleteTestDao {
@@ -80,5 +81,14 @@ interface SqlCompleteTestDao {
 
   @Select
   Principal completeForItemIndex(Principal principal);
+
+  @Select
+  Project completeOptionalDaoParam(Optional<Project> project);
+
+  @Select
+  Project completeOptionalStaticProperty();
+
+  @Select
+  Project completeOptionalByForItem(List<Project> projects);
 
 }

--- a/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
@@ -25,6 +25,9 @@ interface SqlCompleteTestDao {
   @Update(sqlFile = true)
   int completeDirective(Employee employee);
 
+  @BatchInsert(sqlFile = true)
+  int completeBatchInsert(List<Employee> employees);
+
   @Select
   Project completeStaticPropertyFromStaticPropertyCall(ProjectDetail detail);
 

--- a/src/test/testData/src/main/java/doma/example/dao/document/DocumentTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/document/DocumentTestDao.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.HashSet;
 import doma.example.entity.*;
 import org.seasar.doma.*;
+import java.util.Optional;
 
 @Dao
 public interface DocumentTestDao {
@@ -34,5 +35,11 @@ public interface DocumentTestDao {
 
   @Select
   int documentForItemHasNext(Principal principal);
+
+  @Select
+  Project documentForItemOptionalForItem(Optional<List<Optional<Project>>> optionalProjects);
+
+  @Select
+  Project documentForItemOptionalProperty(Optional<List<Optional<Project>>> optionalProjects);
 
 }

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/TestDataCheckDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/TestDataCheckDao.java
@@ -29,4 +29,5 @@ interface TestDataCheckDao {
 
   @Insert(sqlFile=true)
   int invalidTestData(Employee employee);
+
 }

--- a/src/test/testData/src/main/java/doma/example/entity/Project.java
+++ b/src/test/testData/src/main/java/doma/example/entity/Project.java
@@ -5,6 +5,7 @@ import org.seasar.doma.*;
 import org.seasar.doma.Id;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Entity
 public class Project {
@@ -14,6 +15,9 @@ public class Project {
   private String projectName;
   private static String status;
   private Integer rank;
+
+  public static Optional<List<Optional<Integer>>> optionalIds;
+  public static Optional<User> manager;
 
   // Accessible static fields
   public static Integr projectNumber;

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/EmployeeSummaryDao/optionalDaoParameterFieldAccess.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/EmployeeSummaryDao/optionalDaoParameterFieldAccess.sql
@@ -1,0 +1,14 @@
+select * from projects
+-- project : Optional<Project> -> Project
+where id = /* project.projectId */0
+  and project_name = /* project.<error descr="The field or method [flatMap] does not exist in the class [Project]">flatMap</error>() */'projectName'
+  and sa_number = /* id.<error descr="The field or method [flatMap] does not exist in the class [Integer]">flatMap</error>() */0
+  and number = /* id.MAX_VALUE */0
+  and as_long = /* longId.<error descr="The field or method [getAsLong] does not exist in the class [Long]">getAsLong</error>() */0
+  and long = /* longId.doubleValue() */0
+  and as_double = /* doubleId.<error descr="The field or method [getAsDouble] does not exist in the class [Double]">getAsDouble</error>() */0
+  and doubles = /* longId.doubleValue() */0
+  -- optId : Optional<Integer> -> Integer
+ /*%for optId : project.optionalIds */
+  OR  sub_id = /* optId.MAX_VALUE */0
+ /*%end */

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeBatchInsert.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeBatchInsert.sql
@@ -1,0 +1,5 @@
+INSERT INTO employee
+            (id
+             , name)
+     VALUES ( /* employees.userId */0
+             , /* employees.<caret>emplo */'name')

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeOptionalBatchAnnotation.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeOptionalBatchAnnotation.sql
@@ -1,0 +1,11 @@
+DELETE FROM project
+ WHERE rank > 10
+   -- projects : Optional<List<Optional<Project>>> -> Project
+   AND id = /* projects.projectId */
+   -- projects.optionalIds : Optional<List<Optional<Integer>>> -> List<Integer>
+/*%for id : projects.<caret>option */
+   opt_id = /* id */0
+ /*%if id_has_next */
+   /*# "OR" */
+ /*%end */
+/*%end */

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeOptionalByForItem.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeOptionalByForItem.sql
@@ -1,0 +1,5 @@
+select * from project
+ where
+ /*%for project : projects */
+  or user_id = /* project.<caret> */0
+ /*%end */

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeOptionalDaoParam.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeOptionalDaoParam.sql
@@ -1,0 +1,2 @@
+select * from project
+ where id = /* project.<caret> */0

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeOptionalStaticProperty.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeOptionalStaticProperty.sql
@@ -1,0 +1,2 @@
+select * from project
+ where id = /* @doma.example.entity.Project@manager.<caret> */0

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemOptionalForItem.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemOptionalForItem.sql
@@ -1,0 +1,18 @@
+select * from project
+where
+ -- optionalProjects : Optional<List<Optional<Project>>> -> List<Project>
+ -- project : Optional<Project> -> Project
+ /*%for pro<caret>ject : optionalProjects */
+   -- project.optionalIds : Optional<List<Optional<Integer>>> -> List<Integer>
+    -- id : Optional<Integer> -> Integer
+   /*%for id : project.optionalIds */
+      project_next_id = /* id */0
+     /*%if id_has_next */
+      /*# "OR" */
+     /*%end */
+   /*%end */
+     project_id = /* project.projectId */0
+    /*%if project_has_next */
+      /*# "OR" */
+    /*%end */
+ /*%end */

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemOptionalProperty.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemOptionalProperty.sql
@@ -1,0 +1,18 @@
+select * from project
+where
+ -- optionalProjects : Optional<List<Optional<Project>>> -> List<Project>
+ -- project : Optional<Project> -> Project
+ /*%for project : optionalProjects */
+   -- project.optionalIds : Optional<List<Optional<Integer>>> -> List<Integer>
+    -- id : Optional<Integer> -> Integer
+   /*%for id : project.optionalIds */
+      project_next_id = /* id */0
+     /*%if id_has_next */
+      /*# "OR" */
+     /*%end */
+   /*%end */
+     project_id = /* project.projectId */0
+    /*%if project_has_next */
+      /*# "OR" */
+    /*%end */
+ /*%end */


### PR DESCRIPTION
This pull request fixes issues related to optional DAO parameter type conversion while updating relevant test files, DAO interfaces, and internal conversion utilities for Optional types. Key changes include:

- New test cases for Optional DAO parameter conversion.
- Support Optional, OptionalInt, OptionalLong, and OptionalDouble.
- Modifications to utility classes to properly convert Optional types.