### PR TITLE
Replace Trailing Characters During Code Completion

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/DirectiveCompletion.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/DirectiveCompletion.kt
@@ -23,6 +23,7 @@ class DirectiveCompletion(
     private val originalFile: PsiFile,
     private val bindText: String,
     private val element: PsiElement,
+    private val caretNextText: String,
     private val result: CompletionResultSet,
 ) {
     fun directiveHandle(symbol: String): Boolean {
@@ -52,6 +53,7 @@ class DirectiveCompletion(
                 StaticDirectiveHandler(
                     originalFile = originalFile,
                     element = element,
+                    caretNextText = caretNextText,
                     result = result,
                     bindText = bindText,
                 ).directiveHandle()

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/StaticDirectiveHandlerData.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/StaticDirectiveHandlerData.kt
@@ -18,16 +18,6 @@ package org.domaframework.doma.intellij.common.sql.directive
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.VariableLookupItem
 import com.intellij.icons.AllIcons
-import com.intellij.psi.PsiType
-
-/**
- * Function information displayed with code completion for built-in functions
- */
-data class DomaFunction(
-    val name: String,
-    val returnType: PsiType,
-    val parameters: List<PsiType>,
-)
 
 /**
  * Show parameters in code completion for fields and methods

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/collector/StaticPropertyCollector.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/collector/StaticPropertyCollector.kt
@@ -22,10 +22,12 @@ import com.intellij.psi.PsiElement
 import org.domaframework.doma.intellij.common.psi.PsiParentClass
 import org.domaframework.doma.intellij.common.psi.PsiStaticElement
 import org.domaframework.doma.intellij.common.sql.directive.CompletionSuggest
+import org.domaframework.doma.intellij.common.util.SqlCompletionUtil.createMethodLookupElement
 import org.domaframework.doma.intellij.extension.psi.psiClassType
 
 class StaticPropertyCollector(
     private val element: PsiElement,
+    private val caretNextText: String,
     private val bind: String,
 ) : StaticDirectiveHandlerCollector() {
     public override fun collectCompletionSuggest(fqdn: String): CompletionSuggest? {
@@ -39,7 +41,7 @@ class StaticPropertyCollector(
             val methods =
                 clazz.searchStaticMethod(bind)?.map { m ->
                     LookupElementBuilder
-                        .create("${m.name}()")
+                        .create(createMethodLookupElement(caretNextText, m))
                         .withPresentableText(m.name)
                         .withTailText(m.parameterList.text, true)
                         .withIcon(AllIcons.Nodes.Method)

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/util/ForDirectiveUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/util/ForDirectiveUtil.kt
@@ -225,7 +225,7 @@ class ForDirectiveUtil {
                                 val classType = lastType.type as? PsiClassType
                                 val nestClass =
                                     if (classType != null &&
-                                        PsiClassTypeUtil.Companion.isIterableType(
+                                        PsiClassTypeUtil.isIterableType(
                                             classType,
                                             project,
                                         )

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/util/SqlCompletionUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/util/SqlCompletionUtil.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.common.util
+
+import com.intellij.psi.PsiMethod
+
+object SqlCompletionUtil {
+    fun createMethodLookupElement(
+        caretNextText: String,
+        method: PsiMethod,
+    ): String =
+        if (caretNextText == "(") {
+            method.name
+        } else {
+            "${method.name}()"
+        }
+}

--- a/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
@@ -36,6 +36,7 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDaoName/completeBatchInsert.sql",
             "$testDaoName/completeStaticPropertyFromStaticPropertyCall.sql",
             "$testDaoName/completePropertyAfterStaticPropertyCall.sql",
+            "$testDaoName/completePropertyAfterStaticMethodCall.sql",
             "$testDaoName/completeBuiltinFunction.sql",
             "$testDaoName/completeDirectiveInsideIf.sql",
             "$testDaoName/completeDirectiveInsideElseIf.sql",
@@ -177,10 +178,10 @@ class SqlCompleteTest : DomaSqlTest() {
         innerDirectiveCompleteTest(
             "$testDaoName/completeBatchInsert.sql",
             listOf(
-                "employeeId",
-                "employeeName",
+                "getFirstProject()",
             ),
             listOf(
+                "employeeName",
                 "userId",
                 "get()",
                 "size()",
@@ -249,6 +250,20 @@ class SqlCompleteTest : DomaSqlTest() {
                 "managerId",
             ),
             listOf(
+                "userId",
+                "employeeName",
+            ),
+        )
+    }
+
+    fun testCompletePropertyAfterStaticMethodCall() {
+        innerDirectiveCompleteTest(
+            "$testDaoName/completePropertyAfterStaticMethodCall.sql",
+            listOf(
+                "getTermNumber()",
+            ),
+            listOf(
+                "managerId",
                 "userId",
                 "employeeName",
             ),
@@ -408,7 +423,7 @@ class SqlCompleteTest : DomaSqlTest() {
         addResourceCompileFile("doma.compile.config")
         innerDirectiveCompleteTest(
             "$testDaoName/completeImplementCustomFunction.sql",
-            listOf("userId()", "userName()", "userAge()"),
+            listOf("userId", "userName", "userAge"),
             listOf(
                 "getId()",
                 "getName()",

--- a/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
@@ -35,6 +35,9 @@ interface SqlCompleteTestDao {
   Project completePropertyAfterStaticPropertyCall();
 
   @Select
+  Project completePropertyAfterStaticMethodCall();
+
+  @Select
   Project completeBuiltinFunction(ProjectDetail detail);
 
   @Update(sqlFile = true)

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeBatchInsert.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeBatchInsert.sql
@@ -2,4 +2,4 @@ INSERT INTO employee
             (id
              , name)
      VALUES ( /* employees.userId */0
-             , /* employees.<caret>emplo */'name')
+             , /* employees.getFirst<caret>Project() */'name')

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completePropertyAfterStaticMethodCall.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completePropertyAfterStaticMethodCall.sql
@@ -1,0 +1,11 @@
+select
+   p.project_id
+   , p.statis
+   , p.project_name
+   , p.rank
+from project p
+ inner join project_detail pd
+  on p.project_id = pd.project_id
+ where
+  -- Code completion for static fields and methods
+  and pd.manager_id = /* @doma.example.entity.ProjectDetail@getTerm<caret>Number() */'TODO'


### PR DESCRIPTION
When code completion is invoked with the cursor immediately before a function’s argument-parameter element, the parameter placeholder was being duplicated in the suggestions. Adjust the behavior so that:

- If the cursor is positioned just before the parameter element, () is not suggested. 
- If completion is triggered mid-method name, the suggestion includes the parentheses.

These changes ensure argument parameters are suggested correctly based on cursor position.