### PR TITLE
Enable SQL File Generation in Multi-Module Projects

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/CommonPathParameter.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/CommonPathParameter.kt
@@ -47,7 +47,7 @@ object CommonPathParameterUtil {
     )
 
     // Cache for each module's directory information.
-    private val modulePathCache = ConcurrentHashMap<String, ModulePaths>()
+    private val modulePathCache = ConcurrentHashMap<Module, ModulePaths>()
 
     /**
      * Returns the directory information for the specified module (uses cache if available).
@@ -55,7 +55,7 @@ object CommonPathParameterUtil {
      * @param module The module to retrieve directory information for.
      * @return The cached or newly computed ModulePaths.
      */
-    fun getModulePaths(module: Module): ModulePaths? = modulePathCache[module.name]
+    fun getModulePaths(module: Module): ModulePaths? = modulePathCache[module]
 
     /**
      * Checks if a given path is a generated directory based on annotation processor settings.
@@ -129,7 +129,7 @@ object CommonPathParameterUtil {
                 testSourceDirs,
                 testResourceDirs,
             )
-        modulePathCache[module.name] = paths
+        modulePathCache[module] = paths
     }
 
     /**

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
@@ -34,13 +34,11 @@ import org.domaframework.doma.intellij.common.getJarRoot
 import org.domaframework.doma.intellij.common.getMethodDaoFilePath
 import org.domaframework.doma.intellij.common.isInjectionSqlFile
 import org.domaframework.doma.intellij.common.isSupportFileType
-import org.domaframework.doma.intellij.common.sourceExtensionNames
-import org.domaframework.doma.intellij.extension.findFile
 import org.domaframework.doma.intellij.extension.getContentRoot
 import org.domaframework.doma.intellij.extension.getJavaClazz
 import org.domaframework.doma.intellij.extension.getModule
+import org.domaframework.doma.intellij.extension.getSourceRootDir
 import org.jetbrains.kotlin.idea.base.util.module
-import java.nio.file.Paths
 
 /**
  * Get DAO method corresponding to SQL file
@@ -58,36 +56,24 @@ fun findDaoMethod(
             return PsiTreeUtil.getParentOfType(originalFile.context, PsiMethod::class.java)
         }
     } else if (isSupportFileType(originalFile)) {
-        // TODO: Add Support Kotlin
         val methodName = virtualFile.nameWithoutExtension
         val daoFile = daoFile ?: findDaoFile(project, originalFile) ?: return null
         if (module != null) {
-            val relativePath =
+            val contentRootPath = project.getContentRoot(virtualFile)?.path ?: return null
+            val daoJavaFile =
                 getDaoPathFromSqlFilePath(
                     originalFile,
-                    project.getContentRoot(virtualFile)?.path ?: "",
-                )
-            // get ClassPath with package name
-            val daoClassName: String =
-                relativePath
-                    .substringBefore(".")
-                    .replace("/", ".")
-                    .replace("\\", ".")
-                    .replace("..", ".")
-                    .trim('.')
+                    contentRootPath,
+                ) ?: return null
 
-            val daoJavaFile = project.findFile(daoFile)
-            val isTest = CommonPathParameterUtil.isTest(module, originalFile.virtualFile)
-            findDaoClass(module, isTest, daoClassName)
-                ?.let { daoClass ->
-                    val daoMethod =
-                        // TODO Support Kotlin Project
-                        when (daoJavaFile) {
-                            is PsiJavaFile -> findUseSqlDaoMethod(daoJavaFile, methodName)
-                            else -> null
-                        }
-                    return daoMethod
+            // TODO Support Kotlin Project
+            val daoFile = daoJavaFile.containingFile
+            val daoMethod =
+                when (daoFile) {
+                    is PsiJavaFile -> findUseSqlDaoMethod(daoFile, methodName)
+                    else -> null
                 }
+            return daoMethod
         } else {
             val fileType = getExtension(daoFile.fileType.name)
             val jarRootPath = virtualFile.path.substringBefore("jar!").plus("jar!")
@@ -133,78 +119,36 @@ fun findDaoFile(
     if (contentRoot == null) {
         return getJarRoot(virtualFile, sqlFile)
     }
-    return searchDaoFile(sqlFile.module, contentRoot, sqlFile)
+    return getDaoPathFromSqlFilePath(
+        sqlFile,
+        contentRoot.path,
+    )?.containingFile?.virtualFile
 }
-
-/**
- * DAO file search for SQL file
- */
-private fun searchDaoFile(
-    module: Module?,
-    contentRoot: VirtualFile?,
-    sqlFile: PsiFile,
-): VirtualFile? {
-    val contentRootPath = contentRoot?.path ?: return null
-    val pathParams = module?.let { CommonPathParameterUtil.getModulePaths(it) } ?: return null
-    val moduleBaseName =
-        pathParams.moduleBasePaths
-            .find { baseName -> Paths.get(contentRootPath).startsWith(Paths.get(baseName.path)) }
-            ?.nameWithoutExtension ?: ""
-    // TODO: Add Support Kotlin
-    val relativeDaoFilePaths =
-        getDaoPathFromSqlFilePath(sqlFile, contentRoot.path)
-    val sources = CommonPathParameterUtil.getSources(module, sqlFile.virtualFile)
-
-    if (contentRootPath.endsWith(moduleBaseName) == true) {
-        sources.forEach { source ->
-            sourceExtensionNames.forEach { extension ->
-                val fileExtension = getExtension(extension)
-                val findDaoFile =
-                    contentRoot.findFileByRelativePath("${source.nameWithoutExtension}$relativeDaoFilePaths.$fileExtension")
-                if (findDaoFile != null) return findDaoFile
-            }
-        }
-    }
-    return null
-}
-
-private fun findDaoClass(
-    module: Module,
-    includeTest: Boolean,
-    daoClassName: String,
-): PsiClass? = module.getJavaClazz(includeTest, daoClassName)
 
 /**
  * Generate DAO deployment path from SQL file path
  * @param sqlFile SQL File
- * @param projectRootPath project content Root Path
+ * @param contentRootPath project content Root Path
  * @return
  */
 private fun getDaoPathFromSqlFilePath(
     sqlFile: PsiFile,
-    projectRootPath: String,
-): String {
+    contentRootPath: String,
+): PsiClass? {
     if (isInjectionSqlFile(sqlFile)) {
-        return ""
+        return null
     }
-    val module = sqlFile.module
-    val sqlPath = sqlFile.virtualFile?.path ?: return ""
-    var relativeFilePath = sqlPath.substring(projectRootPath.length)
-    if (!relativeFilePath.startsWith("/")) {
-        relativeFilePath = "/$relativeFilePath"
-    }
-    val resources =
-        module?.let { CommonPathParameterUtil.getResources(it, sqlFile.virtualFile) }
-            ?: emptyList()
+    val module = sqlFile.module ?: return null
+    val sqlPath = sqlFile.virtualFile?.path ?: return null
+    val relativePath =
+        sqlPath.substringAfter(contentRootPath, "").replace("/$RESOURCES_META_INF_PATH", "")
+    val resourcesRootPath = module.project.getSourceRootDir(sqlFile.virtualFile)?.name ?: ""
+    val isTest = CommonPathParameterUtil.isTest(module, sqlFile.virtualFile)
 
-    return resources
-        .find { resource ->
-            relativeFilePath.startsWith("/${resource.nameWithoutExtension}/")
-        }?.let { resource ->
-            relativeFilePath
-                .replace("${resource.nameWithoutExtension}/$RESOURCES_META_INF_PATH/", "")
-                .replace("/${sqlFile.name}", "")
-        } ?: ""
+    val packageName = relativePath.replaceFirst("/$resourcesRootPath/", "").replace("/${sqlFile.name}", "").replace("/", ".")
+    val daoClassFile = module.getJavaClazz(isTest, packageName)
+
+    return daoClassFile
 }
 
 /**
@@ -219,30 +163,14 @@ fun getRelativeSqlFilePathFromDaoFilePath(
 ): String {
     if (module == null) return ""
     val extension = daoFile.fileType.defaultExtension
+    val sourceRoot = module.project.getSourceRootDir(daoFile) ?: return ""
+
+    val project = module.project
+    val sourceRootParent = project.getContentRoot(daoFile) ?: return ""
     val daoFilePath = daoFile.path
-    val pathParams = CommonPathParameterUtil.getModulePaths(module)
-    val containsModuleBaseName =
-        pathParams.moduleBasePaths
-            .find { basePath -> daoFilePath.contains("${basePath.path}/") }
-            ?.path ?: return ""
-    var relativeSqlFilePath =
-        daoFilePath
-            .replaceFirst(containsModuleBaseName, "")
-            .replace(".$extension", "")
-    val sources = CommonPathParameterUtil.getSources(module, daoFile)
-    sources
-        .find {
-            daoFilePath
-                .startsWith(containsModuleBaseName.plus("/${it.nameWithoutExtension}/"))
-        }?.let { source ->
-            val startSourceName = "/${source.nameWithoutExtension}"
-            if (relativeSqlFilePath.startsWith("$startSourceName/")) {
-                relativeSqlFilePath =
-                    relativeSqlFilePath.replaceFirst(
-                        startSourceName,
-                        RESOURCES_META_INF_PATH,
-                    )
-            }
-        }
-    return relativeSqlFilePath
+
+    return daoFilePath
+        .substringAfter(sourceRootParent.path)
+        .replaceFirst("/${sourceRoot.name}", RESOURCES_META_INF_PATH)
+        .replace(".$extension", "")
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
@@ -40,6 +40,7 @@ import org.domaframework.doma.intellij.extension.getContentRoot
 import org.domaframework.doma.intellij.extension.getJavaClazz
 import org.domaframework.doma.intellij.extension.getModule
 import org.jetbrains.kotlin.idea.base.util.module
+import java.nio.file.Paths
 
 /**
  * Get DAO method corresponding to SQL file
@@ -147,7 +148,7 @@ private fun searchDaoFile(
     val pathParams = module?.let { CommonPathParameterUtil.getModulePaths(it) } ?: return null
     val moduleBaseName =
         pathParams.moduleBasePaths
-            .find { baseName -> contentRootPath.contains(baseName.path) }
+            .find { baseName -> Paths.get(contentRootPath).startsWith(Paths.get(baseName.path)) }
             ?.nameWithoutExtension ?: ""
     // TODO: Add Support Kotlin
     val relativeDaoFilePaths =
@@ -218,19 +219,20 @@ fun getRelativeSqlFilePathFromDaoFilePath(
 ): String {
     if (module == null) return ""
     val extension = daoFile.fileType.defaultExtension
+    val daoFilePath = daoFile.path
     val pathParams = CommonPathParameterUtil.getModulePaths(module)
     val containsModuleBaseName =
         pathParams.moduleBasePaths
-            .find { basePath -> daoFile.path.contains("${basePath.path}/") }
+            .find { basePath -> daoFilePath.contains("${basePath.path}/") }
             ?.path ?: return ""
     var relativeSqlFilePath =
-        daoFile.path
+        daoFilePath
             .replaceFirst(containsModuleBaseName, "")
             .replace(".$extension", "")
     val sources = CommonPathParameterUtil.getSources(module, daoFile)
     sources
         .find {
-            daoFile.path
+            daoFilePath
                 .startsWith(containsModuleBaseName.plus("/${it.nameWithoutExtension}/"))
         }?.let { source ->
             val startSourceName = "/${source.nameWithoutExtension}"

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
@@ -140,11 +140,13 @@ class PsiDaoMethod(
                 sqlFile = jarRoot?.findFileByRelativePath(sqlFilePath)
                 return
             } else {
-                sqlFile =
-                    module.getResourcesSQLFile(
-                        sqlFilePath,
-                        isTest,
-                    )
+                if (sqlFilePath.isNotEmpty()) {
+                    sqlFile =
+                        module.getResourcesSQLFile(
+                            sqlFilePath,
+                            isTest,
+                        )
+                }
                 return
             }
         }
@@ -172,6 +174,7 @@ class PsiDaoMethod(
 
     fun generateSqlFile() {
         ApplicationManager.getApplication().runReadAction {
+            if (sqlFilePath.isEmpty()) return@runReadAction
             val rootDir = psiProject.getContentRoot(daoFile) ?: return@runReadAction
             val sqlFile = File(sqlFilePath)
             val sqlFileName = sqlFile.name

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
@@ -140,13 +140,15 @@ class PsiDaoMethod(
                 sqlFile = jarRoot?.findFileByRelativePath(sqlFilePath)
                 return
             } else {
-                if (sqlFilePath.isNotEmpty()) {
-                    sqlFile =
+                sqlFile =
+                    if (sqlFilePath.isNotEmpty()) {
                         module.getResourcesSQLFile(
                             sqlFilePath,
                             isTest,
                         )
-                }
+                    } else {
+                        null
+                    }
                 return
             }
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
@@ -39,7 +39,7 @@ import org.domaframework.doma.intellij.common.getExtension
 import org.domaframework.doma.intellij.extension.findFile
 import org.domaframework.doma.intellij.extension.getContentRoot
 import org.domaframework.doma.intellij.extension.getModule
-import org.domaframework.doma.intellij.extension.getResourcesSQLFile
+import org.domaframework.doma.intellij.extension.getResourcesFile
 import org.domaframework.doma.intellij.extension.getSourceRootDir
 import org.domaframework.doma.intellij.extension.psi.DomaAnnotationType
 import org.domaframework.doma.intellij.setting.SqlLanguage
@@ -142,14 +142,10 @@ class PsiDaoMethod(
                 return
             } else {
                 sqlFile =
-                    if (sqlFilePath.isNotEmpty()) {
-                        module.getResourcesSQLFile(
-                            sqlFilePath,
-                            isTest,
-                        )
-                    } else {
-                        null
-                    }
+                    module.getResourcesFile(
+                        sqlFilePath,
+                        isTest,
+                    )
                 return
             }
         }
@@ -185,7 +181,7 @@ class PsiDaoMethod(
             val isTest = CommonPathParameterUtil.isTest(module, daoFile)
 
             val sqlDir = sqlFilePath.replace("/$sqlFileName", "")
-            val existSqlDir = module.getResourcesSQLFile("$RESOURCES_META_INF_PATH/$sqlDir", isTest)
+            val existSqlDir = module.getResourcesFile(sqlDir, isTest)
             val resourceDir = existSqlDir ?.let { psiProject.getSourceRootDir(it) }
             val resourcesDirPath = resourceDir?.nameWithoutExtension ?: "resources"
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/collector/FunctionCallCollector.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/collector/FunctionCallCollector.kt
@@ -36,23 +36,15 @@ class FunctionCallCollector(
     public override fun collect(): List<LookupElement>? {
         var functions = mutableSetOf<PsiMethod>()
         val project = file?.project
-        val module = file?.module
-        val resourcePaths =
-            if (file?.virtualFile != null && module != null) {
-                CommonPathParameterUtil
-                    .getResources(module, file.virtualFile)
-            } else {
-                emptyList()
-            }
+        val module = file?.module ?: return null
+        val isTest = CommonPathParameterUtil.isTest(module, file.virtualFile)
 
         val customFunctionClassName =
-            project?.let {
-                DomaCompileConfigUtil.getConfigValue(
-                    it,
-                    resourcePaths,
-                    "doma.expr.functions",
-                )
-            }
+            DomaCompileConfigUtil.getConfigValue(
+                module,
+                isTest,
+                "doma.expr.functions",
+            )
 
         val expressionFunctionInterface =
             project?.let { ExpressionFunctionsHelper.setExpressionFunctionsInterface(it) }

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/ModuleExtensions.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/ModuleExtensions.kt
@@ -34,7 +34,7 @@ fun Module.getPackagePathFromDaoPath(daoFile: VirtualFile): VirtualFile? {
             getRelativeSqlFilePathFromDaoFilePath(daoFile, this)
         } ?: ""
     val isTest = CommonPathParameterUtil.isTest(this, daoFile)
-    return this.getResourcesSQLFile(
+    return this.getResourcesFile(
         packagePath,
         isTest,
     )
@@ -57,7 +57,7 @@ fun Module.getJavaClazz(
  * @param includeTest true: test source, false: main source
  * @return SQL file
  */
