### PR TITLE
Test data check skipped for directives at end of file

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlTestDataAfterBlockCommentVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/visitor/SqlTestDataAfterBlockCommentVisitor.kt
@@ -51,11 +51,15 @@ class SqlTestDataAfterBlockCommentVisitor(
         super.visitBlockComment(element)
         if (hasOtherBindVariable(element)) return
 
-        val nextElement = element.nextSibling ?: return
+        val result = ValidationTestDataResult(element, shortName)
+        val nextElement = element.nextSibling
+        if (nextElement == null) {
+            result.highlightElement(holder)
+            return
+        }
         if (isSqlLiteral(nextElement)) return
         if (isMatchListTestData(element)) return
 
-        val result = ValidationTestDataResult(element, shortName)
         result.highlightElement(holder)
     }
 

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/inspection/TestDataCheckDao/commentBlock.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/inspection/TestDataCheckDao/commentBlock.sql
@@ -11,3 +11,4 @@ SELECT e.employee_id AS employeeId
    AND e.age >= /*^ literalAge */99
    AND e.sub_id IN /* subIds */(1, 2, 3)
    AND e.sub_id IN /* subIds */(true, False, NULL)
+   AND e.final IN <error descr="Test data is required after a bind variable directive or a literal variable directive">/* literalAge */</error>


### PR DESCRIPTION
Ensure that when a SQL block comment appears as the last element in a file (i.e., no following element), it is still included in the test-data validation process.