### PR TITLE
Instance member suggestions missing inside static property call arguments 

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
@@ -295,9 +295,13 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
 
         var isBatchAnnotation = false
         if (top.parent !is PsiFile && top.parent?.parent !is PsiDirectory) {
-            val staticDirective = top.findNodeParent(SqlTypes.EL_STATIC_FIELD_ACCESS_EXPR)
-            staticDirective?.let {
-                topElementType = getElementTypeByStaticFieldAccess(top, it, topText) ?: return
+            // In function-parameter elements, apply the same processing as normal field access.
+            val parameter = top.findNodeParent(SqlTypes.EL_PARAMETERS)
+            if (parameter == null) {
+                val staticDirective = top.findNodeParent(SqlTypes.EL_STATIC_FIELD_ACCESS_EXPR)
+                staticDirective?.let {
+                    topElementType = getElementTypeByStaticFieldAccess(top, it, topText) ?: return
+                }
             }
         }
 

--- a/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
@@ -50,6 +50,14 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDaoName/completeParameterFirstProperty.sql",
             "$testDaoName/completeParameterSecond.sql",
             "$testDaoName/completeParameterSecondProperty.sql",
+            "$testDaoName/completeParameterFirstInStaticAccess.sql",
+            "$testDaoName/completeParameterFirstPropertyInStaticAccess.sql",
+            "$testDaoName/completeParameterSecondInStaticAccess.sql",
+            "$testDaoName/completeParameterSecondPropertyInStaticAccess.sql",
+            "$testDaoName/completeParameterFirstInCustomFunctions.sql",
+            "$testDaoName/completeParameterFirstPropertyInCustomFunctions.sql",
+            "$testDaoName/completeParameterSecondInCustomFunctions.sql",
+            "$testDaoName/completeParameterSecondPropertyInCustomFunctions.sql",
             "$testDaoName/completeCallStaticPropertyClassPackage.sql",
             "$testDaoName/completeCallStaticPropertyClass.sql",
             "$testDaoName/completeForItemHasNext.sql",
@@ -376,6 +384,130 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDaoName/completeParameterSecondProperty.sql",
             listOf("managerId"),
             listOf("employee", "department", "rank"),
+        )
+    }
+
+    fun testCompleteParameterInStaticAccess() {
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeParameterFirstInStaticAccess.sql",
+            listOf(
+                "project",
+            ),
+            listOf(
+                "projectId",
+                "projectName",
+                "rank",
+                "projectNumber",
+                "projectCategory",
+                "getFirstEmployee()",
+                "getTermNumber()",
+            ),
+        )
+
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeParameterFirstPropertyInStaticAccess.sql",
+            listOf(
+                "projectId",
+                "projectName",
+                "rank",
+                "projectNumber",
+                "projectCategory",
+                "getFirstEmployee()",
+                "getTermNumber()",
+            ),
+            listOf(
+                "project",
+            ),
+        )
+
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeParameterSecondInStaticAccess.sql",
+            listOf("project"),
+            listOf(
+                "projectId",
+                "projectName",
+                "rank",
+                "projectNumber",
+                "projectCategory",
+                "getFirstEmployee()",
+                "getTermNumber()",
+            ),
+        )
+
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeParameterSecondPropertyInStaticAccess.sql",
+            listOf(
+                "projectId",
+                "projectName",
+                "rank",
+                "projectNumber",
+                "projectCategory",
+                "getFirstEmployee()",
+                "getTermNumber()",
+            ),
+            listOf("project"),
+        )
+    }
+
+    fun testCompleteParameterInCustomFunctions() {
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeParameterFirstInCustomFunctions.sql",
+            listOf(
+                "project",
+            ),
+            listOf(
+                "projectId",
+                "projectName",
+                "rank",
+                "projectNumber",
+                "projectCategory",
+                "getFirstEmployee()",
+                "getTermNumber()",
+            ),
+        )
+
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeParameterFirstPropertyInCustomFunctions.sql",
+            listOf(
+                "projectId",
+                "projectName",
+                "rank",
+                "projectNumber",
+                "projectCategory",
+                "getFirstEmployee()",
+                "getTermNumber()",
+            ),
+            listOf(
+                "project",
+            ),
+        )
+
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeParameterSecondInCustomFunctions.sql",
+            listOf("project"),
+            listOf(
+                "projectId",
+                "projectName",
+                "rank",
+                "projectNumber",
+                "projectCategory",
+                "getFirstEmployee()",
+                "getTermNumber()",
+            ),
+        )
+
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeParameterSecondPropertyInCustomFunctions.sql",
+            listOf(
+                "projectId",
+                "projectName",
+                "rank",
+                "projectNumber",
+                "projectCategory",
+                "getFirstEmployee()",
+                "getTermNumber()",
+            ),
+            listOf("project"),
         )
     }
 

