### PR TITLE
Optional Keyword Support for ON CONFLICT Syntax

### DIFF
--- a/src/main/java/org/domaframework/doma/intellij/Sql.flex
+++ b/src/main/java/org/domaframework/doma/intellij/Sql.flex
@@ -37,6 +37,7 @@ import org.domaframework.doma.intellij.psi.SqlTypes;
       "conflict",
       "constraint",
       "column",
+      "collate",
       "comment",
       "create",
       "cross",

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
@@ -89,6 +89,8 @@ open class SqlBlock(
     open var parentBlock: SqlBlock? = null
     open val childBlocks = mutableListOf<SqlBlock>()
 
+    fun getChildBlocksDropLast(dropIndex: Int = 1): List<SqlBlock> = childBlocks.dropLast(dropIndex)
+
     open val indent: ElementIndent =
         ElementIndent(
             IndentType.FILE,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
@@ -20,11 +20,11 @@ import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.common.util.TypeUtil.isExpectedClassType
 import org.domaframework.doma.intellij.formatter.block.conflict.SqlConflictClauseBlock
 import org.domaframework.doma.intellij.formatter.block.group.column.SqlColumnDefinitionRawGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.column.SqlColumnRawGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateTableColumnDefinitionGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateColumnGroupBlock
-import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateSetGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateValueGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithQuerySubGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlFunctionParamBlock

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
@@ -20,11 +20,11 @@ import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.common.util.TypeUtil.isExpectedClassType
 import org.domaframework.doma.intellij.formatter.block.conflict.SqlConflictClauseBlock
 import org.domaframework.doma.intellij.formatter.block.group.column.SqlColumnDefinitionRawGroupBlock
-import org.domaframework.doma.intellij.formatter.block.group.column.SqlColumnRawGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateTableColumnDefinitionGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateColumnGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateSetGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateValueGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithQuerySubGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlFunctionParamBlock

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlLineCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlLineCommentBlock.kt
@@ -41,7 +41,7 @@ open class SqlLineCommentBlock(
     override fun createBlockIndentLen(): Int {
         parentBlock?.let { parent ->
             if (parent is SqlSubQueryGroupBlock) {
-                if (parent.childBlocks.dropLast(1).isEmpty()) {
+                if (parent.getChildBlocksDropLast().isEmpty()) {
                     return 0
                 }
                 if (parent.isFirstLineComment) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElBlockCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElBlockCommentBlock.kt
@@ -130,7 +130,7 @@ open class SqlElBlockCommentBlock(
     override fun createBlockIndentLen(): Int {
         parentBlock?.let {
             if (it is SqlSubQueryGroupBlock) {
-                if (it.childBlocks.dropLast(1).isEmpty()) {
+                if (it.getChildBlocksDropLast().isEmpty()) {
                     return 0
                 }
                 if (it.isFirstLineComment) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/insert/SqlInsertQueryGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/insert/SqlInsertQueryGroupBlock.kt
@@ -16,7 +16,7 @@
 package org.domaframework.doma.intellij.formatter.block.group.keyword.insert
 
 import com.intellij.lang.ASTNode
-import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlValuesGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlValuesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlTopQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlReturningGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlReturningGroupBlock.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.domaframework.doma.intellij.formatter.block.group.keyword.second
 
 import com.intellij.lang.ASTNode

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlReturningGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlReturningGroupBlock.kt
@@ -1,0 +1,16 @@
+package org.domaframework.doma.intellij.formatter.block.group.keyword.second
+
+import com.intellij.lang.ASTNode
+import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
+
+class SqlReturningGroupBlock(
+    node: ASTNode,
+    context: SqlBlockFormattingContext,
+) : SqlSecondKeywordBlock(node, context) {
+    override fun createBlockIndentLen(): Int {
+        parentBlock?.let { parent ->
+            return parent.indent.indentLen
+        }
+        return 0
+    }
+}

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlSecondKeywordBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlSecondKeywordBlock.kt
@@ -49,7 +49,7 @@ open class SqlSecondKeywordBlock(
 
     override fun isSaveSpace(lastGroup: SqlBlock?): Boolean {
         lastGroup?.let { last ->
-            val prevKeyword = last.childBlocks.dropLast(1).findLast { it is SqlKeywordBlock }
+            val prevKeyword = last.childBlocks.findLast { it is SqlKeywordBlock }
             prevKeyword?.let { prev ->
                 return !SqlKeywordUtil.isSetLineKeyword(getNodeText(), prev.getNodeText())
             }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlSecondKeywordBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlSecondKeywordBlock.kt
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group.keyword
+package org.domaframework.doma.intellij.formatter.block.group.keyword.second
 
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.SqlKeywordBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 import org.domaframework.doma.intellij.formatter.util.SqlKeywordUtil
@@ -46,8 +48,12 @@ open class SqlSecondKeywordBlock(
     }
 
     override fun isSaveSpace(lastGroup: SqlBlock?): Boolean {
-        lastGroup?.let {
-            return !SqlKeywordUtil.isSetLineKeyword(getNodeText(), lastGroup.getNodeText())
+        lastGroup?.let { last ->
+            val prevKeyword = last.childBlocks.dropLast(1).findLast { it is SqlKeywordBlock }
+            prevKeyword?.let { prev ->
+                return !SqlKeywordUtil.isSetLineKeyword(getNodeText(), prev.getNodeText())
+            }
+            return !SqlKeywordUtil.isSetLineKeyword(getNodeText(), last.getNodeText())
         }
         return true
     }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlValuesGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlValuesGroupBlock.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group.keyword
+package org.domaframework.doma.intellij.formatter.block.group.keyword.second
 
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/top/SqlJoinQueriesGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/top/SqlJoinQueriesGroupBlock.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.domaframework.doma.intellij.formatter.block.group.keyword.top
 
 import com.intellij.lang.ASTNode

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/top/SqlJoinQueriesGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/top/SqlJoinQueriesGroupBlock.kt
@@ -1,22 +1,8 @@
-/*
- * Copyright Doma Tools Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.domaframework.doma.intellij.formatter.block.group.keyword
+package org.domaframework.doma.intellij.formatter.block.group.keyword.top
 
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithQuerySubGroupBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/top/SqlSelectQueryGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/top/SqlSelectQueryGroupBlock.kt
@@ -65,7 +65,7 @@ class SqlSelectQueryGroupBlock(
     override fun isSaveSpace(lastGroup: SqlBlock?): Boolean {
         lastGroup?.let { lastBlock ->
             if (lastGroup is SqlWithQuerySubGroupBlock) return true
-            if (lastBlock is SqlSubGroupBlock) return lastBlock.childBlocks.dropLast(1).isNotEmpty()
+            if (lastBlock is SqlSubGroupBlock) return lastBlock.getChildBlocksDropLast().isNotEmpty()
         }
         return true
     }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/with/SqlWithCommonTableGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/with/SqlWithCommonTableGroupBlock.kt
@@ -56,7 +56,7 @@ class SqlWithCommonTableGroupBlock(
     private fun findWithQueryChildBlocks(): SqlBlock? {
         parentBlock?.let { parent ->
             if (parent is SqlWithQueryGroupBlock) {
-                return parent.childBlocks.dropLast(1).find { it is SqlWithCommonTableGroupBlock }
+                return parent.getChildBlocksDropLast().find { it is SqlWithCommonTableGroupBlock }
             }
         }
         return null
@@ -75,7 +75,7 @@ class SqlWithCommonTableGroupBlock(
 
     override fun createGroupIndentLen(): Int {
         parentBlock?.let { parent ->
-            childBlocks.dropLast(1).sumOf { it.getNodeText().length.plus(1) }
+            getChildBlocksDropLast().sumOf { it.getNodeText().length.plus(1) }
         }
         return offset
     }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlParallelListBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlParallelListBlock.kt
@@ -16,6 +16,8 @@
 package org.domaframework.doma.intellij.formatter.block.group.subgroup
 
 import com.intellij.lang.ASTNode
+import org.domaframework.doma.intellij.formatter.block.comment.SqlBlockCommentBlock
+import org.domaframework.doma.intellij.formatter.block.comment.SqlLineCommentBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
@@ -41,8 +43,9 @@ class SqlParallelListBlock(
 
     override fun createBlockIndentLen(): Int {
         parentBlock?.let { parent ->
-            return parent.childBlocks
-                .dropLast(1)
+            return parent
+                .getChildBlocksDropLast()
+                .filter { it !is SqlLineCommentBlock && it !is SqlBlockCommentBlock }
                 .sumOf { it.getNodeText().length.plus(1) }
                 .plus(parent.indent.indentLen)
                 .plus(parent.getNodeText().length)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubGroupBlock.kt
@@ -25,8 +25,8 @@ import org.domaframework.doma.intellij.formatter.block.SqlRightPatternBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlCommentBlock
 import org.domaframework.doma.intellij.formatter.block.conflict.SqlDoGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.SqlNewGroupBlock
-import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlJoinQueriesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateViewGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlJoinQueriesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithCommonTableGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithQueryGroupBlock

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubQueryGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubQueryGroupBlock.kt
@@ -18,8 +18,8 @@ package org.domaframework.doma.intellij.formatter.block.group.subgroup
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlJoinQueriesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.condition.SqlConditionalExpressionGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlJoinQueriesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithCommonTableGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithQuerySubGroupBlock
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
@@ -123,25 +123,24 @@ class SqlCustomSpacingBuilder {
     }
 
     fun getSpacingRightPattern(block: SqlRightPatternBlock): Spacing? {
+        val paramBlock = block.parentBlock
         return when {
-            block.parentBlock is SqlCreateTableColumnDefinitionGroupBlock ||
-                block.parentBlock is SqlUpdateColumnGroupBlock ||
-                block.parentBlock is SqlUpdateValueGroupBlock -> {
+            paramBlock is SqlCreateTableColumnDefinitionGroupBlock ||
+                paramBlock is SqlUpdateColumnGroupBlock ||
+                (paramBlock is SqlUpdateValueGroupBlock && !paramBlock.subQueryValue) -> {
                 return getSpacing(block)
             }
 
-            block.parentBlock is SqlParallelListBlock -> {
-                if (block.parentBlock
-                        ?.childBlocks
-                        ?.dropLast(1)
-                        ?.lastOrNull() is SqlKeywordGroupBlock
-                ) {
-                    return normalSpacing
+            paramBlock is SqlParallelListBlock -> {
+                val lastKeywordGroup = paramBlock.childBlocks.dropLast(1).lastOrNull()
+                return if (lastKeywordGroup is SqlKeywordGroupBlock) {
+                    normalSpacing
+                } else {
+                    nonSpacing
                 }
-                return nonSpacing
             }
 
-            block.parentBlock is SqlDataTypeParamBlock -> nonSpacing
+            paramBlock is SqlDataTypeParamBlock -> nonSpacing
 
             block.preSpaceRight -> normalSpacing
             else -> nonSpacing

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
@@ -127,7 +127,7 @@ class SqlCustomSpacingBuilder {
         return when {
             paramBlock is SqlCreateTableColumnDefinitionGroupBlock ||
                 paramBlock is SqlUpdateColumnGroupBlock ||
-                (paramBlock is SqlUpdateValueGroupBlock && !paramBlock.subQueryValue) -> {
+                (paramBlock is SqlUpdateValueGroupBlock) -> {
                 return getSpacing(block)
             }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
@@ -132,7 +132,7 @@ class SqlCustomSpacingBuilder {
             }
 
             paramBlock is SqlParallelListBlock -> {
-                val lastKeywordGroup = paramBlock.childBlocks.dropLast(1).lastOrNull()
+                val lastKeywordGroup = paramBlock.getChildBlocksDropLast().lastOrNull()
                 return if (lastKeywordGroup is SqlKeywordGroupBlock) {
                     normalSpacing
                 } else {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlSetParentGroupProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlSetParentGroupProcessor.kt
@@ -155,6 +155,17 @@ class SqlSetParentGroupProcessor(
                 return@setParentGroups lastGroupBlock
             }
         } else if (lastIndentLevel == currentIndentLevel) {
+            val prevKeyword = lastGroupBlock.childBlocks.findLast { it is SqlKeywordBlock }
+            prevKeyword?.let { prev ->
+                if (SqlKeywordUtil.isSetLineKeyword(childBlock.getNodeText(), prev.getNodeText())) {
+                    updateGroupBlockLastGroupParentAddGroup(
+                        lastGroupBlock,
+                        childBlock,
+                    )
+                    return
+                }
+            }
+
             blockBuilder.removeLastGroupTopNodeIndexHistory()
             updateGroupBlockLastGroupParentAddGroup(
                 lastGroupBlock,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlSetParentGroupProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlSetParentGroupProcessor.kt
@@ -29,6 +29,7 @@ import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlInlineSe
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateViewGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlReturningGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlTopQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithCommonTableGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithQuerySubGroupBlock
@@ -174,7 +175,7 @@ class SqlSetParentGroupProcessor(
                 // Since `DO UPDATE` does not include a `RETURNING` clause, it should be registered as a child of the parent `INSERT` query.
                 // The `DO` keyword should align with the `INSERT` query, and therefore it will serve as the **indentation anchor** for the following update block.
                 setParentGroups(context) { history ->
-                    val lastGroup = history.lastOrNull()
+                    val lastGroup = history.findLast { it is SqlTopQueryGroupBlock }
                     return@setParentGroups if (lastGroup is SqlUpdateQueryGroupBlock && lastGroup.parentBlock is SqlDoGroupBlock) {
                         lastGroup.parentBlock
                     } else {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlSetParentGroupProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlSetParentGroupProcessor.kt
@@ -179,7 +179,7 @@ class SqlSetParentGroupProcessor(
                     return@setParentGroups if (lastGroup is SqlUpdateQueryGroupBlock && lastGroup.parentBlock is SqlDoGroupBlock) {
                         lastGroup.parentBlock
                     } else {
-                        history.lastOrNull()
+                        lastGroup
                     }
                 }
                 return

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/InsertClauseUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/InsertClauseUtil.kt
@@ -17,10 +17,10 @@ package org.domaframework.doma.intellij.formatter.util
 
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlValuesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertValueGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlValuesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 
 object InsertClauseUtil {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/NotQueryGroupUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/NotQueryGroupUtil.kt
@@ -21,6 +21,7 @@ import com.intellij.psi.util.elementType
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.condition.SqlConditionKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.condition.SqlConditionalExpressionGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlReturningGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlFunctionParamBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlParallelListBlock
 import org.domaframework.doma.intellij.psi.SqlTypes
@@ -49,6 +50,17 @@ object NotQueryGroupUtil {
             )
         }
 
+        return null
+    }
+
+    fun getKeywordGroup(
+        child: ASTNode,
+        sqlBlockFormattingCtx: SqlBlockFormattingContext,
+    ): SqlBlock? {
+        val keyword = child.text.lowercase()
+        if (keyword == "returning") {
+            return SqlReturningGroupBlock(child, sqlBlockFormattingCtx)
+        }
         return null
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlBlockUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlBlockUtil.kt
@@ -42,18 +42,18 @@ import org.domaframework.doma.intellij.formatter.block.group.column.SqlColumnRaw
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlInlineGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlInlineSecondGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlJoinGroupBlock
-import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlJoinQueriesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
-import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlSecondKeywordBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlSecondOptionKeywordGroupBlock
-import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlValuesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.condition.SqlConditionKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateTableColumnDefinitionGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateTableColumnDefinitionRawGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateViewGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertQueryGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlSecondKeywordBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlValuesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlDeleteQueryGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlJoinQueriesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlSelectQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateSetGroupBlock
@@ -260,6 +260,13 @@ class SqlBlockUtil(
                         WithClauseUtil
                             .getWithClauseKeywordGroup(lastGroupBlock, child, sqlBlockFormattingCtx)
                             ?.let { return it }
+
+                        NotQueryGroupUtil
+                            .getKeywordGroup(
+                                child,
+                                sqlBlockFormattingCtx,
+                            )?.let { return it }
+
                         SqlSecondKeywordBlock(
                             child,
                             sqlBlockFormattingCtx,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlKeywordUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlKeywordUtil.kt
@@ -296,7 +296,7 @@ class SqlKeywordUtil {
         private val SET_LINE_KEYWORDS =
             mapOf(
                 "into" to setOf("insert"),
-                "from" to setOf("delete"),
+                "from" to setOf("delete", "distinct"),
                 "distinct" to setOf("select"),
                 "table" to setOf("create", "alter", "rename", "truncate", "drop"),
                 "index" to setOf("create", "alter", "rename", "truncate", "drop"),

--- a/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
@@ -66,12 +66,20 @@ class SqlFormatterTest : BasePlatformTestCase() {
         formatSqlFile("Insert.sql", "Insert$formatDataPrefix.sql")
     }
 
+    fun testInsertReturningFormatter() {
+        formatSqlFile("InsertReturning.sql", "InsertReturning$formatDataPrefix.sql")
+    }
+
     fun testInsertWithBindVariableFormatter() {
         formatSqlFile("InsertWithBindVariable.sql", "InsertWithBindVariable$formatDataPrefix.sql")
     }
 
     fun testUpdateFormatter() {
         formatSqlFile("Update.sql", "Update$formatDataPrefix.sql")
+    }
+
+    fun testUpdateReturningFormatter() {
+        formatSqlFile("UpdateReturning.sql", "UpdateReturning$formatDataPrefix.sql")
     }
 
     fun testUpdateBindVariableFormatter() {
@@ -82,8 +90,20 @@ class SqlFormatterTest : BasePlatformTestCase() {
         formatSqlFile("UpdateTupleAssignment.sql", "UpdateTupleAssignment$formatDataPrefix.sql")
     }
 
+    fun testUpdateTupleAssignmentSubQueryFormatter() {
+        formatSqlFile("UpdateTupleAssignmentSubQuery.sql", "UpdateTupleAssignmentSubQuery$formatDataPrefix.sql")
+    }
+
+    fun testUpdateTupleSubUseQueryRowFormatter() {
+        formatSqlFile("UpdateTupleSubUseQueryRow.sql", "UpdateTupleSubUseQueryRow$formatDataPrefix.sql")
+    }
+
     fun testDeleteFormatter() {
         formatSqlFile("Delete.sql", "Delete$formatDataPrefix.sql")
+    }
+
+    fun testDeleteReturningFormatter() {
+        formatSqlFile("DeleteReturning.sql", "DeleteReturning$formatDataPrefix.sql")
     }
 
     fun testInsertConflictUpdateFormatter() {

--- a/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
@@ -90,10 +90,6 @@ class SqlFormatterTest : BasePlatformTestCase() {
         formatSqlFile("UpdateTupleAssignment.sql", "UpdateTupleAssignment$formatDataPrefix.sql")
     }
 
-    fun testUpdateTupleSubUseQueryRowFormatter() {
-        formatSqlFile("UpdateTupleSubUseQueryRow.sql", "UpdateTupleSubUseQueryRow$formatDataPrefix.sql")
-    }
-
     fun testDeleteFormatter() {
         formatSqlFile("Delete.sql", "Delete$formatDataPrefix.sql")
     }

--- a/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
@@ -90,10 +90,6 @@ class SqlFormatterTest : BasePlatformTestCase() {
         formatSqlFile("UpdateTupleAssignment.sql", "UpdateTupleAssignment$formatDataPrefix.sql")
     }
 
-    fun testUpdateTupleAssignmentSubQueryFormatter() {
-        formatSqlFile("UpdateTupleAssignmentSubQuery.sql", "UpdateTupleAssignmentSubQuery$formatDataPrefix.sql")
-    }
-
     fun testUpdateTupleSubUseQueryRowFormatter() {
         formatSqlFile("UpdateTupleSubUseQueryRow.sql", "UpdateTupleSubUseQueryRow$formatDataPrefix.sql")
     }

--- a/src/test/testData/sql/formatter/DeleteReturning.sql
+++ b/src/test/testData/sql/formatter/DeleteReturning.sql
@@ -1,0 +1,5 @@
+DELETE FROM x
+ WHERE id IN ( SELECT id, name
+                 FROM x2
+                WHERE id > /* id */101 AND div = 't' ) 
+returning id, name

--- a/src/test/testData/sql/formatter/DeleteReturning_format.sql
+++ b/src/test/testData/sql/formatter/DeleteReturning_format.sql
@@ -1,0 +1,8 @@
+DELETE FROM x
+ WHERE id IN ( SELECT id
+                      , name
+                 FROM x2
+                WHERE id > /* id */101
+                  AND div = 't' )
+RETURNING id
+          , name 

--- a/src/test/testData/sql/formatter/InsertConflictNothing.sql
+++ b/src/test/testData/sql/formatter/InsertConflictNothing.sql
@@ -1,2 +1,2 @@
 insert into employee (id, username) values ( /* employees.id */0, /* employees.name */'name')
-on conflict (username) do nothing
+on conflict (username)  on Constraint do nothing

--- a/src/test/testData/sql/formatter/InsertConflictNothing_format.sql
+++ b/src/test/testData/sql/formatter/InsertConflictNothing_format.sql
@@ -3,5 +3,5 @@ INSERT INTO employee
              , username)
      VALUES ( /* employees.id */0
              , /* employees.name */'name')
-ON CONFLICT (username)
+ON CONFLICT (username) ON CONSTRAINT
 DO NOTHING 

--- a/src/test/testData/sql/formatter/InsertConflictUpdate.sql
+++ b/src/test/testData/sql/formatter/InsertConflictUpdate.sql
@@ -3,6 +3,7 @@ SELECT name, user_id
 FROM user_settings
 WHERE user_id = /*employee.id*/0  AND name = /*employee.name*/'name'
 on conflict (id) do 
-update set name = EXCLUDED.name
+update set name = EXCLUDED.name,
+ email = default
 WHERE employees.name is Distinct from EXCLUDED.name
 returning id, manager_id, name

--- a/src/test/testData/sql/formatter/InsertConflictUpdate.sql
+++ b/src/test/testData/sql/formatter/InsertConflictUpdate.sql
@@ -1,3 +1,8 @@
-insert into users (username, email)
-values ('user', 'user@example.com')
-on CONFLICT(username) ON constraint do update set email = EXCLUDED.email, created_at = CURRENT_TIMESTAMP 
+insert into employees (name, manager_id)
+SELECT name, user_id
+FROM user_settings
+WHERE user_id = /*employee.id*/0  AND name = /*employee.name*/'name'
+on conflict (id) do 
+update set name = EXCLUDED.name
+WHERE employees.name is Distinct from EXCLUDED.name
+returning id, manager_id, name

--- a/src/test/testData/sql/formatter/InsertConflictUpdate_format.sql
+++ b/src/test/testData/sql/formatter/InsertConflictUpdate_format.sql
@@ -9,6 +9,7 @@ SELECT name
 ON CONFLICT (id)
 DO UPDATE
       SET name = EXCLUDED.name
+          , email = DEFAULT
     WHERE employees.name IS DISTINCT
      FROM EXCLUDED.name
 RETURNING id

--- a/src/test/testData/sql/formatter/InsertConflictUpdate_format.sql
+++ b/src/test/testData/sql/formatter/InsertConflictUpdate_format.sql
@@ -1,9 +1,16 @@
-INSERT INTO users
-            (username
-             , email)
-     VALUES ('user'
-             , 'user@example.com')
-ON CONFLICT (username) ON CONSTRAINT
+INSERT INTO employees
+            (name
+             , manager_id)
+SELECT name
+       , user_id
+  FROM user_settings
+ WHERE user_id = /*employee.id*/0
+   AND name = /*employee.name*/'name'
+ON CONFLICT (id)
 DO UPDATE
-      SET email = EXCLUDED.email
-          , created_at = CURRENT_TIMESTAMP 
+      SET name = EXCLUDED.name
+    WHERE employees.name IS DISTINCT
+     FROM EXCLUDED.name
+RETURNING id
+          , manager_id
+          , name 

--- a/src/test/testData/sql/formatter/InsertConflictUpdate_format.sql
+++ b/src/test/testData/sql/formatter/InsertConflictUpdate_format.sql
@@ -10,8 +10,7 @@ ON CONFLICT (id)
 DO UPDATE
       SET name = EXCLUDED.name
           , email = DEFAULT
-    WHERE employees.name IS DISTINCT
-     FROM EXCLUDED.name
+    WHERE employees.name IS DISTINCT FROM EXCLUDED.name
 RETURNING id
           , manager_id
           , name 

--- a/src/test/testData/sql/formatter/InsertReturning.sql
+++ b/src/test/testData/sql/formatter/InsertReturning.sql
@@ -1,0 +1,15 @@
+INSERT INTO /*# tableName */
+            (x1 , x2
+             /*%for entity : entities */
+             , /*# entity.itemIdentifier */
+             /*%end*/ , x3 , x4)
+     VALUES ( /* reportId */1
+             , /* reportId */1
+             /*%for entity : entities */
+             , /* entity.value */'abc'
+             /*%end*/
+             , /* @userId() */1
+             , x5
+             , /* @userId() */1
+             , x6, 1
+             , /* @maxDateTime() */'9999-12-31')  returning x1, x2

--- a/src/test/testData/sql/formatter/InsertReturning_format.sql
+++ b/src/test/testData/sql/formatter/InsertReturning_format.sql
@@ -1,0 +1,21 @@
+INSERT INTO /*# tableName */
+            (x1
+             , x2
+             /*%for entity : entities */
+             , /*# entity.itemIdentifier */
+             /*%end*/
+             , x3
+             , x4)
+     VALUES ( /* reportId */1
+             , /* reportId */1
+             /*%for entity : entities */
+             , /* entity.value */'abc'
+             /*%end*/
+             , /* @userId() */1
+             , x5
+             , /* @userId() */1
+             , x6
+             , 1
+             , /* @maxDateTime() */'9999-12-31')
+RETURNING x1
+          , x2 

--- a/src/test/testData/sql/formatter/UpdateReturning.sql
+++ b/src/test/testData/sql/formatter/UpdateReturning.sql
@@ -1,0 +1,4 @@
+update user set
+name = /* user.name */'name',
+rank = /*user.rank */3 
+where  id = /* user.id */1 returning id, name, rank

--- a/src/test/testData/sql/formatter/UpdateReturning_format.sql
+++ b/src/test/testData/sql/formatter/UpdateReturning_format.sql
@@ -1,0 +1,7 @@
+UPDATE user
+   SET name = /* user.name */'name'
+       , rank = /*user.rank */3
+ WHERE id = /* user.id */1
+RETURNING id
+          , name
+          , rank 

--- a/src/test/testData/sql/formatter/WithDelete_format.sql
+++ b/src/test/testData/sql/formatter/WithDelete_format.sql
@@ -2,7 +2,7 @@ WITH deleted_posts AS (
     DELETE FROM posts
      WHERE deleted = TRUE
        AND deleted_at < CURRENT_DATE - INTERVAL '30 days'
- RETURNING id
+    RETURNING id
 )
 SELECT *
   FROM deleted_posts 

--- a/src/test/testData/sql/formatter/WithInsert.sql
+++ b/src/test/testData/sql/formatter/WithInsert.sql
@@ -1,5 +1,5 @@
 WITH new_user AS ( INSERT INTO users (name, email)
-         VALUES ('Alice Example', 'alice@example.com') RETURNING id)
+         VALUES ('Alice Example', 'alice@example.com') RETURNING id,name)
 INSERT INTO user_profiles (user_id, bio)
-SELECT id , 'This is Alice' , profile
+SELECT id , name
   FROM new_user 

--- a/src/test/testData/sql/formatter/WithInsert_format.sql
+++ b/src/test/testData/sql/formatter/WithInsert_format.sql
@@ -4,12 +4,12 @@ WITH new_user AS (
                  , email)
          VALUES ('Alice Example'
                  , 'alice@example.com')
-      RETURNING id
+    RETURNING id
+              , name
 )
 INSERT INTO user_profiles
             (user_id
              , bio)
 SELECT id
-       , 'This is Alice'
-       , profile
+       , name
   FROM new_user 

--- a/src/test/testData/sql/formatter/WithUpdate_format.sql
+++ b/src/test/testData/sql/formatter/WithUpdate_format.sql
@@ -9,7 +9,7 @@ WITH recent_activity AS (
        SET last_login_at = ra.last_login
       FROM recent_activity ra
      WHERE u.id = ra.user_id
- RETURNING id
+    RETURNING id
 )
 SELECT *
   FROM updated_users 


### PR DESCRIPTION
This update introduces formatting rules for optional keywords that appear within the `ON CONFLICT` and `DO` action clauses of SQL upsert statements.

# Implemented Formatting Rules
## `RETURNING` alignment:
When used with `INSERT`, `UPDATE`, or `DELETE`, the `RETURNING` clause is aligned with the indentation level of the parent query.

## `RETURNING` after `DO UPDATE` :
If `RETURNING` appears after a `DO UPDATE` clause (in an `ON CONFLICT` context), it is aligned with the parent `INSERT` statement instead of the `DO` block.

- `WHERE DISTINCT FROM` formatting:
When `WHERE` is followed by `DISTINCT FROM`, the `FROM` keyword is not line-broken; it remains inline to preserve clarity.

# Note on `COLLATE`
Although `COLLATE` is registered as a keyword element in the formatter, using it within `ON CONFLICT` syntax leads to a parse error in actual SQL execution.
Therefore, no special formatting rule is applied to  `COLLATE` in this context — it is treated as a normal keyword block.