### PR TITLE
Fix Test-Data Validation

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlTestDataAfterBlockCommentVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlTestDataAfterBlockCommentVisitor.kt
@@ -84,7 +84,7 @@ class SqlTestDataAfterBlockCommentVisitor(
 
     private fun isSqlLiteral(element: PsiElement): Boolean =
         element.elementType == SqlTypes.STRING ||
-            listOf("true", "false", "null").contains(element.text) ||
+            listOf("true", "false", "null").contains(element.text.lowercase()) ||
             element.text.matches(Regex("^\\d+$"))
 
     /**

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/TestDataCheckDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/TestDataCheckDao.java
@@ -13,7 +13,7 @@ import java.util.function.BiFunction;
 interface TestDataCheckDao {
 
   @Select
-  EmployeeSummary literalDirective(String literalName, Integer literalId, Integer literalAge);
+  EmployeeSummary literalDirective(String literalName, Integer literalId, Integer literalAge, Boolean literalTrue, Boolean literalFalse, Employee literalNull);
 
   @Insert(sqlFile=true)
   int bindVariableDirective(Employee employee);

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/inspection/TestDataCheckDao/literalDirective.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/inspection/TestDataCheckDao/literalDirective.sql
@@ -5,3 +5,6 @@ SELECT e.employee_id AS employeeId
  WHERE e.employee_id = <error descr="Bind variables must be followed by test data">/*^ literalId */</error>
    AND e.employee_name = <error descr="Bind variables must be followed by test data">/*^ literalName */</error>
    AND e.age >= /*^ literalAge */99
+   AND e.use = /* literalTrue */TRUE
+   AND e.use = /* literalFalse */false
+   AND e.use = /* literalNull */Null


### PR DESCRIPTION
Normalize the text that follows a block comment to lowercase, ensuring that literal values are detected as test data regardless of their original letter case.