### PR TITLE
Fix to not display Dao parameter information in the document for elements defined with the for directive.

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/document/generator/DocumentDaoParameterGenerator.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/document/generator/DocumentDaoParameterGenerator.kt
@@ -24,7 +24,9 @@ import org.domaframework.doma.intellij.common.psi.PsiParentClass
 import org.domaframework.doma.intellij.common.util.ForDirectiveUtil
 import org.domaframework.doma.intellij.extension.expr.accessElementsPrevOriginalElement
 import org.domaframework.doma.intellij.extension.psi.findParameter
+import org.domaframework.doma.intellij.extension.psi.getForItem
 import org.domaframework.doma.intellij.psi.SqlElFieldAccessExpr
+import org.domaframework.doma.intellij.psi.SqlElForDirective
 
 class DocumentDaoParameterGenerator(
     val originalElement: PsiElement,
@@ -59,6 +61,15 @@ class DocumentDaoParameterGenerator(
                     forItemClassType
                 }
         } else {
+            val forDirectiveExpr =
+                PsiTreeUtil.getParentOfType(
+                    searchElement,
+                    SqlElForDirective::class.java,
+                )
+            if (forDirectiveExpr != null && forDirectiveExpr.getForItem() == searchElement) {
+                // For elements defined with the for directive, Dao parameters are not searched.
+                return
+            }
             val daoMethod = findDaoMethod(originalElement.containingFile) ?: return
             val param = daoMethod.findParameter(originalElement.text) ?: return
             isBatchAnnotation = PsiDaoMethod(project, daoMethod).daoType.isBatchAnnotation()

--- a/src/test/kotlin/org/domaframework/doma/intellij/document/SqlSymbolDocumentTestCase.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/document/SqlSymbolDocumentTestCase.kt
@@ -44,6 +44,7 @@ class SqlSymbolDocumentTestCase : DomaSqlTest() {
         addSqlFile("$testPackage/$testDaoName/documentForItemIndex.sql")
         addSqlFile("$testPackage/$testDaoName/documentForItemOptionalForItem.sql")
         addSqlFile("$testPackage/$testDaoName/documentForItemOptionalProperty.sql")
+        addSqlFile("$testPackage/$testDaoName/documentForItemInvalidPrimary.sql")
     }
 
     fun testDocumentForItemDaoParam() {
@@ -143,6 +144,13 @@ class SqlSymbolDocumentTestCase : DomaSqlTest() {
             "<a href=\"psi_element://doma.example.entity.Project\">Project</a> project"
 
         documentationFindTextTest(sqlName, "project", result)
+    }
+
+    fun testDocumentForItemInvalidPrimary() {
+        val sqlName = "documentForItemInvalidPrimary"
+        val result = " item"
+
+        documentationFindTextTest(sqlName, "item", result)
     }
 
     private fun documentationTest(

--- a/src/test/testData/src/main/java/doma/example/dao/document/DocumentTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/document/DocumentTestDao.java
@@ -42,4 +42,7 @@ public interface DocumentTestDao {
   @Select
   Project documentForItemOptionalProperty(Optional<List<Optional<Project>>> optionalProjects);
 
+  @Select
+  int documentForItemInvalidPrimary(Principal item, Principal principal);
+
 }

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemInvalidPrimary.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/document/DocumentTestDao/documentForItemInvalidPrimary.sql
@@ -1,0 +1,8 @@
+select count(*) from principal
+where
+/*%for item : principal */
+name = /* ite<caret>m.name */'name'
+   /*%if item_has_next */
+/*# "or" */
+   /*%end */
+/*%end */


### PR DESCRIPTION
When generating docs for elements defined by a `for directive`, if a DAO parameter had the same element name its information was being pulled instead. This change ensures that documentation for `for directive` elements always refers to the directive’s own definitions, not conflicting DAO parameters.