### PR TITLE
Enhance the usage checks of DAO method parameters for subtypes.

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
@@ -103,11 +103,6 @@ class PsiDaoMethod(
 
     private fun getSqlAnnotation(): PsiAnnotation? = DomaAnnotationType.Sql.getPsiAnnotation(psiMethod)
 
-    fun isSelectTypeCollect(): Boolean {
-        val selectAnnotation = DomaAnnotationType.Select.getPsiAnnotation(psiMethod) ?: return false
-        return daoType.isSelectTypeCollect(selectAnnotation)
-    }
-
     fun useSqlAnnotation(): Boolean = getSqlAnnotation() != null
 
     private fun setSqlFilePath() {

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/util/DomaClassName.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/util/DomaClassName.kt
@@ -38,6 +38,7 @@ enum class DomaClassName(
     VOID("java.lang.Void"),
     RETURNING("org.seasar.doma.Returning"),
     REFERENCE("org.seasar.doma.jdbc.Reference"),
+    SELECT_OPTIONS("org.seasar.doma.jdbc.SelectOptions"),
 
     STRING("java.lang.String"),
     OBJECT("java.lang.Object"),

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/DomaAnnotationType.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/DomaAnnotationType.kt
@@ -18,9 +18,6 @@ package org.domaframework.doma.intellij.extension.psi
 import com.intellij.codeInsight.AnnotationUtil
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiModifierListOwner
-import com.intellij.psi.PsiNameValuePair
-import com.intellij.psi.PsiReferenceExpression
-import com.intellij.psi.util.PsiTreeUtil
 
 enum class DomaAnnotationType(
     val fqdn: String,
@@ -74,19 +71,4 @@ enum class DomaAnnotationType(
         } else {
             false
         }
-
-    fun isSelectTypeCollect(element: PsiAnnotation): Boolean {
-        val strategyPair =
-            PsiTreeUtil
-                .getChildrenOfTypeAsList(element.parameterList, PsiNameValuePair::class.java)
-                .firstOrNull {
-                    it.text.startsWith("strategy")
-                } ?: return false
-
-        return PsiTreeUtil
-            .getChildOfType(
-                strategyPair,
-                PsiReferenceExpression::class.java,
-            )?.text == "SelectType.COLLECT"
-    }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiParameterExtension.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiParameterExtension.kt
@@ -19,32 +19,17 @@ import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiParameter
 import org.domaframework.doma.intellij.common.util.DomaClassName
 
-val PsiParameter.isFunctionClazz: Boolean
-    get() {
-        val functionType = DomaClassName.JAVA_FUNCTION
-        val superCollection: PsiClassType? = getSuperClassType(functionType)
-        return superCollection != null
-    }
+private val ignoreUsageCheckType =
+    listOf<DomaClassName>(
+        DomaClassName.JAVA_FUNCTION,
+        DomaClassName.BI_FUNCTION,
+        DomaClassName.SELECT_OPTIONS,
+        DomaClassName.JAVA_COLLECTOR,
+    )
 
-val PsiParameter.isBiFunctionClazz: Boolean
-    get() {
-        val functionType = DomaClassName.BI_FUNCTION
-        val superCollection: PsiClassType? = getSuperClassType(functionType)
-        return superCollection != null
-    }
-
-val PsiParameter.isSelectOption: Boolean
-    get() {
-        val collectorType = DomaClassName.SELECT_OPTIONS
-        val superCollection: PsiClassType? = getSuperClassType(collectorType)
-        return superCollection != null
-    }
-
-val PsiParameter.isCollector: Boolean
-    get() {
-        val collectorType = DomaClassName.JAVA_COLLECTOR
-        val superCollection: PsiClassType? = getSuperClassType(collectorType)
-        return superCollection != null
+fun PsiParameter.isIgnoreUsageCheck(): Boolean =
+    ignoreUsageCheckType.any { type ->
+        getSuperClassType(type) != null
     }
 
 fun PsiParameter.getSuperClassType(superClassType: DomaClassName): PsiClassType? {

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiParameterExtension.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiParameterExtension.kt
@@ -17,22 +17,44 @@ package org.domaframework.doma.intellij.extension.psi
 
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiParameter
+import org.domaframework.doma.intellij.common.util.DomaClassName
 
 val PsiParameter.isFunctionClazz: Boolean
-    get() =
-        (this.typeElement?.type as? PsiClassType)
-            ?.resolve()
-            ?.qualifiedName
-            ?.contains("java.util.function") == true
+    get() {
+        val functionType = DomaClassName.JAVA_FUNCTION
+        val superCollection: PsiClassType? = getSuperClassType(functionType)
+        return superCollection != null
+    }
+
+val PsiParameter.isBiFunctionClazz: Boolean
+    get() {
+        val functionType = DomaClassName.BI_FUNCTION
+        val superCollection: PsiClassType? = getSuperClassType(functionType)
+        return superCollection != null
+    }
 
 val PsiParameter.isSelectOption: Boolean
-    get() =
-        (this.typeElement?.type as? PsiClassType)
-            ?.resolve()
-            ?.qualifiedName == "org.seasar.doma.jdbc.SelectOptions"
+    get() {
+        val collectorType = DomaClassName.SELECT_OPTIONS
+        val superCollection: PsiClassType? = getSuperClassType(collectorType)
+        return superCollection != null
+    }
 
 val PsiParameter.isCollector: Boolean
-    get() =
-        (this.typeElement?.type as? PsiClassType)
-            ?.resolve()
-            ?.qualifiedName == "java.util.stream.Collector"
+    get() {
+        val collectorType = DomaClassName.JAVA_COLLECTOR
+        val superCollection: PsiClassType? = getSuperClassType(collectorType)
+        return superCollection != null
+    }
+
+fun PsiParameter.getSuperClassType(superClassType: DomaClassName): PsiClassType? {
+    val clazzType = this.typeElement?.type as? PsiClassType
+    var superCollection: PsiClassType? = clazzType
+    while (superCollection != null &&
+        !superClassType.isTargetClassNameStartsWith(superCollection.canonicalText)
+    ) {
+        superCollection =
+            superCollection.getSuperType(superClassType.className)
+    }
+    return superCollection
+}

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/visitor/UsedDaoMethodParamInspectionVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/visitor/UsedDaoMethodParamInspectionVisitor.kt
@@ -27,10 +27,7 @@ import org.domaframework.doma.intellij.common.dao.getDaoClass
 import org.domaframework.doma.intellij.common.isJavaOrKotlinFileType
 import org.domaframework.doma.intellij.common.psi.PsiDaoMethod
 import org.domaframework.doma.intellij.extension.findFile
-import org.domaframework.doma.intellij.extension.psi.isBiFunctionClazz
-import org.domaframework.doma.intellij.extension.psi.isCollector
-import org.domaframework.doma.intellij.extension.psi.isFunctionClazz
-import org.domaframework.doma.intellij.extension.psi.isSelectOption
+import org.domaframework.doma.intellij.extension.psi.isIgnoreUsageCheck
 import org.domaframework.doma.intellij.extension.psi.methodParameters
 
 class UsedDaoMethodParamInspectionVisitor(
@@ -45,8 +42,7 @@ class UsedDaoMethodParamInspectionVisitor(
         if (!psiDaoMethod.useSqlAnnotation() && !psiDaoMethod.isUseSqlFileMethod()) return
 
         val methodParameters =
-            method.methodParameters
-                .filter { !it.isFunctionClazz && !it.isBiFunctionClazz && !it.isSelectOption && !it.isCollector }
+            method.methodParameters.filter { !it.isIgnoreUsageCheck() }
         val sqlFileManager =
             psiDaoMethod.sqlFile?.let {
                 method.project.findFile(it)

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/visitor/UsedDaoMethodParamInspectionVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/visitor/UsedDaoMethodParamInspectionVisitor.kt
@@ -27,6 +27,7 @@ import org.domaframework.doma.intellij.common.dao.getDaoClass
 import org.domaframework.doma.intellij.common.isJavaOrKotlinFileType
 import org.domaframework.doma.intellij.common.psi.PsiDaoMethod
 import org.domaframework.doma.intellij.extension.findFile
+import org.domaframework.doma.intellij.extension.psi.isBiFunctionClazz
 import org.domaframework.doma.intellij.extension.psi.isCollector
 import org.domaframework.doma.intellij.extension.psi.isFunctionClazz
 import org.domaframework.doma.intellij.extension.psi.isSelectOption
@@ -45,7 +46,7 @@ class UsedDaoMethodParamInspectionVisitor(
 
         val methodParameters =
             method.methodParameters
-                .filter { !it.isFunctionClazz && !it.isSelectOption && !(it.isCollector && psiDaoMethod.isSelectTypeCollect()) }
+                .filter { !it.isFunctionClazz && !it.isBiFunctionClazz && !it.isSelectOption && !it.isCollector }
         val sqlFileManager =
             psiDaoMethod.sqlFile?.let {
                 method.project.findFile(it)

--- a/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/DomaUseVariableTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/DomaUseVariableTest.kt
@@ -36,7 +36,14 @@ class DomaUseVariableTest : DomaSqlTest() {
             "$testDaoName/collectDoesCauseError.sql",
             "$testDaoName/noErrorWhenUsedInFunctionParameters.sql",
             "$testDaoName/duplicateForDirectiveDefinitionNames.sql",
+            "$testDaoName/selectHogeFunction.sql",
+            "$testDaoName/functionDoesNotCauseError.sql",
+            "$testDaoName/selectHogeCollector.sql",
         )
+        addOtherJavaFile("collector", "HogeCollector.java")
+        addOtherJavaFile("function", "HogeFunction.java")
+        addOtherJavaFile("function", "HogeBiFunction.java")
+        addOtherJavaFile("option", "HogeSelectOptions.java")
         myFixture.enableInspections(UsedDaoMethodParamInspection())
     }
 

--- a/src/test/testData/src/main/java/doma/example/dao/DaoMethodVariableInspectionTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/DaoMethodVariableInspectionTestDao.java
@@ -17,7 +17,12 @@ import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.PreparedSql;
 import org.seasar.doma.jdbc.SelectOptions;
 import org.seasar.doma.SelectType;
+import java.util.stream.Stream;
+import java.util.function.Function;
 import java.util.stream.Collector;
+import doma.example.function.*;
+import doma.example.collector.*;
+import doma.example.option.*;
 
 import java.util.List;
 import java.util.function.BiFunction;
@@ -38,20 +43,52 @@ interface DaoMethodVariableInspectionTestDao {
   @SqlProcessor
   <R> R biFunctionDoesNotCauseError(Integer id, BiFunction<Config, PreparedSql, R> handler);
 
+  @SqlProcessor
+  @Sql("SELECT id, name FROM demo")
+  <R> R biFunctionHogeFunction(HogeBiFunction handler);
+
   @Select
-  Project selectOptionDoesNotCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,String searchName,SelectOptions options);
+  Project selectOptionDoesNotCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,
+      String searchName,
+      SelectOptions options);
+
+  @Select
+  @Sql("SELECT * FROM project WHERE name = /* searchName */'test'")
+  Project selectHogeOption(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,
+      String searchName,
+      HogeSelectOptions options);
 
   @Select(strategy = SelectType.COLLECT)
-  Project collectDoesNotCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,Integer id,Collector<Project, ?, Project> collector);
+  Project collectDoesNotCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,
+      Integer id,
+      Collector<Project, ?, Project> collector);
+
+  @Select(strategy = SelectType.COLLECT)
+  Project selectHogeCollector(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,
+      Integer id,
+      HogeCollector collector);
 
   @Select
-  Project collectDoesCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,String searchName,Collector<Project, ?, Project> <error descr="There are unused parameters in the SQL [collector]">collector</error>);
+  Project collectDoesCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,
+      String searchName,
+      Collector<Project, ?, Project> collector);
+
+  @Select(strategy = SelectType.STREAM)
+  String functionDoesNotCauseError(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,
+      Integer id,
+      Function<Stream<Employee>, String> function);
+
+  @Select(strategy = SelectType.STREAM)
+  String selectHogeFunction(Employee <error descr="There are unused parameters in the SQL [employee]">employee</error>,
+      Integer id,
+      HogeFunction function);
 
   @Select
   Project noErrorWhenUsedInFunctionParameters(Employee employee, Integer count);
 
   @Select
-  Employee duplicateForDirectiveDefinitionNames(Employee <error descr="An element name that is a duplicate of an element name defined in SQL is used">member</error>, Integer <error descr="There are unused parameters in the SQL [count]">count</error>,
+  Employee duplicateForDirectiveDefinitionNames(Employee <error descr="An element name that is a duplicate of an element name defined in SQL is used">member</error>,
+      Integer <error descr="There are unused parameters in the SQL [count]">count</error>,
       List<Employee> users,
       String searchName,
       Boolean inForm);

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/SelectReturnTypeTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/SelectReturnTypeTestDao.java
@@ -129,7 +129,7 @@ public interface SelectReturnTypeTestDao {
 
   @Select(strategy = SelectType.COLLECT)
   @Sql("select * from emp where salary > /* salary */0")
-  Pckt selectHogeCollect(BigDecimal salary, HogeCollector collector);
+  Pckt <error descr="The return type must match RESULT of the \"java.util.stream.Collector\" type parameter">selectHogeCollect</error>(BigDecimal salary, HogeCollector collector);
 
   @Select(strategy = SelectType.STREAM)
   @Sql("select * from emp where salary > /* salary */0")

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/SelectReturnTypeTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/SelectReturnTypeTestDao.java
@@ -129,7 +129,7 @@ public interface SelectReturnTypeTestDao {
 
   @Select(strategy = SelectType.COLLECT)
   @Sql("select * from emp where salary > /* salary */0")
-  Pckt <error descr="The return type must match RESULT of the \"java.util.stream.Collector\" type parameter">selectHogeCollect</error>(BigDecimal salary, HogeCollector collector);
+  Pckt selectHogeCollect(BigDecimal salary, HogeCollector collector);
 
   @Select(strategy = SelectType.STREAM)
   @Sql("select * from emp where salary > /* salary */0")

--- a/src/test/testData/src/main/java/doma/example/function/HogeBiFunction.java
+++ b/src/test/testData/src/main/java/doma/example/function/HogeBiFunction.java
@@ -1,0 +1,17 @@
+package doma.example.function;
+
+import org.seasar.doma.jdbc.Config;
+import org.seasar.doma.jdbc.PreparedSql;
+
+import java.io.ObjectInputFilter;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class HogeBiFunction implements BiFunction<Config, PreparedSql, String> {
+
+  @Override
+  public String apply(Config config, PreparedSql preparedSql) {
+    return "";
+  }
+}

--- a/src/test/testData/src/main/java/doma/example/option/HogeSelectOptions.java
+++ b/src/test/testData/src/main/java/doma/example/option/HogeSelectOptions.java
@@ -1,0 +1,6 @@
+package doma.example.option;
+
+import org.seasar.doma.jdbc.SelectOptions;
+
+public class HogeSelectOptions extends SelectOptions {
+}

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/DaoMethodVariableInspectionTestDao/functionDoesNotCauseError.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/DaoMethodVariableInspectionTestDao/functionDoesNotCauseError.sql
@@ -1,0 +1,6 @@
+select
+ p.project_id
+ , p.project_name
+ , p.project_number
+from project p
+where p.project_id = /* id */0

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/DaoMethodVariableInspectionTestDao/selectHogeCollector.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/DaoMethodVariableInspectionTestDao/selectHogeCollector.sql
@@ -1,0 +1,6 @@
+select
+ p.project_id
+ , p.project_name
+ , p.project_number
+from project p
+where p.project_id = /* id */0

--- a/src/test/testData/src/main/resources/META-INF/doma/example/dao/DaoMethodVariableInspectionTestDao/selectHogeFunction.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/example/dao/DaoMethodVariableInspectionTestDao/selectHogeFunction.sql
@@ -1,0 +1,6 @@
+select
+ p.project_id
+ , p.project_name
+ , p.project_number
+from project p
+where p.project_id = /* id */0


### PR DESCRIPTION
Exclude parameters defined in subtypes of unused types in the SQL template from error highlighting in DAO methods:

- Function 
- Collector 
- BiFunction
- SelectOptions