### PR TITLE
Completion for directive items

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
@@ -366,11 +366,7 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
             }
             // Add ForDirective Items
             val forDirectives = ForDirectiveUtil.getForDirectiveBlocks(position)
-            forDirectives.forEach {
-                result.addElement(LookupElementBuilder.create(it.item.text))
-                result.addElement(LookupElementBuilder.create("${it.item.text}_has_next"))
-                result.addElement(LookupElementBuilder.create("${it.item.text}_index"))
-            }
+            addForDirectiveSuggestions(forDirectives, result)
             return null
         }
         if (findParam == null) {
@@ -378,6 +374,17 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
         }
         val immediate = findParam.type
         return PsiClassTypeUtil.convertOptionalType(immediate, originalFile.project)
+    }
+
+    private fun addForDirectiveSuggestions(
+        forDirectives: List<ForDirectiveUtil.BlockToken>,
+        result: CompletionResultSet,
+    ) {
+        forDirectives.forEach {
+            result.addElement(LookupElementBuilder.create(it.item.text))
+            result.addElement(LookupElementBuilder.create("${it.item.text}_has_next"))
+            result.addElement(LookupElementBuilder.create("${it.item.text}_index"))
+        }
     }
 
     private fun getRefClazz(

--- a/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
@@ -58,6 +58,7 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDapName/completeOptionalStaticProperty.sql",
             "$testDapName/completeOptionalByForItem.sql",
             "$testDapName/completeOptionalBatchAnnotation.sql",
+            "$testDapName/completeForDirectiveItem.sql",
         )
         myFixture.enableInspections(SqlBindVariableValidInspector())
     }
@@ -388,6 +389,14 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDapName/completeOptionalBatchAnnotation.sql",
             listOf("optionalIds"),
             listOf("get()", "orElseGet()", "isPresent()", "projectId"),
+        )
+    }
+
+    fun testCompleteForDirectiveItem() {
+        innerDirectiveCompleteTest(
+            "$testDapName/completeForDirectiveItem.sql",
+            listOf("projects", "project", "project_has_next", "project_index"),
+            listOf("get()", "size()", "toString()", "projectId"),
         )
     }
 

--- a/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
@@ -97,4 +97,7 @@ interface SqlCompleteTestDao {
   @BatchDelete(sqlFile = true)
   int completeOptionalBatchAnnotation(Optional<List<Optional<Project>>> projects);
 
+  @Select
+  Employee completeForDirectiveItem(List<Project> projects);
+
 }

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeForDirectiveItem.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeForDirectiveItem.sql
@@ -1,0 +1,11 @@
+SELECT id
+       , name
+       , age
+  FROM employees
+ WHERE
+/*%for project : projects */
+  id = /* <caret> */0
+/*%if project_has_next */
+/*# "OR" */
+/*%end */
+/*%end */ 


### PR DESCRIPTION
Add element names defined by the for directive to code-completion suggestions.

When performing code completion at the top level of a bind variable, include the directive’s element names as well as _has_next and _index in the suggestions.