-fun Module.getResourcesSQLFile(
+fun Module.getResourcesFile(
     relativePath: String,
     includeTest: Boolean,
 ): VirtualFile? =

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/ProjectExtensions.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/ProjectExtensions.kt
@@ -17,6 +17,7 @@ package org.domaframework.doma.intellij.extension
 
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.JavaPsiFacade
@@ -51,3 +52,5 @@ fun Project.getJavaClazz(fqdn: String): PsiClass? {
             GlobalSearchScope.allScope(this),
         )
 }
+
+fun Project.getSourceRootDir(file: VirtualFile): VirtualFile? = ProjectFileIndex.getInstance(this).getSourceRootForFile(file)

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/processor/InspectionFunctionCallVisitorProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/processor/InspectionFunctionCallVisitorProcessor.kt
@@ -34,15 +34,13 @@ class InspectionFunctionCallVisitorProcessor(
 ) : InspectionVisitorProcessor(shortName) {
     fun check(holder: ProblemsHolder) {
         val project = element.project
+        val module = element.module ?: return
         val expressionHelper = ExpressionFunctionsHelper
         val expressionFunctionalInterface = expressionHelper.setExpressionFunctionsInterface(project)
         val functionName = element.elIdExpr
 
-        val resources =
-            element.module
-                ?.let { CommonPathParameterUtil.getResources(it, element.containingFile.virtualFile) }
-                ?: emptyList()
-        val customFunctionClassName = DomaCompileConfigUtil.getConfigValue(project, resources, "doma.expr.functions")
+        val isTest = CommonPathParameterUtil.isTest(module, element.containingFile.virtualFile)
+        val customFunctionClassName = DomaCompileConfigUtil.getConfigValue(module, isTest, "doma.expr.functions")
 
         var result: ValidationResult =
             ValidationInvalidFunctionCallResult(

--- a/src/main/kotlin/org/domaframework/doma/intellij/refactoring/dao/DaoPackageRenameListenerProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/refactoring/dao/DaoPackageRenameListenerProcessor.kt
@@ -33,7 +33,7 @@ import org.domaframework.doma.intellij.common.CommonPathParameterUtil
 import org.domaframework.doma.intellij.common.RESOURCES_META_INF_PATH
 import org.domaframework.doma.intellij.common.dao.getDaoClass
 import org.domaframework.doma.intellij.common.util.PluginLoggerUtil
-import org.domaframework.doma.intellij.extension.getResourcesSQLFile
+import org.domaframework.doma.intellij.extension.getResourcesFile
 import org.jetbrains.kotlin.idea.base.util.module
 import java.io.IOException
 
@@ -149,7 +149,7 @@ class DaoPackageRenameListenerProcessor : RefactoringElementListenerProvider {
                         try {
                             val newDir = VfsUtil.createDirectories(newPath)
                             val oldResourcePath =
-                                module.getResourcesSQLFile(
+                                module.getResourcesFile(
                                     RESOURCES_META_INF_PATH + "/" + oldQualifiedName.replace(".", "/"),
                                     isTest,
                                 )

--- a/src/main/kotlin/org/domaframework/doma/intellij/reference/SqlElFunctionCallExprReference.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/reference/SqlElFunctionCallExprReference.kt
@@ -37,22 +37,20 @@ class SqlElFunctionCallExprReference(
         val variableName = functionCallExpr.elIdExpr.text ?: ""
 
         val project = element.project
-        val module = file.module
+        val module = file.module ?: return null
         val expressionFunctionsInterface =
             ExpressionFunctionsHelper.setExpressionFunctionsInterface(project)
                 ?: return null
 
-        val resourcePaths =
-            module?.let {
-                CommonPathParameterUtil
-                    .getResources(it, file.virtualFile)
-            } ?: emptyList()
-
-        val customFunctionClassName = DomaCompileConfigUtil.getConfigValue(project, resourcePaths, "doma.expr.functions")
+        val isTest =
+            CommonPathParameterUtil
+                .isTest(module, file.virtualFile)
+        val customFunctionClassName = DomaCompileConfigUtil.getConfigValue(module, isTest, "doma.expr.functions")
 
         val implementsClass =
             if (customFunctionClassName != null) {
-                val expressionFunction = project.getJavaClazz(customFunctionClassName)
+                val customFunctionClass = customFunctionClassName
+                val expressionFunction = project.getJavaClazz(customFunctionClass)
                 if (ExpressionFunctionsHelper.isInheritor(expressionFunction)) {
                     expressionFunction
                 } else {

--- a/src/main/kotlin/org/domaframework/doma/intellij/setting/DomaToolStartupActivity.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/setting/DomaToolStartupActivity.kt
@@ -22,12 +22,20 @@ import org.domaframework.doma.intellij.common.util.PluginUtil
 
 class DomaToolStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
+        setProperty()
+        registerModuleRootListener(project)
+    }
+
+    private fun setProperty() {
         System.setProperty("org.domaframework.doma.intellij.log.path", PathManager.getLogPath())
         System.setProperty(
             "org.domaframework.doma.intellij.plugin.version",
             PluginUtil.getVersion(),
         )
-
         println("PluginVersion: ${System.getProperty("org.domaframework.doma.intellij.plugin.version")} ")
+    }
+
+    private fun registerModuleRootListener(project: Project) {
+        DomaToolsModuleRootListener.updateModuleDirectoryCache(project)
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/setting/DomaToolStartupActivity.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/setting/DomaToolStartupActivity.kt
@@ -17,6 +17,7 @@ package org.domaframework.doma.intellij.setting
 
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootListener
 import com.intellij.openapi.startup.ProjectActivity
 import org.domaframework.doma.intellij.common.util.PluginUtil
 
@@ -36,6 +37,9 @@ class DomaToolStartupActivity : ProjectActivity {
     }
 
     private fun registerModuleRootListener(project: Project) {
-        DomaToolsModuleRootListener.updateModuleDirectoryCache(project)
+        project.messageBus.connect().subscribe(
+            ModuleRootListener.TOPIC,
+            DomaToolsModuleRootListener(project),
+        )
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/setting/DomaToolStartupActivity.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/setting/DomaToolStartupActivity.kt
@@ -17,14 +17,12 @@ package org.domaframework.doma.intellij.setting
 
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ModuleRootListener
 import com.intellij.openapi.startup.ProjectActivity
 import org.domaframework.doma.intellij.common.util.PluginUtil
 
 class DomaToolStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
         setProperty()
-        registerModuleRootListener(project)
     }
 
     private fun setProperty() {
@@ -34,12 +32,5 @@ class DomaToolStartupActivity : ProjectActivity {
             PluginUtil.getVersion(),
         )
         println("PluginVersion: ${System.getProperty("org.domaframework.doma.intellij.plugin.version")} ")
-    }
-
-    private fun registerModuleRootListener(project: Project) {
-        project.messageBus.connect().subscribe(
-            ModuleRootListener.TOPIC,
-            DomaToolsModuleRootListener(project),
-        )
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/setting/DomaToolsModuleRootListener.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/setting/DomaToolsModuleRootListener.kt
@@ -21,9 +21,10 @@ import com.intellij.openapi.roots.ModuleRootEvent
 import com.intellij.openapi.roots.ModuleRootListener
 import org.domaframework.doma.intellij.common.CommonPathParameterUtil
 
-object DomaToolsModuleRootListener : ModuleRootListener {
+class DomaToolsModuleRootListener(
+    private val project: Project,
+) : ModuleRootListener {
     override fun rootsChanged(event: ModuleRootEvent) {
-        val project = event.source as? Project ?: return
         updateModuleDirectoryCache(project)
     }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/setting/DomaToolsModuleRootListener.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/setting/DomaToolsModuleRootListener.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.setting
+
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootEvent
+import com.intellij.openapi.roots.ModuleRootListener
+import org.domaframework.doma.intellij.common.CommonPathParameterUtil
+
+object DomaToolsModuleRootListener : ModuleRootListener {
+    override fun rootsChanged(event: ModuleRootEvent) {
+        val project = event.source as? Project ?: return
+        updateModuleDirectoryCache(project)
+    }
+
+    fun updateModuleDirectoryCache(project: Project) {
+        val modules = ModuleManager.getInstance(project).modules
+        modules
+            .filter { module -> module.name != project.name }
+            .forEach { module ->
+                CommonPathParameterUtil.refreshModulePaths(module)
+            }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -93,6 +93,11 @@
     <supportsKotlinPluginMode supportsK2="true"/>
   </extensions>
 
+  <projectListeners>
+    <listener class="org.domaframework.doma.intellij.setting.DomaToolsModuleRootListener"
+      topic="com.intellij.openapi.roots.ModuleRootListener" />
+  </projectListeners>
+
   <!-- Action -->
   <actions>
     <group

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,12 @@
   <resource-bundle>messages.DomaToolsBundle</resource-bundle>
   <resource-bundle>messages.LLMInstallerBundle</resource-bundle>
 
+  <projectListeners>
+    <listener
+      class="org.domaframework.doma.intellij.setting.DomaToolsModuleRootListener"
+      topic="com.intellij.openapi.roots.ModuleRootListener"/>
+  </projectListeners>
+
   <extensions defaultExtensionNs="com.intellij">
     <postStartupActivity implementation="org.domaframework.doma.intellij.setting.DomaToolStartupActivity"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -93,11 +93,6 @@
     <supportsKotlinPluginMode supportsK2="true"/>
   </extensions>
 
-  <projectListeners>
-    <listener class="org.domaframework.doma.intellij.setting.DomaToolsModuleRootListener"
-      topic="com.intellij.openapi.roots.ModuleRootListener" />
-  </projectListeners>
-
   <!-- Action -->
   <actions>
     <group

--- a/src/test/kotlin/org/domaframework/doma/intellij/DomaSqlTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/DomaSqlTest.kt
@@ -30,7 +30,7 @@ import com.intellij.testFramework.PsiTestUtil
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import org.domaframework.doma.intellij.common.CommonPathParameterUtil
 import org.domaframework.doma.intellij.common.RESOURCES_META_INF_PATH
-import org.domaframework.doma.intellij.extension.getResourcesSQLFile
+import org.domaframework.doma.intellij.extension.getResourcesFile
 import org.jetbrains.jps.model.java.JavaResourceRootType
 import org.jetbrains.jps.model.java.JavaSourceRootType
 import org.junit.Ignore
@@ -231,7 +231,7 @@ open class DomaSqlTest : LightJavaCodeInsightFixtureTestCase() {
     ): VirtualFile? {
         val module = myFixture.module
         val sqlFileName = "$RESOURCES_META_INF_PATH/$packageName/dao/$sqlName"
-        return module?.getResourcesSQLFile(
+        return module?.getResourcesFile(
             sqlFileName,
             false,
         )


### PR DESCRIPTION
Fix an issue where generating SQL files from DAO methods in a project with multiple modules (e.g., using Gradle source set configurations) results in an IOException.

# Problem
When a subproject contains multiple modules and source sets, the existing logic caches a single directory structure per module, using the module as a key.
This leads to incorrect path resolution when DAO classes exist in different source roots, causing the SQL file generator to produce invalid paths (e.g., mixing build and source paths).

# Fix
## Cache Update via ModuleRootListener
The module directory structure cache is updated only when IntelliJ IDEA detects changes in the directory structure, using ModuleRootListener.

## Minimal Use of Cache for File Resolution
For both DAO → SQL and SQL → DAO resolution, path generation is based on the file's own source root and content root, rather than relying on cached directory mappings.

 ## File Resolution Logic
###  DAO → SQL
Generate the expected SQL file path from the DAO's content root:

```
/META-INF/[dao package path]/[DaoName].sql
```
Check if the corresponding file exists within the module’s resource directories using:
`ResourceFileUtil.findResourceFileInScope`

If the SQL file does not yet exist, fallback to cached resource directory information.
If no resource directory is explicitly marked, use a default path.

###  SQL → DAO
From the SQL file path under /META-INF, extract the corresponding package name.

Use the package name and DAO file name to construct a fully qualified class name.

Resolve the class using `JavaPsiFacade`, and set the matching DAO file as the navigation target.

This approach ensures accurate file linkage in dynamic project structures, improves consistency, and reduces reliance on potentially outdated cached data.