### PR TITLE
Ensure Correct SQL File Path Generation When Package Name Matches Source Directory

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
@@ -218,12 +218,12 @@ fun getRelativeSqlFilePathFromDaoFilePath(
     val pathParams = CommonPathParameterUtil.getModulePaths(module)
     var relativeSqlFilePath =
         daoFile.path
-            .replace(pathParams.moduleBasePath?.path ?: "", "")
+            .replaceFirst(pathParams.moduleBasePath?.path ?: "", "")
             .replace(".$extension", "")
     val sources = CommonPathParameterUtil.getSources(module, daoFile)
     sources.forEach { source ->
         relativeSqlFilePath =
-            relativeSqlFilePath.replace(
+            relativeSqlFilePath.replaceFirst(
                 "/" + source.nameWithoutExtension,
                 RESOURCES_META_INF_PATH,
             )

--- a/src/test/kotlin/org/domaframework/doma/intellij/DomaSqlTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/DomaSqlTest.kt
@@ -207,12 +207,20 @@ open class DomaSqlTest : LightJavaCodeInsightFixtureTestCase() {
 
     fun addSqlFile(vararg sqlNames: String) {
         for (sqlName in sqlNames) {
-            val file = File("$testDataPath/$resourceRoot/$RESOURCES_META_INF_PATH/$packagePath/dao/$sqlName")
-            myFixture.addFileToProject(
-                "main/$resourceRoot/$RESOURCES_META_INF_PATH/$packagePath/dao/$sqlName",
-                file.readText(),
-            )
+            addOtherPackageSqlFile("$packagePath/dao", sqlName)
         }
+    }
+
+    fun addOtherPackageSqlFile(
+        packageName: String,
+        sqlName: String,
+    ) {
+        val sqlPath = "$resourceRoot/$RESOURCES_META_INF_PATH/$packageName/$sqlName"
+        val file = File("$testDataPath/$sqlPath")
+        myFixture.addFileToProject(
+            "main/$sqlPath",
+            file.readText(),
+        )
     }
 
     fun findSqlFile(sqlName: String): VirtualFile? = findSqlFile(packagePath, sqlName)

--- a/src/test/kotlin/org/domaframework/doma/intellij/DomaSqlTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/DomaSqlTest.kt
@@ -173,9 +173,17 @@ open class DomaSqlTest : LightJavaCodeInsightFixtureTestCase() {
         packageName: String,
         fileName: String,
     ) {
-        val file = File("$testDataPath/$sourceRoot/$packagePath/$packageName/$fileName")
+        val originalPackageName = "$packagePath/$packageName"
+        addOtherPackageJavaFile(originalPackageName, fileName)
+    }
+
+    protected fun addOtherPackageJavaFile(
+        packageName: String,
+        fileName: String,
+    ) {
+        val file = File("$testDataPath/$sourceRoot/$packageName/$fileName")
         myFixture.addFileToProject(
-            "main/$sourceRoot/$packagePath/$packageName/$fileName",
+            "main/$sourceRoot/$packageName/$fileName",
             file.readText(),
         )
     }
@@ -207,18 +215,29 @@ open class DomaSqlTest : LightJavaCodeInsightFixtureTestCase() {
         }
     }
 
-    fun findSqlFile(sqlName: String): VirtualFile? {
+    fun findSqlFile(sqlName: String): VirtualFile? = findSqlFile(packagePath, sqlName)
+
+    fun findSqlFile(
+        packageName: String,
+        sqlName: String,
+    ): VirtualFile? {
         val module = myFixture.module
+        val sqlFileName = "$RESOURCES_META_INF_PATH/$packageName/dao/$sqlName"
         return module?.getResourcesSQLFile(
-            "$RESOURCES_META_INF_PATH/$packagePath/dao/$sqlName",
+            sqlFileName,
             false,
         )
     }
 
-    fun findDaoClass(testDaoName: String): PsiClass {
-        val daoName = testDaoName.replace("/", ".")
-        val dao = myFixture.findClass("doma.example.dao.$daoName")
-        assertNotNull("Not Found [$testDaoName]", dao)
+    fun findDaoClass(testDaoName: String): PsiClass = findDaoClass("doma.example.dao", testDaoName)
+
+    fun findDaoClass(
+        packageName: String,
+        testDaoName: String,
+    ): PsiClass {
+        val daoName = "$packageName.$testDaoName".replace("/", ".")
+        val dao = myFixture.findClass(daoName)
+        assertNotNull("Not Found [$daoName]", dao)
         return dao
     }
 

--- a/src/test/kotlin/org/domaframework/doma/intellij/gutteraction/dao/DaoGutterActionTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/gutteraction/dao/DaoGutterActionTest.kt
@@ -20,6 +20,7 @@ import com.intellij.codeInsight.daemon.GutterMark
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import org.domaframework.doma.intellij.DomaSqlTest
 import org.domaframework.doma.intellij.bundle.MessageBundle
@@ -72,76 +73,86 @@ class DaoGutterActionTest : DomaSqlTest() {
             "$packageName/BatchUpdateGutterTestDao/existsSQLFile3.sql",
             "$packageName/BatchDeleteGutterTestDao/existsSQLFile3.sql",
         )
+
+        addOtherPackageJavaFile("doma/java/dao", "SourceNameDao.java")
+        addOtherPackageSqlFile("doma/java/dao", "SourceNameDao/existsSQLFile1.sql")
     }
 
     fun testSelectDisplayGutter() {
         val daoName = "$packageName.SelectGutterTestDao"
         val total = 2
-        val targetGutter = gutterIconsDisplayedTest(daoName, total)
+        val targetGutter = gutterIconsDisplayedTest(findDaoClass(daoName), total)
         gutterIconNavigation("existsSQLFile1.sql", targetGutter)
     }
 
     fun testInsertDisplayGutter() {
         val daoName = "$packageName.InsertGutterTestDao"
         val total = 2
-        val targetGutter = gutterIconsDisplayedTest(daoName, total)
+        val targetGutter = gutterIconsDisplayedTest(findDaoClass(daoName), total)
         gutterIconNavigation("existsSQLFile1.sql", targetGutter)
     }
 
     fun testUpdateDisplayGutter() {
         val daoName = "$packageName.UpdateGutterTestDao"
         val total = 2
-        val targetGutter = gutterIconsDisplayedTest(daoName, total)
+        val targetGutter = gutterIconsDisplayedTest(findDaoClass(daoName), total)
         gutterIconNavigation("existsSQLFile1.sql", targetGutter)
     }
 
     fun testDeleteDisplayGutter() {
         val daoName = "$packageName.DeleteGutterTestDao"
         val total = 1
-        val targetGutter = gutterIconsDisplayedTest(daoName, total)
+        val targetGutter = gutterIconsDisplayedTest(findDaoClass(daoName), total)
         gutterIconNavigation("existsSQLFile1.sql", targetGutter)
     }
 
     fun testBatchInsertDisplayGutter() {
         val daoName = "$packageName.BatchInsertGutterTestDao"
         val total = 3
-        val targetGutter = gutterIconsDisplayedTest(daoName, total)
+        val targetGutter = gutterIconsDisplayedTest(findDaoClass(daoName), total)
         gutterIconNavigation("existsSQLFile1.sql", targetGutter)
     }
 
     fun testBatchUpdateDisplayGutter() {
         val daoName = "$packageName.BatchUpdateGutterTestDao"
         val total = 3
-        val targetGutter = gutterIconsDisplayedTest(daoName, total)
+        val targetGutter = gutterIconsDisplayedTest(findDaoClass(daoName), total)
         gutterIconNavigation("existsSQLFile1.sql", targetGutter)
     }
 
     fun testBatchDeleteDisplayGutter() {
         val daoName = "$packageName.BatchDeleteGutterTestDao"
         val total = 2
-        val targetGutter = gutterIconsDisplayedTest(daoName, total)
+        val targetGutter = gutterIconsDisplayedTest(findDaoClass(daoName), total)
         gutterIconNavigation("existsSQLFile1.sql", targetGutter)
     }
 
     fun testScriptDisplayGutter() {
         val daoName = "$packageName.ScriptGutterTestDao"
         val total = 2
-        val targetGutter = gutterIconsDisplayedTest(daoName, total)
+        val targetGutter = gutterIconsDisplayedTest(findDaoClass(daoName), total)
         gutterIconNavigation("existsSQLFile1.script", targetGutter)
     }
 
     fun testSqlProcessorDisplayGutter() {
         val daoName = "$packageName.SqlProcessorGutterTestDao"
         val total = 2
-        val targetGutter = gutterIconsDisplayedTest(daoName, total)
+        val targetGutter = gutterIconsDisplayedTest(findDaoClass(daoName), total)
+        gutterIconNavigation("existsSQLFile1.sql", targetGutter)
+    }
+
+    fun testSourceDirectoryDisplayGutter() {
+        val originalPackageName = "doma.java.dao"
+        val daoName = "SourceNameDao"
+        val total = 1
+        val targetGutter = gutterIconsDisplayedTest(findDaoClass(originalPackageName, daoName), total)
         gutterIconNavigation("existsSQLFile1.sql", targetGutter)
     }
 
     private fun gutterIconsDisplayedTest(
-        daoName: String,
+        dao: PsiClass,
         total: Int,
     ): LineMarkerInfo<*>? {
-        val dao = findDaoClass(daoName)
         val targetElementNames = listOf("existsSQLFile1", "existsSQLFile2", "existsSQLFile3")
 
         myFixture.configureFromExistingVirtualFile(dao.containingFile.virtualFile)

--- a/src/test/kotlin/org/domaframework/doma/intellij/gutteraction/dao/DaoJumpActionTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/gutteraction/dao/DaoJumpActionTest.kt
@@ -24,6 +24,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.psi.PsiClass
 import org.domaframework.doma.intellij.DomaSqlTest
 import java.awt.event.InputEvent
 import java.awt.event.MouseEvent
@@ -83,12 +84,15 @@ class DaoJumpActionTest : DomaSqlTest() {
             "$packageName/ScriptGutterTestDao/existsSQLFile2.script",
             "$packageName/SqlProcessorGutterTestDao/existsSQLFile2.sql",
         )
+
+        addOtherPackageJavaFile("doma/java/dao", "SourceNameDao.java")
+        addOtherPackageSqlFile("doma/java/dao", "SourceNameDao/jumpToDaoFile.sql")
     }
 
     fun testSelectJumpToSqlAction() {
         val daoName = "$packageName.SelectGutterTestDao"
         val sqlFileName = "existsSQLFile1.sql"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isDisplayedActionTest(action)
         jumpToSqlTest(action, sqlFileName)
     }
@@ -96,7 +100,7 @@ class DaoJumpActionTest : DomaSqlTest() {
     fun testInsertJumpToSqlAction() {
         val daoName = "$packageName.InsertGutterTestDao"
         val sqlFileName = "existsSQLFile2.sql"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isDisplayedActionTest(action)
         jumpToSqlTest(action, sqlFileName)
     }
@@ -104,7 +108,7 @@ class DaoJumpActionTest : DomaSqlTest() {
     fun testUpdateJumpToSqlAction() {
         val daoName = "$packageName.UpdateGutterTestDao"
         val sqlFileName = "existsSQLFile1.sql"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isDisplayedActionTest(action)
         jumpToSqlTest(action, sqlFileName)
     }
@@ -112,7 +116,7 @@ class DaoJumpActionTest : DomaSqlTest() {
     fun testDeleteJumpToSqlAction() {
         val daoName = "$packageName.DeleteGutterTestDao"
         val sqlFileName = "existsSQLFile1.sql"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isDisplayedActionTest(action)
         jumpToSqlTest(action, sqlFileName)
     }
@@ -120,7 +124,7 @@ class DaoJumpActionTest : DomaSqlTest() {
     fun testBatchInsertJumpToSqlAction() {
         val daoName = "$packageName.BatchInsertGutterTestDao"
         val sqlFileName = "existsSQLFile2.sql"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isDisplayedActionTest(action)
         jumpToSqlTest(action, sqlFileName)
     }
@@ -128,7 +132,7 @@ class DaoJumpActionTest : DomaSqlTest() {
     fun testBatchUpdateJumpToSqlAction() {
         val daoName = "$packageName.BatchUpdateGutterTestDao"
         val sqlFileName = "existsSQLFile2.sql"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isDisplayedActionTest(action)
         jumpToSqlTest(action, sqlFileName)
     }
@@ -136,7 +140,7 @@ class DaoJumpActionTest : DomaSqlTest() {
     fun testBatchDeleteJumpToSqlAction() {
         val daoName = "$packageName.BatchDeleteGutterTestDao"
         val sqlFileName = "existsSQLFile2.sql"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isDisplayedActionTest(action)
         jumpToSqlTest(action, sqlFileName)
     }
@@ -144,7 +148,7 @@ class DaoJumpActionTest : DomaSqlTest() {
     fun testScriptJumpToSqlAction() {
         val daoName = "$packageName.ScriptGutterTestDao"
         val sqlFileName = "existsSQLFile2.script"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isDisplayedActionTest(action)
         jumpToSqlTest(action, sqlFileName)
     }
@@ -152,83 +156,90 @@ class DaoJumpActionTest : DomaSqlTest() {
     fun testSqlProcessorJumpToSqlAction() {
         val daoName = "$packageName.SqlProcessorGutterTestDao"
         val sqlFileName = "existsSQLFile1.sql"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
+        isDisplayedActionTest(action)
+        jumpToSqlTest(action, sqlFileName)
+    }
+
+    fun testSourceNameJumpToSql() {
+        val daoName = "SourceNameDao"
+        val sqlFileName = "jumpToDaoFile.sql"
+        val action: AnAction = getActionTest(findDaoClass("doma.java.dao", daoName))
         isDisplayedActionTest(action)
         jumpToSqlTest(action, sqlFileName)
     }
 
     fun testSelectNotDisplayJumpToSql() {
         val daoName = "$packageName.SelectInvalidCaretTestDao"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isNotDisplayedActionTest(action)
         canSqlTest(action, "nonExistSQLFile.sql")
     }
 
     fun testInsertNotDisplayJumpToSql() {
         val daoName = "$packageName.InsertInvalidCaretTestDao"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isNotDisplayedActionTest(action)
         canSqlTest(action, "nonExistSQLFileAndTemplateIncludedList.sql")
     }
 
     fun testUpdateNotDisplayJumpToSql() {
         val daoName = "$packageName.UpdateInvalidCaretTestDao"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isNotDisplayedActionTest(action)
         canSqlTest(action, "nonRequireSQLFile.sql")
     }
 
     fun testDeleteNotDisplayJumpToSql() {
         val daoName = "$packageName.DeleteInvalidCaretTestDao"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isNotDisplayedActionTest(action)
         canSqlTest(action, "nonRequireSQLFile.sql")
     }
 
     fun testBatchInsertNotDisplayJumpToSql() {
         val daoName = "$packageName.BatchInsertInvalidCaretTestDao"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isNotDisplayedActionTest(action)
         canSqlTest(action, "nonExistSQLFileError.sql")
     }
 
     fun testBatchUpdateNotDisplayJumpToSql() {
         val daoName = "$packageName.BatchUpdateInvalidCaretTestDao"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isNotDisplayedActionTest(action)
         canSqlTest(action, "nonExistSQLFileAndTemplateIncludedList.sql")
     }
 
     fun testBatchDeleteNotDisplayJumpToSql() {
         val daoName = "$packageName.BatchDeleteInvalidCaretTestDao"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isNotDisplayedActionTest(action)
         canSqlTest(action, "nonRequireSQLFile.sql")
     }
 
     fun testScriptNotDisplayJumpToSql() {
         val daoName = "$packageName.ScriptInvalidCaretTestDao"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isNotDisplayedActionTest(action)
         canSqlTest(action, "nonExistSQLFileAndTemplateIncludedList.script")
     }
 
     fun testSqlProcessorNotDisplayJumpToSql() {
         val daoName = "$packageName.SqlProcessorInvalidCaretTestDao"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isNotDisplayedActionTest(action)
         canSqlTest(action, "nonExistSQLFile.sql")
     }
 
     fun testSqlNotDisplayJumpToSql() {
         val daoName = "$packageName.InvalidCaretTestDao"
-        val action: AnAction = getActionTest(daoName)
+        val action: AnAction = getActionTest(findDaoClass(daoName))
         isNotDisplayedActionTest(action)
         canSqlTest(action, "nonExistSQLFile.sql")
     }
 
-    private fun getActionTest(daoName: String): AnAction {
-        val dao = findDaoClass(daoName)
+    private fun getActionTest(dao: PsiClass): AnAction {
         myFixture.configureFromExistingVirtualFile(dao.containingFile.virtualFile)
 
         val action: AnAction = ActionManager.getInstance().getAction(actionId)

--- a/src/test/kotlin/org/domaframework/doma/intellij/gutteraction/sql/SqlGutterActionTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/gutteraction/sql/SqlGutterActionTest.kt
@@ -20,6 +20,7 @@ import com.intellij.codeInsight.daemon.GutterMark
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import org.domaframework.doma.intellij.DomaSqlTest
 import org.domaframework.doma.intellij.bundle.MessageBundle
@@ -38,29 +39,40 @@ class SqlGutterActionTest : DomaSqlTest() {
             "$packageName/JumpActionTestDao/jumpToDaoFile.sql",
             "$packageName/JumpActionTestDao/notDisplayGutterWithNonExistentDaoMethod.sql",
         )
+        addOtherPackageJavaFile("doma/java/dao", "SourceNameDao.java")
+        addOtherPackageSqlFile("doma/java/dao", "SourceNameDao/jumpToDaoFile.sql")
     }
 
     fun testSqlDisplayGutter() {
         val sqlName = "$packageName/JumpActionTestDao/jumpToDaoFile.sql"
         val total = 1
-        val targetGutter = gutterIconsDisplayedTest(sqlName, total)
+        val targetGutter = gutterIconsDisplayedTest(findSqlFile(sqlName), total)
         gutterIconNavigation("JumpActionTestDao.java", targetGutter)
     }
 
     fun testSqlNonDisplayGutter() {
         val sqlName = "$packageName/JumpActionTestDao/notDisplayGutterWithNonExistentDaoMethod.sql"
         val total = 0
-        val targetGutter = gutterIconsDisplayedTest(sqlName, total)
+        val targetGutter = gutterIconsDisplayedTest(findSqlFile(sqlName), total)
         assertNull("Gutter is displayed", targetGutter)
     }
 
+    fun testSourceDirectoryPackageGutter() {
+        val packageName = "doma/java"
+        val sqlName = "SourceNameDao/jumpToDaoFile.sql"
+        val total = 1
+        val targetGutter = gutterIconsDisplayedTest(findSqlFile(packageName, sqlName), total)
+        gutterIconNavigation("SourceNameDao.java", targetGutter)
+    }
+
     private fun gutterIconsDisplayedTest(
-        sqlName: String,
+        sql: VirtualFile?,
         total: Int,
     ): LineMarkerInfo<*>? {
-        val sql = findSqlFile(sqlName)
-        assertNotNull("Not Found SQL File", sql)
-        if (sql == null) return null
+        if (sql == null) {
+            fail("Not Found SQL File")
+            return null
+        }
 
         myFixture.configureFromExistingVirtualFile(sql)
         myFixture.doHighlighting()

--- a/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/DomaSqlQuickFixTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/DomaSqlQuickFixTest.kt
@@ -40,7 +40,7 @@ class DomaSqlQuickFixTest : DomaSqlTest() {
             "$packagename/SqlProcessorQuickFixTestDao.java",
         )
 
-        addOtherPackageJavaFile("doma/java/dao", "SourceNameDao.java")
+        addOtherPackageJavaFile("doma/java/dao", "SourceNameGenerateDao.java")
 
         addResourceEmptySqlFile(
             "$packagename/SelectQuickFixTestDao/existsSQLFile.sql",
@@ -119,9 +119,9 @@ class DomaSqlQuickFixTest : DomaSqlTest() {
         }
     }
 
-    fun testSourceNameDaoGenerateSQLFileQuickFix() {
+    fun testSourceNameGenerateDaoGenerateSQLFileQuickFix() {
         val originalPackageName = "doma/java"
-        val testDaoName = "SourceNameDao"
+        val testDaoName = "SourceNameGenerateDao"
         daoQuickFixTestOtherPackage(originalPackageName, testDaoName) { virtual ->
             highlightingDao(virtual)
         }

--- a/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/DomaSqlQuickFixTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/DomaSqlQuickFixTest.kt
@@ -172,9 +172,7 @@ class DomaSqlQuickFixTest : DomaSqlTest() {
         val extension = if (isScript) "script" else "sql"
         findSqlFile(packageName, "$testDaoName/generateSQLFile.$extension")?.let { generatedSql ->
             afterCheck(generatedSql)
-        } ?: {
-            fail("Not Found SQL File: $packageName/$testDaoName/generateSQLFile.$extension")
-        }
+        } ?: fail("Not Found SQL File: $packageName/$testDaoName/generateSQLFile.$extension")
     }
 
     private fun getQuickFixTestDaoName(daoName: String): String = "$packagename/$daoName"

--- a/src/test/testData/src/main/java/doma/example/dao/quickfix/BatchDeleteQuickFixTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/quickfix/BatchDeleteQuickFixTestDao.java
@@ -8,15 +8,11 @@ import org.seasar.doma.Dao;
 @Dao
 public interface BatchDeleteQuickFixTestDao {
 
-
-
   @BatchDelete
   int[] nonExistSQLFile(List<Employee> employees);
 
-
   @BatchDelete(sqlFile = true)
   int[] generateSQLFile<caret>(List<Employee> employees);
-
 
   @BatchDelete(sqlFile = true)
   int[] existsSQLFile(List<Employee> employees);

--- a/src/test/testData/src/main/java/doma/java/dao/SourceNameDao.java
+++ b/src/test/testData/src/main/java/doma/java/dao/SourceNameDao.java
@@ -1,0 +1,10 @@
+package doma.java.dao;
+
+import doma.example.entity.*;
+import org.seasar.doma.*;
+
+@Dao
+interface SourceNameDao {
+  @Select
+  Employee generateSQLFile<caret>(Integer id,String name);
+}

--- a/src/test/testData/src/main/java/doma/java/dao/SourceNameDao.java
+++ b/src/test/testData/src/main/java/doma/java/dao/SourceNameDao.java
@@ -6,5 +6,11 @@ import org.seasar.doma.*;
 @Dao
 interface SourceNameDao {
   @Select
-  Employee generateSQLFile<caret>(Integer id,String name);
+  Employee generateSQLFile(Integer id,String name);
+
+  @Select
+  Employee <caret>jumpToDaoFile(Integer id);
+
+  @Select
+  Employee existsSQLFile1(Integer id, String name);
 }

--- a/src/test/testData/src/main/java/doma/java/dao/SourceNameGenerateDao.java
+++ b/src/test/testData/src/main/java/doma/java/dao/SourceNameGenerateDao.java
@@ -1,0 +1,11 @@
+package doma.java.dao;
+
+import doma.example.entity.*;
+import org.seasar.doma.*;
+
+@Dao
+interface SourceNameGenerateDao {
+  @Select
+  Employee generateSQLFile<caret>(Integer id,String name);
+
+}

--- a/src/test/testData/src/main/resources/META-INF/doma/java/dao/SourceNameDao/existsSQLFile1.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/java/dao/SourceNameDao/existsSQLFile1.sql
@@ -1,0 +1,2 @@
+-- Gutter, jump to SourceNameDao.java with action call
+select * from emp where id = /*id*/1 and name = /*name*/'name'<caret>

--- a/src/test/testData/src/main/resources/META-INF/doma/java/dao/SourceNameDao/jumpToDaoFile.sql
+++ b/src/test/testData/src/main/resources/META-INF/doma/java/dao/SourceNameDao/jumpToDaoFile.sql
@@ -1,0 +1,2 @@
+-- Gutter, jump to SourceNameDao.java with action call
+select * from emp where id = /*id*/1<caret>


### PR DESCRIPTION
Replaced replace(...) with replaceFirst(...) in SQL file path generation logic to ensure only the first occurrence of the source directory name (e.g., "java/") is removed.

This ensures SQL files are generated under the correct META-INF path even when the package contains source folder names.