### PR TITLE
Reflect Custom Error Levels in DAO Method Inspection

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/validator/result/ValidationSqlFileExistResult.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/validator/result/ValidationSqlFileExistResult.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.common.sql.validator.result
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.domaframework.doma.intellij.bundle.MessageBundle
+import org.domaframework.doma.intellij.common.psi.PsiDaoMethod
+import org.domaframework.doma.intellij.common.psi.PsiParentClass
+import org.domaframework.doma.intellij.inspection.dao.quickfix.GenerateSQLFileQuickFixFactory
+
+class ValidationSqlFileExistResult(
+    private val psiDaoMethod: PsiDaoMethod,
+    override val identify: PsiElement?,
+    override val shortName: String = "",
+) : ValidationResult(identify, null, shortName) {
+    override fun setHighlight(
+        highlightRange: TextRange,
+        identify: PsiElement,
+        holder: ProblemsHolder,
+        parent: PsiParentClass?,
+    ) {
+        val project = psiDaoMethod.psiMethod.project
+        holder.registerProblem(
+            identify,
+            MessageBundle.message("inspection.invalid.dao.notExistSql"),
+            problemHighlightType(project, shortName),
+            GenerateSQLFileQuickFixFactory.createSql(psiDaoMethod),
+        )
+    }
+}

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/validator/result/ValidationUsedDaoMethodArgsResult.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/validator/result/ValidationUsedDaoMethodArgsResult.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.common.sql.validator.result
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiParameter
+import com.intellij.psi.impl.source.PsiParameterImpl
+import org.domaframework.doma.intellij.bundle.MessageBundle
+import org.domaframework.doma.intellij.common.psi.PsiParentClass
+import org.domaframework.doma.intellij.inspection.dao.visitor.DaoMethodVariableInspectionVisitor.DaoMethodVariableVisitorResult
+
+class ValidationUsedDaoMethodArgsResult(
+    private val daoMethodVariableResult: DaoMethodVariableVisitorResult,
+    override val identify: PsiElement?,
+    override val shortName: String = "",
+) : ValidationResult(identify, null, shortName) {
+    override fun setHighlight(
+        highlightRange: TextRange,
+        identify: PsiElement,
+        holder: ProblemsHolder,
+        parent: PsiParentClass?,
+    ) {
+        val param = identify as? PsiParameter ?: return
+        val project = identify.project
+        val message =
+            if (daoMethodVariableResult.deplicateForItemElements.contains(identify)) {
+                MessageBundle.message("inspection.invalid.dao.duplicate")
+            } else {
+                MessageBundle.message(
+                    "inspection.invalid.dao.paramUse",
+                    param.name,
+                )
+            }
+        holder.registerProblem(
+            (param.originalElement as PsiParameterImpl).nameIdentifier,
+            message,
+            problemHighlightType(project, shortName),
+        )
+    }
+}

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/inspector/DaoMethodVariableInspection.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/inspector/DaoMethodVariableInspection.kt
@@ -38,5 +38,5 @@ class DaoMethodVariableInspection : AbstractBaseJavaLocalInspectionTool() {
     override fun buildVisitor(
         holder: ProblemsHolder,
         isOnTheFly: Boolean,
-    ): PsiElementVisitor = DaoMethodVariableInspectionVisitor(holder)
+    ): PsiElementVisitor = DaoMethodVariableInspectionVisitor(holder, this.shortName)
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/inspector/SqlFileExistInspection.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/inspector/SqlFileExistInspection.kt
@@ -38,5 +38,5 @@ class SqlFileExistInspection : AbstractBaseJavaLocalInspectionTool() {
     override fun buildVisitor(
         holder: ProblemsHolder,
         isOnTheFly: Boolean,
-    ): PsiElementVisitor = SqlFileExistInspectionVisitor(holder)
+    ): PsiElementVisitor = SqlFileExistInspectionVisitor(holder, this.shortName)
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/visitor/SqlFileExistInspectionVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/visitor/SqlFileExistInspectionVisitor.kt
@@ -15,18 +15,17 @@
  */
 package org.domaframework.doma.intellij.inspection.dao.visitor
 
-import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.JavaElementVisitor
 import com.intellij.psi.PsiMethod
-import org.domaframework.doma.intellij.bundle.MessageBundle
 import org.domaframework.doma.intellij.common.dao.getDaoClass
 import org.domaframework.doma.intellij.common.isJavaOrKotlinFileType
 import org.domaframework.doma.intellij.common.psi.PsiDaoMethod
-import org.domaframework.doma.intellij.inspection.dao.quickfix.GenerateSQLFileQuickFixFactory
+import org.domaframework.doma.intellij.common.sql.validator.result.ValidationSqlFileExistResult
 
 class SqlFileExistInspectionVisitor(
     private val holder: ProblemsHolder,
+    private val shortName: String,
 ) : JavaElementVisitor() {
     // TODO Support Kotlin Project
     override fun visitMethod(method: PsiMethod) {
@@ -46,11 +45,15 @@ class SqlFileExistInspectionVisitor(
     ) {
         val identifier = psiDaoMethod.psiMethod.nameIdentifier ?: return
         if (psiDaoMethod.sqlFile == null) {
-            problemHolder.registerProblem(
+            ValidationSqlFileExistResult(
+                psiDaoMethod,
                 identifier,
-                MessageBundle.message("inspection.invalid.dao.notExistSql"),
-                ProblemHighlightType.ERROR,
-                GenerateSQLFileQuickFixFactory.createSql(psiDaoMethod),
+                shortName,
+            ).setHighlight(
+                identifier.textRange,
+                identifier,
+                problemHolder,
+                null,
             )
         }
     }


### PR DESCRIPTION
For code inspection of DAO methods, reference the inspection settings and apply the appropriate highlight levels.

Added a code inspection result class for DAO methods and set the error highlight level from IntelliJ's inspection settings.