### PR TITLE
Establish formatting rules for consecutive AND / OR clauses

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
@@ -260,36 +260,11 @@ open class SqlBlock(
                         return@setParentGroups lastGroupBlock
                     }
                 } else if (lastIndentLevel == childBlock.indent.indentLevel) {
-                    // The AND following an OR will be a child of OR unless surrounded by a subgroup
-                    if (childBlock.getNodeText() == "and" && lastGroupBlock.getNodeText() == "or") {
-                        setParentGroups(
-                            childBlock,
-                        ) { history ->
-                            return@setParentGroups lastGroupBlock
-                        }
-                    } else {
-                        if (childBlock.getNodeText() == "or" &&
-                            lastGroupBlock.getNodeText() == "and" &&
-                            lastGroupBlock.parentBlock?.getNodeText() == "or"
-                        ) {
-                            val orParentIndex =
-                                blockBuilder.getGroupTopNodeIndex { block ->
-                                    block is SqlKeywordGroupBlock && block.getNodeText() == "or"
-                                }
-                            blockBuilder.clearSubListGroupTopNodeIndexHistory(orParentIndex)
-                            setParentGroups(
-                                childBlock,
-                            ) { history ->
-                                return@setParentGroups history.lastOrNull()?.second
-                            }
-                        } else {
-                            blockBuilder.removeLastGroupTopNodeIndexHistory()
-                            setParentGroups(
-                                childBlock,
-                            ) { history ->
-                                return@setParentGroups lastGroupBlock.parentBlock
-                            }
-                        }
+                    blockBuilder.removeLastGroupTopNodeIndexHistory()
+                    setParentGroups(
+                        childBlock,
+                    ) { history ->
+                        return@setParentGroups lastGroupBlock.parentBlock
                     }
                 } else if (lastIndentLevel < childBlock.indent.indentLevel) {
                     setParentGroups(

--- a/src/test/testData/sql/formatter/FormattedSelect.sql
+++ b/src/test/testData/sql/formatter/FormattedSelect.sql
@@ -29,13 +29,14 @@ SELECT COUNT(DISTINCT (x))
              -- Line3
              OR (p.flags & DBO.FPHOTOFLAGS('EDGE') = 0
                  AND (p.psfmag_g - p.extinction_g) BETWEEN 15 AND 20)
-                /*%if status == 2 */
-                -- Line4
-                AND u.propermotion > 2.
-                /** And  Group */
-                AND (p.psfmag_g - p.extinction_g + 5 * LOG(u.propermotion / 100.) + 5 > 16.136 + 2.727 * (p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i))
-                      OR p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i) < 0.)
-                /*%end*/ ) AS o
+            /*%if status == 2 */
+            -- Line4
+            AND u.propermotion > 2.
+            /** And  Group */
+            AND (p.psfmag_g - p.extinction_g + 5 * LOG(u.propermotion / 100.) + 5 > 16.136 + 2.727 * (p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i))
+                  OR p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i) < 0.
+                 AND p.extinction_g - u.propermotion > 0)
+            /*%end*/ ) AS o
        LEFT OUTER JOIN ( SELECT n.objid
                                 , MIN(n.distance) AS nearest
                            FROM neighbors n
@@ -43,13 +44,13 @@ SELECT COUNT(DISTINCT (x))
                                   ON n.neighborobjid = x.objid
                                  AND n.neighbormode = DBO.FPHOTOMODE('Primary')
                                   OR n.MODE = /*# "active" */'mode'
-                                     AND n.status = 2
-                                     AND n.flag = true
+                                 AND n.status = 2
+                                 AND n.flag = true
                           WHERE n.TYPE = DBO.FPHOTOTYPE('Star')
                             AND n.MODE = DBO.FPHOTOMODE('Primary')
                              OR n.neighbormode = DBO.FPHOTOMODE('Primary')
-                                AND (x.TYPE = DBO.FPHOTOTYPE('Star')
-                                     AND x.TYPE = DBO.FPHOTOTYPE('Galaxy'))
+                            AND (x.TYPE = DBO.FPHOTOTYPE('Star')
+                                 AND x.TYPE = DBO.FPHOTOTYPE('Galaxy'))
                              OR x.modelmag_g BETWEEN 10 AND 21
                           GROUP BY n.objid ) AS nbor
                     ON o.objid = nbor.objid

--- a/src/test/testData/sql/formatter/Select.sql
+++ b/src/test/testData/sql/formatter/Select.sql
@@ -35,7 +35,9 @@ SELECT COUNT( DISTINCT (x)),o.*
             /** And  Group */
             AND (p.psfmag_g - p.extinction_g + 5 * LOG(u.propermotion / 100.) + 5 > 16.136 + 2.727 * (p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i))
 
-                  OR p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i) < 0.)/*%end*/) AS o
+                  OR p.psfmag_g - p.extinction_g - (p.psfmag_i - p.extinction_i) < 0. AND p.extinction_g - u.propermotion > 0)
+                 
+                /*%end*/) AS o
 
        LEFT OUTER JOIN ( SELECT n.objid
                                 , MIN(n.distance) AS nearest


### PR DESCRIPTION
Modify the logic so that keywords such as OR and AND are right-aligned, regardless of their order or combination.