### PR TITLE
No error when static field-access element shares the same name as a parameter

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/visitor/DaoMethodVariableSqlVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/visitor/DaoMethodVariableSqlVisitor.kt
@@ -39,11 +39,13 @@ class DaoMethodVariableSqlVisitor(
 
     // Recursively explore child elements in a file with PsiRecursiveElementVisitor.
     override fun visitElement(element: PsiElement) {
+        val prevElementType = PsiTreeUtil.prevLeaf(element)?.elementType
         if ((
                 element.elementType == SqlTypes.EL_IDENTIFIER ||
                     element is SqlElPrimaryExpr
             ) &&
-            PsiTreeUtil.prevLeaf(element)?.elementType != SqlTypes.DOT
+            prevElementType != SqlTypes.DOT &&
+            prevElementType != SqlTypes.AT_SIGN
         ) {
             iterator = args.minus(elements.toSet()).iterator()
             while (iterator.hasNext()) {

--- a/src/test/testData/src/main/java/doma/example/dao/DaoMethodVariableInspectionTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/DaoMethodVariableInspectionTestDao.java
@@ -32,8 +32,11 @@ interface DaoMethodVariableInspectionTestDao {
   List<Employee> nonExistSQLFile(String name);
 
   @Select
-  @Sql("select * from employee where name = /* employee.employeeName */'test'")
-  Employee noArgumentsUsedInSQLAnnotations(Employee employee,String <error descr="There are unused parameters in the SQL [employeeName]">employeeName</error>);
+  @Sql("select * from employee where name = /* employee.employeeName */'test' and status = /* @doma.example.entity.Project@status */'status'")
+  Employee noArgumentsUsedInSQLAnnotations(Employee employee,
+      String <error descr="There are unused parameters in the SQL [employeeName]">employeeName</error>,
+      String <error descr="There are unused parameters in the SQL [status]">status</error>,
+      String <error descr="There are unused parameters in the SQL [doma]">doma</error>);
 
   @SqlProcessor
   <R> R biFunctionDoesNotCauseError(Integer id, BiFunction<Config, PreparedSql, R> handler);
@@ -42,10 +45,12 @@ interface DaoMethodVariableInspectionTestDao {
   Project selectOptionDoesNotCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,String searchName,SelectOptions options);
 
   @Select(strategy = SelectType.COLLECT)
-  Project collectDoesNotCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,Integer id,Collector<Project, ?, Project> collector);
+  Project collectDoesNotCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,Integer id,
+      Collector<Project, ?, Project> collector);
 
   @Select
-  Project collectDoesCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,String searchName,Collector<Project, ?, Project> <error descr="There are unused parameters in the SQL [collector]">collector</error>);
+  Project collectDoesCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,String searchName,
+      Collector<Project, ?, Project> <error descr="There are unused parameters in the SQL [collector]">collector</error>);
 
   @Select
   Project noErrorWhenUsedInFunctionParameters(Employee employee, Integer count);


### PR DESCRIPTION
Address an issue in DAO method argument usage validation where a method parameter was not error-highlighted if a `static-field-access` element invoked a property with the same name.

Update the logic that retrieves preceding elements under inspection to use the PsiTreeUtil API.

Modify as below:
https://github.com/domaframework/doma-tools-for-intellij/pull/241