### PR TITLE
No error when a field-access element shares the same name as a parameter

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiPatternUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiPatternUtil.kt
@@ -24,7 +24,6 @@ import com.intellij.psi.TokenType
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
-import com.intellij.psi.util.prevLeaf
 import com.intellij.psi.util.prevLeafs
 import com.intellij.util.ProcessingContext
 import org.domaframework.doma.intellij.common.sql.directive.DirectiveCompletion
@@ -79,11 +78,11 @@ object PsiPatternUtil {
                     element: PsiElement,
                     context: ProcessingContext?,
                 ): Boolean {
-                    val bindText = element.prevLeaf()?.text ?: ""
+                    val bindText = PsiTreeUtil.prevLeaf(element)?.text ?: ""
                     val directiveSymbol = DirectiveCompletion.directiveSymbols
                     return directiveSymbol.any {
                         bindText.startsWith(it) ||
-                            (element.elementType == SqlTypes.EL_IDENTIFIER && element.prevLeaf()?.text == it) ||
+                            (element.elementType == SqlTypes.EL_IDENTIFIER && PsiTreeUtil.prevLeaf(element)?.text == it) ||
                             (
                                 element.elementType == TokenType.BAD_CHARACTER &&
                                     element.parent

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/DirectiveHandler.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/DirectiveHandler.kt
@@ -16,8 +16,8 @@
 package org.domaframework.doma.intellij.common.sql.directive
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
 import org.domaframework.doma.intellij.common.psi.PsiPatternUtil
-import org.jetbrains.kotlin.psi.psiUtil.prevLeaf
 
 /**
  * Determine directive elements and perform code completion
@@ -31,7 +31,7 @@ open class DirectiveHandler(
         it: PsiElement,
         symbol: String,
     ): Boolean {
-        val prev = it.prevLeaf()
+        val prev = PsiTreeUtil.prevLeaf(it)
         return (
             prev?.text == symbol ||
                 it.text.startsWith(symbol)

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/visitor/DaoMethodVariableSqlVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/visitor/DaoMethodVariableSqlVisitor.kt
@@ -43,7 +43,7 @@ class DaoMethodVariableSqlVisitor(
                 element.elementType == SqlTypes.EL_IDENTIFIER ||
                     element is SqlElPrimaryExpr
             ) &&
-            element.prevSibling?.elementType != SqlTypes.DOT
+            PsiTreeUtil.prevLeaf(element)?.elementType != SqlTypes.DOT
         ) {
             iterator = args.minus(elements.toSet()).iterator()
             while (iterator.hasNext()) {

--- a/src/test/testData/src/main/java/doma/example/dao/DaoMethodVariableInspectionTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/DaoMethodVariableInspectionTestDao.java
@@ -32,8 +32,8 @@ interface DaoMethodVariableInspectionTestDao {
   List<Employee> nonExistSQLFile(String name);
 
   @Select
-  @Sql("select * from employee where name = /* name */'test'")
-  Employee noArgumentsUsedInSQLAnnotations(String name,Integer <error descr="There are unused parameters in the SQL [id]">id</error>);
+  @Sql("select * from employee where name = /* employee.employeeName */'test'")
+  Employee noArgumentsUsedInSQLAnnotations(Employee employee,String <error descr="There are unused parameters in the SQL [employeeName]">employeeName</error>);
 
   @SqlProcessor
   <R> R biFunctionDoesNotCauseError(Integer id, BiFunction<Config, PreparedSql, R> handler);


### PR DESCRIPTION
Address an issue in DAO method argument usage validation where a method parameter was not error-highlighted if a field-access element invoked a property with the same name.

Update the logic that retrieves preceding elements under inspection to use the `PsiTreeUtil` API.