### PR TITLE
Fix Return Type Check

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/returntype/UpdateAnnotationReturnTypeCheckProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/returntype/UpdateAnnotationReturnTypeCheckProcessor.kt
@@ -16,7 +16,6 @@
 package org.domaframework.doma.intellij.inspection.dao.processor.returntype
 
 import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiTypes
 import org.domaframework.doma.intellij.common.psi.PsiDaoMethod
@@ -112,10 +111,10 @@ class UpdateAnnotationReturnTypeCheckProcessor(
     ): Boolean {
         if (returnTypeClass?.isEntity() != true) return false
 
-        if (DomaClassName.OPTIONAL.isTargetClassNameStartsWith(paramClass.type.canonicalText)) {
-            val optionalType = paramClass.type as? PsiClassType
+        if (DomaClassName.OPTIONAL.isTargetClassNameStartsWith(returnTypeClass.psiClassType.canonicalText)) {
+            val optionalType = returnTypeClass.psiClassType
             val optionalParam =
-                optionalType?.parameters?.firstOrNull()
+                optionalType.parameters.firstOrNull()
                     ?: return false
             return optionalParam.canonicalText == paramClass.type.canonicalText
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/returntype/UpdateAnnotationReturnTypeCheckProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/returntype/UpdateAnnotationReturnTypeCheckProcessor.kt
@@ -15,14 +15,18 @@
  */
 package org.domaframework.doma.intellij.inspection.dao.processor.returntype
 
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiTypes
 import org.domaframework.doma.intellij.common.psi.PsiDaoMethod
 import org.domaframework.doma.intellij.common.sql.PsiClassTypeUtil
+import org.domaframework.doma.intellij.common.util.DomaClassName
 import org.domaframework.doma.intellij.common.validation.result.ValidationResult
 import org.domaframework.doma.intellij.common.validation.result.ValidationReturnTypeUpdateReturningResult
 import org.domaframework.doma.intellij.extension.getJavaClazz
 import org.domaframework.doma.intellij.extension.psi.isEntity
+import org.domaframework.doma.intellij.extension.psi.psiClassType
 
 /**
  * Processor for checking the return type of update-related annotations in DAO methods.
@@ -41,13 +45,22 @@ class UpdateAnnotationReturnTypeCheckProcessor(
      */
     override fun checkReturnType(): ValidationResult? {
         val methodOtherReturnType = PsiTypes.intType()
-        if (psiDaoMethod.useSqlAnnotation() || psiDaoMethod.sqlFileOption) {
-            return generatePsiTypeReturnTypeResult(methodOtherReturnType)
-        }
-
         val parameters = method.parameterList.parameters
         val immutableEntityParam =
-            parameters.firstOrNull() ?: return null
+            parameters.firstOrNull()
+                ?: return generatePsiTypeReturnTypeResult(methodOtherReturnType)
+
+        if (psiDaoMethod.useSqlAnnotation() || psiDaoMethod.sqlFileOption) {
+            immutableEntityParam.let { methodParam ->
+                val paramTypeName = methodParam.type.canonicalText
+                project.getJavaClazz(paramTypeName)?.let {
+                    if (isImmutableEntity(paramTypeName)) {
+                        return checkReturnTypeImmutableEntity(immutableEntityParam)
+                    }
+                }
+            }
+            return generatePsiTypeReturnTypeResult(methodOtherReturnType)
+        }
 
         // Check if the method is annotated with @Returning
         if (hasReturingOption()) {
@@ -82,7 +95,7 @@ class UpdateAnnotationReturnTypeCheckProcessor(
             PsiClassTypeUtil.convertOptionalType(returnType, project)
         val returnTypeClass = project.getJavaClazz(checkReturnType.canonicalText)
 
-        return if (returnTypeClass?.isEntity() != true || returnType.canonicalText != paramClass.type.canonicalText) {
+        return if (!validateReturnType(returnTypeClass, paramClass)) {
             ValidationReturnTypeUpdateReturningResult(
                 paramClass.type.presentableText,
                 method.nameIdentifier,
@@ -91,6 +104,23 @@ class UpdateAnnotationReturnTypeCheckProcessor(
         } else {
             null
         }
+    }
+
+    private fun validateReturnType(
+        returnTypeClass: PsiClass?,
+        paramClass: PsiParameter,
+    ): Boolean {
+        if (returnTypeClass?.isEntity() != true) return false
+
+        if (DomaClassName.OPTIONAL.isTargetClassNameStartsWith(paramClass.type.canonicalText)) {
+            val optionalType = paramClass.type as? PsiClassType
+            val optionalParam =
+                optionalType?.parameters?.firstOrNull()
+                    ?: return false
+            return optionalParam.canonicalText == paramClass.type.canonicalText
+        }
+
+        return returnTypeClass.psiClassType.canonicalText == paramClass.type.canonicalText
     }
 
     /**

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/BatchReturnTypeTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/BatchReturnTypeTestDao.java
@@ -13,6 +13,9 @@ public interface BatchReturnTypeTestDao {
     @BatchUpdate
     String <error descr="The return type must be \"int[]\"">batchUpdateReturnsString</error>(List<Packet> e);
 
+    @BatchUpdate(sqlFile = true)
+    int[] <error descr="If a method annotated with @BatchUpdate targets immutable entities for insertion, the return type must be BatchResult<Pckt>">batchUpdateImmutableReturnsIntArray</error>(List<Pckt> e);
+
     @BatchDelete
     int[] <error descr="If a method annotated with @BatchDelete targets immutable entities for insertion, the return type must be BatchResult<Pckt>">batchDeleteReturnsIntWithImmutable</error>(List<Pckt> e);
 

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/UpdateReturnTypeTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/UpdateReturnTypeTestDao.java
@@ -1,5 +1,6 @@
 package doma.example.dao.inspection.returntype;
 
+import java.util.Optional;
 import org.seasar.doma.*;
 import org.seasar.doma.jdbc.Result;
 import doma.example.entity.*;
@@ -17,10 +18,16 @@ public interface UpdateReturnTypeTestDao {
     Packet deleteReturningEntity(Packet e);
 
     @Delete(returning = @Returning)
+    Optional<Packet> deleteReturningOptionalEntity(Packet e);
+
+    @Delete(returning = @Returning)
     int <error descr="When \"returning = @Returning\" is specified, the return type must be \"Packet\" or Optional<Packet>">deleteReturningInt</error>(Packet e);
 
     @Update
     Result<Pckt> updateReturnsResultWithImmutable(Pckt e);
+
+    @Update(sqlFile = true)
+    int <error descr="If a method annotated with @Update targets immutable entities for insertion, the return type must be Result<Pckt>">deleteImmutableInt</error>(Pckt e);
 
     @Update
     int <error descr="If a method annotated with @Update targets immutable entities for insertion, the return type must be Result<Pckt>">updateReturnsIntWithImmutable</error>(Pckt e);


### PR DESCRIPTION
Fix parameter and return type checks for DAO methods with update annotations:

- When returning = @Returning is specified, allow return types of Optional<T> as long as T matches the entity type of the method parameter (avoid false error highlights).

- For update and batch annotations with SQL templates, if the method parameter is an immutable Entity class, enforce that the return type must be Result or BatchResult instead of int or int[].