### PR TITLE
Fix code completion for static field access

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiPatternUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiPatternUtil.kt
@@ -51,6 +51,7 @@ object PsiPatternUtil {
                     val inComment = PsiTreeUtil.getParentOfType(element, parentClass, true) != null
                     if (inComment) return true
 
+                    // Even incomplete elements during input are analyzed as strings and included in the code completion process within block comments.
                     var prevElement = PsiTreeUtil.prevLeaf(element, true)
                     while (prevElement != null &&
                         !(

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiPatternUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiPatternUtil.kt
@@ -19,7 +19,9 @@ import com.intellij.patterns.PatternCondition
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.TokenType
+import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
 import com.intellij.psi.util.prevLeaf
@@ -147,5 +149,22 @@ object PsiPatternUtil {
                 .replace("/*", "")
                 .substringAfter(symbol)
         return prefix
+    }
+
+    fun getBindSearchWord(
+        element: PsiElement,
+        targetType: IElementType?,
+    ): MutableList<PsiElement> {
+        var prevElement = PsiTreeUtil.prevLeaf(element, true)
+        var prevElements = mutableListOf<PsiElement>()
+        while (prevElement != null &&
+            prevElement !is PsiWhiteSpace &&
+            prevElement.elementType != targetType &&
+            prevElement.elementType != SqlTypes.BLOCK_COMMENT_START
+        ) {
+            prevElements.add(prevElement)
+            prevElement = PsiTreeUtil.prevLeaf(prevElement, true)
+        }
+        return prevElements
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiStaticElement.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiStaticElement.kt
@@ -19,6 +19,7 @@ import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiFile
 import com.intellij.psi.search.GlobalSearchScope
+import org.domaframework.doma.intellij.common.util.StringUtil
 import org.domaframework.doma.intellij.extension.getJavaClazz
 import org.domaframework.doma.intellij.psi.SqlElExpr
 
@@ -32,10 +33,7 @@ class PsiStaticElement(
     private var fqdn = elExprList?.joinToString(".") { e -> e.text } ?: ""
 
     constructor(elExprNames: String, file: PsiFile) : this(null, file) {
-        fqdn =
-            elExprNames
-                .substringAfter("@")
-                .substringBefore("@")
+        fqdn = StringUtil.getSqlElClassText(elExprNames)
     }
 
     fun getRefClazz(): PsiClass? {

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/CleanElementText.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/CleanElementText.kt
@@ -15,15 +15,16 @@
  */
 package org.domaframework.doma.intellij.common.sql
 
+import org.domaframework.doma.intellij.common.util.StringUtil
+
 /**
  * Exclude extra strings and block symbols added by IntelliJ operations a
  * nd format them into necessary elements
  */
 fun cleanString(str: String): String {
     val intelliKIdeaRuleZzz = "IntellijIdeaRulezzz"
-    return str
-        .substringAfter("/*")
-        .substringBefore("*/")
+    return StringUtil
+        .replaceBlockCommentStartEnd(str)
         .replace(intelliKIdeaRuleZzz, "")
         // TODO: Temporary support when using operators.
         //  Remove the "== a" element because it is attached to the end.

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/DirectiveCompletion.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/DirectiveCompletion.kt
@@ -26,6 +26,16 @@ class DirectiveCompletion(
     private val caretNextText: String,
     private val result: CompletionResultSet,
 ) {
+    companion object {
+        val directiveSymbols =
+            listOf(
+                "%",
+                "#",
+                "^",
+                "@",
+            )
+    }
+
     fun directiveHandle(symbol: String): Boolean {
         return when (symbol) {
             "%" ->

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/util/ForDirectiveUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/util/ForDirectiveUtil.kt
@@ -67,6 +67,9 @@ class ForDirectiveUtil {
         private val cachedForDirectiveBlocks: MutableMap<PsiElement, CachedValue<List<BlockToken>>> =
             mutableMapOf()
 
+        const val HAS_NEXT_PREFIX = "_has_next"
+        const val INDEX_PREFIX = "_index"
+
         /**
          *  Get the parent for directive list to which this directive belongs
          * @param targetElement Element to search for definer
@@ -162,7 +165,7 @@ class ForDirectiveUtil {
             skipSelf: Boolean = true,
             forDirectives: List<BlockToken> = getForDirectiveBlocks(targetElement, skipSelf),
         ): PsiElement? {
-            val searchText = targetElement.text.replace("_has_next", "").replace("_index", "")
+            val searchText = targetElement.text.replace(HAS_NEXT_PREFIX, "").replace(INDEX_PREFIX, "")
             return forDirectives.firstOrNull { it.item.text == searchText }?.item
         }
 
@@ -507,9 +510,9 @@ class ForDirectiveUtil {
             }
 
         fun resolveForDirectiveItemClassTypeBySuffixElement(searchName: String): PsiType? =
-            if (searchName.endsWith("_has_next")) {
+            if (searchName.endsWith(HAS_NEXT_PREFIX)) {
                 PsiTypes.booleanType()
-            } else if (searchName.endsWith("_index")) {
+            } else if (searchName.endsWith(INDEX_PREFIX)) {
                 PsiTypes.intType()
             } else {
                 null

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/util/StringUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/util/StringUtil.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.common.util
+
+object StringUtil {
+    fun getSqlElClassText(text: String): String =
+        text
+            .substringAfter("@")
+            .substringBefore("@")
+
+    fun replaceBlockCommentStartEnd(text: String): String = text.substringAfter("/*").substringBefore("*/")
+}

--- a/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
@@ -80,7 +80,7 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
         try {
             val originalFile = parameters.originalFile
             val pos = parameters.originalPosition ?: return
-            val bindText = StringUtil.replaceBlockCommentStartEnd(cleanString(pos.text))
+            val bindText = cleanString(pos.text)
 
             val handler = DirectiveCompletion(originalFile, bindText, pos, caretNextText, result)
             val directiveSymbols = DirectiveCompletion.directiveSymbols
@@ -342,6 +342,14 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
             ?: clazz.findStaticMethod(topText)?.returnType
     }
 
+    /**
+     * Retrieves the class type from the previous element class words.
+     * If the class is not found, returns null.
+     * @param project The current project.
+     * @param fqdn The fully qualified class name.
+     * @param topText The name of the static property search that is being called first.
+     * @return The class type of the static property, or null if not found.
+     */
     private fun getElementTypeByPrevSqlElClassWords(
         project: Project,
         fqdn: String,

--- a/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlCompleteTest.kt
@@ -32,6 +32,7 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDaoName/completeDaoArgument.sql",
             "$testDaoName/completeInstancePropertyFromDaoArgumentClass.sql",
             "$testDaoName/completeInstancePropertyWithMethodParameter.sql",
+            "$testDaoName/completeTopElementBeforeAtsign.sql",
             "$testDaoName/completeJavaPackageClass.sql",
             "$testDaoName/completeDirective.sql",
             "$testDaoName/completeBatchInsert.sql",
@@ -39,6 +40,7 @@ class SqlCompleteTest : DomaSqlTest() {
             "$testDaoName/completePropertyAfterStaticPropertyCall.sql",
             "$testDaoName/completePropertyAfterStaticPropertyCallWithMethodParameter.sql",
             "$testDaoName/completePropertyAfterStaticMethodCall.sql",
+            "$testDaoName/completeStaticPropertyAfterOtherElement.sql",
             "$testDaoName/completeBuiltinFunction.sql",
             "$testDaoName/completeDirectiveInsideIf.sql",
             "$testDaoName/completeDirectiveFieldInsideIfWithMethodParameter.sql",
@@ -129,6 +131,24 @@ class SqlCompleteTest : DomaSqlTest() {
                 "charAt()",
                 "contains()",
                 "isBlank()",
+            ),
+        )
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeTopElementBeforeAtsign.sql",
+            listOf(
+                "employee",
+                "id",
+                "userIds",
+                "userId",
+                "userId_has_next",
+                "userId_index",
+            ),
+            listOf(
+                "doma",
+                "example",
+                "projectNumber",
+                "subProjects",
+                "valueOf()",
             ),
         )
     }
@@ -245,18 +265,34 @@ class SqlCompleteTest : DomaSqlTest() {
                 "projectNumber",
                 "projectName",
                 "projectCategory",
+                "status",
+                "manager",
+                "getFirstEmployee()",
+                "getTermNumber()",
             ),
             listOf(
                 "projectDetailId",
                 "members",
-                "manager",
-                "getFirstEmployee()",
-                "getTermNumber()",
                 "employeeId",
                 "projects",
-                "rank",
                 "contains()",
                 "isBlank()",
+            ),
+        )
+        innerDirectiveCompleteTest(
+            "$testDaoName/completeStaticPropertyAfterOtherElement.sql",
+            listOf(
+                "projectNumber",
+                "projectName",
+                "projectCategory",
+                "manager",
+                "subProjects",
+                "getTermNumber()",
+                "getCustomNumber()",
+            ),
+            listOf(
+                "doma",
+                "employee",
             ),
         )
     }

--- a/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/SqlCompleteTestDao.java
@@ -22,6 +22,9 @@ interface SqlCompleteTestDao {
   @Select
   Employee completeInstancePropertyWithMethodParameter(Employee employee, String name);
 
+  @Select
+  Employee completeTopElementBeforeAtsign(Employee employee, Integer id, List<Integer> userIds);
+
   @Insert(sqlFile = true)
   int completeJavaPackageClass(Employee employee);
 
@@ -42,6 +45,9 @@ interface SqlCompleteTestDao {
 
   @Select
   Project completePropertyAfterStaticMethodCall();
+
+  @Select
+  Employee completeStaticPropertyAfterOtherElement(Employee employee);
 
   @Select
   Project completeBuiltinFunction(ProjectDetail detail);

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completePropertyAfterStaticPropertyCallWithMethodParameter.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completePropertyAfterStaticPropertyCallWithMethodParameter.sql
@@ -7,5 +7,4 @@ from project p
  inner join project_detail pd
   on p.project_id = pd.project_id
  where
-  -- Code completion for static fields and methods
-  and pd.manager_id = /* @doma.example.entity.ProjectDetail@getProject(employee.rank).<caret>pro */'TODO'
+  and pd.manager_id = /* @doma.example.entity.ProjectDetail@getProject(employee.rank).<caret> */'TODO'

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeStaticPropertyAfterOtherElement.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeStaticPropertyAfterOtherElement.sql
@@ -1,0 +1,15 @@
+select
+   p.project_id
+   , p.statis
+   , p.project_name
+   , p.rank
+from project p
+ inner join project_detail pd
+  on p.project_id = pd.project_id
+ where
+  /*%for userId : userIds */
+   pd.manager_id = /* id @doma.example.entity.ProjectDetail@<caret> */'TODO'
+   /*%if userId_has_next */
+    /*# "OR" */
+   /*%end */
+  /*%end */

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeTopElementBeforeAtsign.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/SqlCompleteTestDao/completeTopElementBeforeAtsign.sql
@@ -1,0 +1,15 @@
+select
+   p.project_id
+   , p.statis
+   , p.project_name
+   , p.rank
+from project p
+ inner join project_detail pd
+  on p.project_id = pd.project_id
+ where
+  /*%for userId : userIds */
+   pd.manager_id = /* id <caret> @doma.example.entity.ProjectDetail@manager */'TODO'
+   /*%if userId_has_next */
+    /*# "OR" */
+   /*%end */
+  /*%end */


### PR DESCRIPTION
When identifying code-completion targets, ignore argument-parameter elements and retrieve only the preceding element list.

Ensure that even if a field-access element isn’t fully constructed mid-typing, string-based parsing still triggers static field-access code completion.

- Prevent entering class-name suggestion logic when completion is invoked immediately before @. 
- Ensure static properties are suggested even if another bind variable appears before the static field access.