### PR TITLE
Update plugin verifier version to 1.386

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
 
         plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
 
-        pluginVerifier(version = "1.383")
+        pluginVerifier(version = "1.386")
         zipSigner()
         testFramework(TestFrameworkType.Platform)
         testFramework(TestFrameworkType.Plugin.Java)


### PR DESCRIPTION
The plugin-verifier dependency was previously pinned to work around an OutOfMemoryError. This change bumps it to the newest available release, which includes memory and performance improvements that prevent the error.

https://platform.jetbrains.com/t/outofmemoryerror-during-plugin-verifier/1036