### PR TITLE
Enhance SQL test data validation to support case-insensitive boolean values

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlTestDataAfterBlockCommentVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlTestDataAfterBlockCommentVisitor.kt
@@ -105,6 +105,7 @@ class SqlTestDataAfterBlockCommentVisitor(
         val parenthesesListPattern =
             Regex(
                 """^\(\s*(?:(?:"[^"]*"|'[^']*'|\d+|true|false|null)\s*(?:,\s*(?:"[^"]*"|'[^']*'|\d+|true|false|null)\s*)*)?\)$""",
+                RegexOption.IGNORE_CASE,
             )
         val testDataText =
             element.nextLeafs

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/inspection/TestDataCheckDao/commentBlock.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/inspection/TestDataCheckDao/commentBlock.sql
@@ -10,3 +10,4 @@ SELECT e.employee_id AS employeeId
  WHERE e.employee_id = <error descr="Bind variables must be followed by test data">/*^ id */</error>
    AND e.age >= /*^ literalAge */99
    AND e.sub_id IN /* subIds */(1, 2, 3)
+   AND e.sub_id IN /* subIds */(true, False, NULL)


### PR DESCRIPTION
List-type test data containing uppercase TRUE, FALSE, or NULL values are not currently recognized as valid. This change adds a case-insensitive flag to the regular expression so that true, TRUE, False, FALSE, null, NULL, etc., are all correctly detected.