--- a/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
@@ -77,6 +77,30 @@ interface SqlCompleteTestDao {
   Employee completeParameterSecondProperty(Employee employee);
 
   @Select
+  ProjectDetail completeParameterFirstInStaticAccess(Project project);
+
+  @Select
+  ProjectDetail completeParameterFirstPropertyInStaticAccess(Project project);
+
+  @Select
+  ProjectDetail completeParameterSecondInStaticAccess(Project project);
+
+  @Select
+  ProjectDetail completeParameterSecondPropertyInStaticAccess(Project project);
+
+  @Select
+  ProjectDetail completeParameterFirstInCustomFunctions(Project project);
+
+  @Select
+  ProjectDetail completeParameterFirstPropertyInCustomFunctions(Project project);
+
+  @Select
+  ProjectDetail completeParameterSecondInCustomFunctions(Project project);
+
+  @Select
+  ProjectDetail completeParameterSecondPropertyInCustomFunctions(Project project);
+
+  @Select
   Employee completeCallStaticPropertyClassPackage();
 
   @Select
@@ -108,4 +132,5 @@ interface SqlCompleteTestDao {
 
   @Select
   Employee completeNotImplementCustomFunction(Project project);
+
 }

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterFirstInCustomFunctions.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterFirstInCustomFunctions.sql
@@ -1,0 +1,2 @@
+select * from project_detail
+where number = /* @langCode(<caret>) */1

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterFirstInStaticAccess.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterFirstInStaticAccess.sql
@@ -1,0 +1,2 @@
+select * from project_detail
+where number = /* @doma.example.entity.Project@getTermNumber(<caret>) */1

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterFirstPropertyInCustomFunctions.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterFirstPropertyInCustomFunctions.sql
@@ -1,0 +1,2 @@
+select * from project_detail
+where number = /* @langCode(project.<caret>) */1

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterFirstPropertyInStaticAccess.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterFirstPropertyInStaticAccess.sql
@@ -1,0 +1,2 @@
+select * from project_detail
+where number = /* @doma.example.entity.Project@getTermNumber(project.<caret>) */1

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterSecondInCustomFunctions.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterSecondInCustomFunctions.sql
@@ -1,0 +1,2 @@
+select * from project_detail
+where number = /* @langCode(project.cons, <caret>) */1

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterSecondInStaticAccess.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterSecondInStaticAccess.sql
@@ -1,0 +1,2 @@
+select * from project_detail
+where number = /* @doma.example.entity.Project@getTermNumber(project.cons, <caret>) */1

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterSecondPropertyInCustomFunctions.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterSecondPropertyInCustomFunctions.sql
@@ -1,0 +1,2 @@
+select * from project_detail
+where number = /* @langCode(project.cost, project.<caret>) */1

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterSecondPropertyInStaticAccess.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterSecondPropertyInStaticAccess.sql
@@ -1,0 +1,2 @@
+select * from project_detail
+where number = /* @doma.example.entity.Project@getTermNumber(project.cost, project.<caret>) */1


### PR DESCRIPTION
This PR resolves a bug where, within the argument-parameter element of a function invoked on a static-access field, instance fields and methods following the top-level element were not being suggested. When suggesting completions for a child of an argument-parameter element, the static-field-access element check is now skipped.