### PR TITLE
Code completion fails after existing values in method arguments

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiElementExtension.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiElementExtension.kt
@@ -17,34 +17,13 @@ package org.domaframework.doma.intellij.extension.psi
 
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.elementType
-import com.intellij.psi.util.prevLeafs
-import org.domaframework.doma.intellij.psi.SqlElIdExpr
 import org.domaframework.doma.intellij.psi.SqlTypes
 
 fun PsiElement.isNotWhiteSpace(): Boolean = this !is PsiWhiteSpace
-
-// Get the list of elements before itself
-fun PsiElement.findSelfBlocks(): List<PsiElement> {
-    val elms =
-        this.prevLeafs
-            .takeWhile {
-                it.isNotWhiteSpace() &&
-                    it.elementType != SqlTypes.AT_SIGN &&
-                    (it.elementType != SqlTypes.LEFT_PAREN || it.parent.elementType == SqlTypes.EL_PARAMETERS) &&
-                    it.elementType != SqlTypes.COMMA
-            }.toList()
-            .plus(this)
-            .filter { it is PsiErrorElement || it is SqlElIdExpr || it.elementType == SqlTypes.EL_IDENTIFIER }
-            .filter { it.isNotWhiteSpace() }
-            .sortedBy { it.textOffset }
-
-    return if (elms.isNotEmpty()) elms else emptyList()
-}
 
 /**
  * Traverse a node's parent hierarchy

--- a/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
@@ -31,16 +31,20 @@ class SqlCompleteTest : DomaSqlTest() {
         addSqlFile(
             "$testDaoName/completeDaoArgument.sql",
             "$testDaoName/completeInstancePropertyFromDaoArgumentClass.sql",
+            "$testDaoName/completeInstancePropertyWithMethodParameter.sql",
             "$testDaoName/completeJavaPackageClass.sql",
             "$testDaoName/completeDirective.sql",
             "$testDaoName/completeBatchInsert.sql",
             "$testDaoName/completeStaticPropertyFromStaticPropertyCall.sql",
             "$testDaoName/completePropertyAfterStaticPropertyCall.sql",
+            "$testDaoName/completePropertyAfterStaticPropertyCallWithMethodParameter.sql",
             "$testDaoName/completePropertyAfterStaticMethodCall.sql",
             "$testDaoName/completeBuiltinFunction.sql",
             "$testDaoName/completeDirectiveInsideIf.sql",
+            "$testDaoName/completeDirectiveFieldInsideIfWithMethodParameter.sql",
             "$testDaoName/completeDirectiveInsideElseIf.sql",
             "$testDaoName/completeDirectiveInsideFor.sql",
+            "$testDaoName/completeDirectiveInsideForWithMethodParameter.sql",
             "$testDaoName/completeDirectiveFieldInsideIf.sql",
             "$testDaoName/completeDirectiveFieldInsideElseIf.sql",
             "$testDaoName/completeDirectiveFieldInsideFor.sql",
@@ -48,6 +52,7 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDaoName/completeComparisonOperator.sql",
             "$testDaoName/completeParameterFirst.sql",
             "$testDaoName/completeParameterFirstProperty.sql",
+            "$testDaoName/completeParameterFirstPropertyWithMethodParameter.sql",
             "$testDaoName/completeParameterSecond.sql",
             "$testDaoName/completeParameterSecondProperty.sql",
             "$testDaoName/completeParameterFirstInStaticAccess.sql",
@@ -105,6 +110,26 @@ class SqlCompleteTest : DomaSqlTest() {
                 "getFirstProject()",
             ),
             listOf("getEmployeeRank()"),
+        )
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeInstancePropertyWithMethodParameter.sql",
+            listOf(
+                "byteValue()",
+                "compareTo()",
+                "doubleValue()",
+                "toString()",
+            ),
+            listOf(
+                "employeeId",
+                "employeeName",
+                "department",
+                "rank",
+                "getFirstProject()",
+                "toLowerCase()",
+                "charAt()",
+                "contains()",
+                "isBlank()",
+            ),
         )
     }
 
@@ -212,6 +237,28 @@ class SqlCompleteTest : DomaSqlTest() {
                 "addTermNumber()",
             ),
         )
+
+        innerDirectiveCompleteTest(
+            "$testDaoName/completePropertyAfterStaticPropertyCallWithMethodParameter.sql",
+            listOf(
+                "projectId",
+                "projectNumber",
+                "projectName",
+                "projectCategory",
+            ),
+            listOf(
+                "projectDetailId",
+                "members",
+                "manager",
+                "getFirstEmployee()",
+                "getTermNumber()",
+                "employeeId",
+                "projects",
+                "rank",
+                "contains()",
+                "isBlank()",
+            ),
+        )
     }
 
     fun testCompleteCallStaticPropertyClassPackage() {
@@ -308,15 +355,29 @@ class SqlCompleteTest : DomaSqlTest() {
             listOf("employee"),
             listOf("project"),
         )
+
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeDirectiveFieldInsideIfWithMethodParameter.sql",
+            listOf("projectNumber", "projectCategory", "getFirstEmployee()", "getTermNumber()"),
+            listOf("project", "employee"),
+        )
+
         innerDirectiveCompleteTest(
             "$testDaoName/completeDirectiveInsideElseIf.sql",
             listOf("employee", "project"),
             emptyList(),
         )
+
         innerDirectiveCompleteTest(
             "$testDaoName/completeDirectiveInsideFor.sql",
             listOf("project"),
             listOf("employee", "member", "%for"),
+        )
+
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeDirectiveInsideForWithMethodParameter.sql",
+            listOf("clear()", "contains()", "get()", "getFirst()"),
+            listOf("projectNumber", "projectCategory", "getFirstEmployee()", "getTermNumber()"),
         )
     }
 
@@ -372,6 +433,12 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDaoName/completeParameterFirstProperty.sql",
             listOf("employeeId", "department", "rank"),
             listOf("employee"),
+        )
+
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeParameterFirstPropertyWithMethodParameter.sql",
+            listOf("projectNumber", "projectCategory", "getFirstEmployee()"),
+            listOf("employeeId", "employeeName", "getFirstProject()"),
         )
 
         innerDirectiveCompleteTest(

--- a/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
@@ -19,6 +19,9 @@ interface SqlCompleteTestDao {
   @Select
   Employee completeInstancePropertyFromDaoArgumentClass(Employee employee, String name);
 
+  @Select
+  Employee completeInstancePropertyWithMethodParameter(Employee employee, String name);
+
   @Insert(sqlFile = true)
   int completeJavaPackageClass(Employee employee);
 
@@ -35,6 +38,9 @@ interface SqlCompleteTestDao {
   Project completePropertyAfterStaticPropertyCall();
 
   @Select
+  Project completePropertyAfterStaticPropertyCallWithMethodParameter(Employee employee);
+
+  @Select
   Project completePropertyAfterStaticMethodCall();
 
   @Select
@@ -44,10 +50,16 @@ interface SqlCompleteTestDao {
   int completeDirectiveInsideIf(Employee employee,Project project);
 
   @Update(sqlFile = true)
+  int completeDirectiveFieldInsideIfWithMethodParameter(Employee employee,Project project);
+
+  @Update(sqlFile = true)
   int completeDirectiveInsideElseIf(Employee employee,Project project);
 
   @Update(sqlFile = true)
   int completeDirectiveInsideFor(Employee employee,Project project);
+
+  @Update(sqlFile = true)
+  int completeDirectiveInsideForWithMethodParameter(Employee employee,List<List<Project>> projectsList);
 
   @Update(sqlFile = true)
   int completeDirectiveFieldInsideIf(Employee employee,Project project);
@@ -69,6 +81,9 @@ interface SqlCompleteTestDao {
 
   @Select
   Employee completeParameterFirstProperty(Employee employee);
+
+  @Select
+  Employee completeParameterFirstPropertyWithMethodParameter(Employee employee, Integer index);
 
   @Select
   Employee completeParameterSecond(Employee employee);

--- a/src/test/testData/src/main/java/doma/example/entity/ProjectDetail.java
+++ b/src/test/testData/src/main/java/doma/example/entity/ProjectDetail.java
@@ -19,6 +19,7 @@ public class ProjectDetail {
   public static Integr projectNumber;
   private static String projectName;
   private static String projectCategory;
+  private static List<Project> subProjects = new ArrayList<>();
 
   private static Employee manager = new Employee();
 
@@ -42,6 +43,10 @@ public class ProjectDetail {
 
   public static String getCustomNumber(String prefix) {
     return prefix + projectName;
+  }
+
+  public static Project getProject(String index){
+    return subProjects.get(Integer.parseInt(index));
   }
 
 }

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeDirectiveFieldInsideIfWithMethodParameter.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeDirectiveFieldInsideIfWithMethodParameter.sql
@@ -1,0 +1,13 @@
+update employee e set
+ e.employee_name = /* employee.employeeName */'name'
+ , e.rank = /* employee.rank */1
+where
+ e.employee_id = /* employee.employeeId */1
+ /*%if employee.getFirstProject(employee.employeeId).<caret>  */
+  and e.department = /* employee.department */'department'
+ /*%elseif employee.department.startWith("100") */
+  and e.sub_department = /* employee.department */'department'
+  and e.rank >= /* employee.rank */9999
+ /*%else */
+  and e.sub_department = /* employee.department */'department'
+ /*%end*/

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeDirectiveInsideForWithMethodParameter.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeDirectiveInsideForWithMethodParameter.sql
@@ -1,0 +1,15 @@
+update employee e set
+ e.employee_name = /* employee.employeeName */'name'
+ , e.rank = /* employee.rank */1
+where
+ e.employee_id = /* employee.employeeId */1
+ /*%for member : projectsList.get(employee.rank).<caret> */
+   /*%if member.department.startWith("200")  */
+    and e.department = /* member.department */'department'
+   /*%elseif member.department.startWith("100") */
+    and e.sub_department = /* member.department */'department'
+    and e.rank >= /* member.rank */9999
+   /*%else */
+    and e.sub_department = /* member.department */'department'
+   /*%end*/
+  /*%end*/

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeInstancePropertyWithMethodParameter.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeInstancePropertyWithMethodParameter.sql
@@ -1,0 +1,1 @@
+select * from employee where id = /* employee.employeeParam(name).<caret> */1

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterFirstPropertyWithMethodParameter.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeParameterFirstPropertyWithMethodParameter.sql
@@ -1,0 +1,1 @@
+select * from employee where id = /* employee.getFirstProject(employee.getFirstProject(index).<caret> ) */1

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completePropertyAfterStaticPropertyCallWithMethodParameter.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completePropertyAfterStaticPropertyCallWithMethodParameter.sql
@@ -1,0 +1,11 @@
+select
+   p.project_id
+   , p.statis
+   , p.project_name
+   , p.rank
+from project p
+ inner join project_detail pd
+  on p.project_id = pd.project_id
+ where
+  -- Code completion for static fields and methods
+  and pd.manager_id = /* @doma.example.entity.ProjectDetail@getProject(employee.rank).<caret>pro */'TODO'


### PR DESCRIPTION

When invoking a method on a field-access element that already has a different variable name set in its argument parameter, subsequent suggestions for instance fields and methods were not shown. 

The issue occurred because, when collecting the list of elements before the caret, children of the argument-parameter element were incorrectly treated as part of the field-access chain, resulting in an invalid property-access structure.

This update filters out any elements whose parent is the argument-parameter class when gathering preceding elements, so that only the correct elements are retrieved for suggestions.