### PR TITLE
Fix missing inspections for injection files

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlTestDataAfterBlockCommentVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlTestDataAfterBlockCommentVisitor.kt
@@ -18,7 +18,6 @@ package org.domaframework.doma.intellij.inspection.sql.visitor
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.nextLeafs
@@ -37,14 +36,13 @@ class SqlTestDataAfterBlockCommentVisitor(
     private val shortName: String,
 ) : SqlVisitorBase() {
     override fun visitElement(element: PsiElement) {
-        if (setFile(element)) return
-        val visitFile: PsiFile = file ?: return
-        if (isJavaOrKotlinFileType(visitFile) && element is PsiLiteralExpression) {
-            val injectionFile = initInjectionElement(visitFile, element.project, element) ?: return
+        val file = element.containingFile ?: return
+        if (isJavaOrKotlinFileType(file) && element is PsiLiteralExpression) {
+            val injectionFile = initInjectionElement(file, element.project, element) ?: return
             injectionFile.accept(this)
             super.visitElement(element)
         }
-        if (isInjectionSqlFile(visitFile)) {
+        if (isInjectionSqlFile(file)) {
             element.acceptChildren(this)
         }
     }

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlVisitorBase.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlVisitorBase.kt
@@ -17,22 +17,12 @@ package org.domaframework.doma.intellij.inspection.sql.visitor
 
 import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiLiteralExpression
 import org.domaframework.doma.intellij.common.isJavaOrKotlinFileType
 import org.domaframework.doma.intellij.psi.SqlVisitor
 
 open class SqlVisitorBase : SqlVisitor() {
-    var file: PsiFile? = null
-
-    protected fun setFile(element: PsiElement): Boolean {
-        if (file == null) {
-            file = element.containingFile
-        }
-        return false
-    }
-
     /**
      * For processing inside Sql annotations, get it as an injected custom language
      */

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/TestDataCheckDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/TestDataCheckDao.java
@@ -1,6 +1,6 @@
 package doma.example.dao.inspection;
 
-import doma.example.entity.*:
+import doma.example.entity.*;
 import org.seasar.doma.*;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.PreparedSql;


### PR DESCRIPTION
During the Visitor class refactoring, the target file was moved to a class‐level field. This prevented correct file information lookup, so the visit method that performs code inspection on injected SQL was never invoked. Revert to obtaining the file object within each method.

Fix From:
https://github.com/domaframework/doma-tools-for-intellij/pull/117
https://github.com/domaframework/doma-tools-for-intellij/commit/62ebb0dcbb44034d5d3b175b368a75bfc9e69d49#diff-cb68fde627471b0922f1eb96f372ec08de75d49bf9eb48691dda551c137986b2