### PR TITLE
Add fallback for parent class name retrieval in validation property result

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/validator/result/ValidationPropertyResult.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/validator/result/ValidationPropertyResult.kt
@@ -37,9 +37,11 @@ class ValidationPropertyResult(
         parent: PsiParentClass?,
     ) {
         val project = identify.project
+        val parentClassType = parentClass?.type
         val parentName =
             parentClass?.clazz?.name
-                ?: (parentClass?.type as? PsiClassType)?.name
+                ?: (parentClassType as? PsiClassType)?.name
+                ?: parentClassType?.canonicalText
                 ?: ""
         holder.registerProblem(
             identify,

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/EmployeeSummaryDao/bindVariableForEntityAndNonEntityParentClass.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/EmployeeSummaryDao/bindVariableForEntityAndNonEntityParentClass.sql
@@ -9,8 +9,10 @@ INSERT INTO employee_project (employee_name, department, project)
                  JOIN user u1 ON e1.employee_id = u1.user_id
                               AND e1.user_tag = /*# 't' */'a'
                               AND e1.user_dept = /*# "development" */'dev'
-                  -- Access to parent private field
+                   -- Access to parent private field
                    WHERE u1.user_name = /* employee.userName.toLowerCase() */'name'
+                    -- Access to property on primitive type
+                    OR u1.name = /* employee.userName.isBlank().<error descr="The field or method [x] does not exist in the class [boolean]">x</error> */'boolean'
                    -- Access to non-existent parent field
                    OR u1.user_name = /* employee.<error descr="The field or method [userFirstName] does not exist in the class [Employee]">userFirstName</error>.toLowerCase() */'name'
                    -- Public parent method


### PR DESCRIPTION
Modify the error message and add test cases for when a property is accessed on a primitive type during the field-access element definition check.