### PR TITLE
Do not suggest element names you define in the for directive element

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
@@ -365,7 +365,14 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
                 result.addElement(LookupElementBuilder.create(match.name))
             }
             // Add ForDirective Items
-            val forDirectives = ForDirectiveUtil.getForDirectiveBlocks(position)
+            val parentForDirectiveExpr =
+                PsiTreeUtil.getParentOfType(position, SqlElForDirective::class.java)
+                    ?: PsiTreeUtil.getChildOfType(position.parent, SqlElForDirective::class.java)
+            val forDirectives =
+                ForDirectiveUtil.getForDirectiveBlocks(position).filter {
+                    PsiTreeUtil.getParentOfType(it.item, SqlElForDirective::class.java) !=
+                        parentForDirectiveExpr
+                }
             addForDirectiveSuggestions(forDirectives, result)
             return null
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/SqlElForDirectiveExtension.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/SqlElForDirectiveExtension.kt
@@ -25,12 +25,13 @@ import org.domaframework.doma.intellij.psi.SqlBlockComment
 import org.domaframework.doma.intellij.psi.SqlElFieldAccessExpr
 import org.domaframework.doma.intellij.psi.SqlElForDirective
 import org.domaframework.doma.intellij.psi.SqlElIdExpr
+import org.domaframework.doma.intellij.psi.SqlElPrimaryExpr
 import org.domaframework.doma.intellij.psi.SqlElStaticFieldAccessExpr
 import org.domaframework.doma.intellij.psi.SqlTypes
 
 fun SqlElForDirective.getForItem(): PsiElement? =
     PsiTreeUtil
-        .getChildOfType(this, SqlElIdExpr::class.java)
+        .getChildOfType(this, SqlElPrimaryExpr::class.java)
 
 fun SqlElForDirective.getForItemDeclaration(): ForDeclarationItem? {
     val parentCommentBlock =

--- a/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
@@ -289,7 +289,7 @@ class SqlCompleteTest : DomaSqlTest() {
         innerDirectiveCompleteTest(
             "$testDapName/completeDirectiveInsideFor.sql",
             listOf("project"),
-            listOf("employee"),
+            listOf("employee", "member", "%for"),
         )
     }
 


### PR DESCRIPTION
When performing code completion within a for directive block, the element names you define yourself are also suggested.
Elements within the same for directive are excluded.