### PR TITLE
VALUES Formatting Support

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
@@ -48,6 +48,7 @@ import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlDataTyp
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlFunctionParamBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
+import org.domaframework.doma.intellij.formatter.block.word.SqlWordBlock
 import org.domaframework.doma.intellij.formatter.builder.SqlBlockBuilder
 import org.domaframework.doma.intellij.formatter.builder.SqlCustomSpacingBuilder
 import org.domaframework.doma.intellij.formatter.processor.SqlSetParentGroupProcessor
@@ -89,7 +90,16 @@ open class SqlBlock(
     open var parentBlock: SqlBlock? = null
     open val childBlocks = mutableListOf<SqlBlock>()
 
-    fun getChildBlocksDropLast(dropIndex: Int = 1): List<SqlBlock> = childBlocks.dropLast(dropIndex)
+    fun getChildBlocksDropLast(
+        dropIndex: Int = 1,
+        skipCommentBlock: Boolean = false,
+    ): List<SqlBlock> {
+        val children = childBlocks.dropLast(dropIndex)
+        if (skipCommentBlock) {
+            return children.filter { it !is SqlLineCommentBlock && it !is SqlBlockCommentBlock }
+        }
+        return children
+    }
 
     open val indent: ElementIndent =
         ElementIndent(

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlCommaBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlCommaBlock.kt
@@ -23,6 +23,8 @@ import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordG
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertValueGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlFromGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlValuesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateSetGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateValueGroupBlock
@@ -30,6 +32,7 @@ import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWit
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlFunctionParamBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlParallelListBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlValuesParamGroupBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
@@ -57,6 +60,12 @@ open class SqlCommaBlock(
         indent.indentLevel = IndentType.COMMA
         indent.indentLen = createBlockIndentLen()
         indent.groupIndentLen = indent.indentLen.plus(getNodeText().length)
+    }
+
+    override fun setParentPropertyBlock(lastGroup: SqlBlock?) {
+        if (lastGroup is SqlFromGroupBlock) {
+            if (lastGroup.tableBlocks.isNotEmpty()) lastGroup.tableBlocks.add(this)
+        }
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
@@ -89,6 +98,8 @@ open class SqlCommaBlock(
                     return parentIndentLen.plus(1)
                 }
 
+                if (parent is SqlValuesParamGroupBlock) return 0
+
                 val grand = parent.parentBlock
                 grand?.let { grand ->
                     if (grand is SqlCreateKeywordGroupBlock) {
@@ -106,6 +117,7 @@ open class SqlCommaBlock(
                 }
                 return parentIndentLen.plus(1)
             } else {
+                if (parent is SqlValuesGroupBlock) return parent.indent.indentLen
                 return parent.indent.groupIndentLen.plus(1)
             }
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
@@ -18,15 +18,17 @@ package org.domaframework.doma.intellij.formatter.block
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.common.util.TypeUtil.isExpectedClassType
-import org.domaframework.doma.intellij.formatter.block.conflict.SqlConflictClauseBlock
+import org.domaframework.doma.intellij.formatter.block.conflict.SqlConflictExpressionSubGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.column.SqlColumnDefinitionRawGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.condition.SqlConditionalExpressionGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateTableColumnDefinitionGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateSetGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateValueGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithQuerySubGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlDataTypeParamBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlFunctionParamBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
@@ -53,7 +55,7 @@ open class SqlRightPatternBlock(
     /**
      * Configures whether to add a space to the right side when the group ends.
      */
-    fun enableLastRight() {
+    private fun enableLastRight() {
         parentBlock?.let { parent ->
             // TODO:Customize spacing
             val notInsertSpaceClassList =
@@ -61,25 +63,29 @@ open class SqlRightPatternBlock(
                     SqlFunctionParamBlock::class,
                     SqlInsertColumnGroupBlock::class,
                     SqlWithQuerySubGroupBlock::class,
+                    SqlConflictExpressionSubGroupBlock::class,
                 )
             if (isExpectedClassType(notInsertSpaceClassList, parent)) {
                 preSpaceRight = false
                 return
             }
 
-            if (parent.parentBlock is SqlConflictClauseBlock) {
-                preSpaceRight = false
-                return
-            }
-
             if (parent is SqlSubQueryGroupBlock) {
-                val prevKeywordBlock =
+                val prevKeywordBlocks =
                     parent.childBlocks
                         .filter { it.node.startOffset < node.startOffset }
-                        .find { it is SqlKeywordGroupBlock && it.indent.indentLevel == IndentType.TOP }
-                if (prevKeywordBlock != null) {
-                    preSpaceRight = true
-                    return
+                        .find { it is SqlKeywordGroupBlock }
+
+                when (prevKeywordBlocks?.indent?.indentLevel) {
+                    IndentType.TOP -> {
+                        preSpaceRight = true
+                        return
+                    }
+
+                    else -> {
+                        preSpaceRight = false
+                        return
+                    }
                 }
             }
 
@@ -100,16 +106,21 @@ open class SqlRightPatternBlock(
 
     override fun setParentGroupBlock(lastGroup: SqlBlock?) {
         super.setParentGroupBlock(lastGroup)
+        enableLastRight()
         indent.indentLevel = IndentType.NONE
         indent.indentLen = createBlockIndentLen()
         indent.groupIndentLen = indent.indentLen
-        enableLastRight()
+    }
+
+    override fun setParentPropertyBlock(lastGroup: SqlBlock?) {
         (lastGroup as? SqlSubGroupBlock)?.endPatternBlock = this
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
 
     override fun createBlockIndentLen(): Int {
+        if (preSpaceRight) return 1
+
         parentBlock?.let { parent ->
             if (parent is SqlWithQuerySubGroupBlock) return 0
             val exceptionalTypes =
@@ -119,29 +130,51 @@ open class SqlRightPatternBlock(
                     SqlCreateTableColumnDefinitionGroupBlock::class,
                 )
             if (isExpectedClassType(exceptionalTypes, parent)) return parent.indent.indentLen
-            return parent.indent.groupIndentLen
+            return parent.indent.indentLen
         } ?: return 0
     }
 
     override fun isLeaf(): Boolean = true
 
     override fun isSaveSpace(lastGroup: SqlBlock?): Boolean {
-        val exceptionalTypes =
-            listOf(
-                SqlCreateTableColumnDefinitionGroupBlock::class,
-                SqlColumnDefinitionRawGroupBlock::class,
-                SqlUpdateColumnGroupBlock::class,
-                SqlUpdateValueGroupBlock::class,
-                SqlWithQuerySubGroupBlock::class,
-            )
-        if (isExpectedClassType(exceptionalTypes, parentBlock)) return true
+        if (preSpaceRight) return false
 
-        val parentExceptionalTypes =
-            listOf(
-                SqlUpdateSetGroupBlock::class,
-                SqlUpdateColumnGroupBlock::class,
-                SqlUpdateValueGroupBlock::class,
-            )
-        return isExpectedClassType(parentExceptionalTypes, parentBlock?.parentBlock)
+        parentBlock?.let { parent ->
+            val exceptionalTypes =
+                listOf(
+                    SqlCreateTableColumnDefinitionGroupBlock::class,
+                    SqlColumnDefinitionRawGroupBlock::class,
+                    SqlUpdateSetGroupBlock::class,
+                    SqlUpdateColumnGroupBlock::class,
+                    SqlUpdateValueGroupBlock::class,
+                    SqlWithQuerySubGroupBlock::class,
+                )
+
+            val excludeTypes =
+                listOf(
+                    SqlDataTypeParamBlock::class,
+                    SqlConditionalExpressionGroupBlock::class,
+                    SqlConflictExpressionSubGroupBlock::class,
+                    SqlFunctionParamBlock::class,
+                )
+
+            if ((
+                    isExpectedClassType(exceptionalTypes, parent) ||
+                        isExpectedClassType(exceptionalTypes, parent.parentBlock)
+                ) &&
+                !isExpectedClassType(excludeTypes, parent)
+            ) {
+                return true
+            }
+
+            if (parent is SqlSubGroupBlock) {
+                val firstChild =
+                    parent.getChildBlocksDropLast(skipCommentBlock = true).firstOrNull()
+                if (firstChild is SqlKeywordGroupBlock) {
+                    return firstChild.indent.indentLevel != IndentType.TOP
+                }
+            }
+        }
+        return false
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/conflict/SqlConflictExpressionSubGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/conflict/SqlConflictExpressionSubGroupBlock.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.formatter.block.conflict
+
+import com.intellij.lang.ASTNode
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
+import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
+
+class SqlConflictExpressionSubGroupBlock(
+    node: ASTNode,
+    context: SqlBlockFormattingContext,
+) : SqlSubGroupBlock(node, context)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElBlockCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElBlockCommentBlock.kt
@@ -25,6 +25,7 @@ import org.domaframework.doma.intellij.formatter.block.SqlOperationBlock
 import org.domaframework.doma.intellij.formatter.block.SqlUnknownBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlBlockCommentBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlCommentBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlValuesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.builder.SqlCustomSpacingBuilder
 import org.domaframework.doma.intellij.formatter.util.IndentType
@@ -128,16 +129,21 @@ open class SqlElBlockCommentBlock(
     override fun isLeaf(): Boolean = false
 
     override fun createBlockIndentLen(): Int {
-        parentBlock?.let {
-            if (it is SqlSubQueryGroupBlock) {
-                if (it.getChildBlocksDropLast().isEmpty()) {
+        parentBlock?.let { parent ->
+            if (parent is SqlSubQueryGroupBlock) {
+                if (parent.getChildBlocksDropLast().isEmpty()) {
                     return 0
                 }
-                if (it.isFirstLineComment) {
-                    return it.indent.groupIndentLen.minus(2)
+                if (parent.isFirstLineComment) {
+                    return parent.indent.groupIndentLen.minus(2)
                 }
+            }
+            if (parent is SqlValuesGroupBlock) {
+                return parent.indent.indentLen
             }
         }
         return 0
     }
+
+    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = parentBlock is SqlValuesGroupBlock
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/column/SqlColumnBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/column/SqlColumnBlock.kt
@@ -18,8 +18,8 @@ package org.domaframework.doma.intellij.formatter.block.group.column
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.SqlWordBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateTableColumnDefinitionGroupBlock
+import org.domaframework.doma.intellij.formatter.block.word.SqlWordBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlKeywordGroupBlock.kt
@@ -20,8 +20,6 @@ import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.common.util.TypeUtil
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlKeywordBlock
-import org.domaframework.doma.intellij.formatter.block.comment.SqlBlockCommentBlock
-import org.domaframework.doma.intellij.formatter.block.comment.SqlLineCommentBlock
 import org.domaframework.doma.intellij.formatter.block.group.SqlNewGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlSelectQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithCommonTableGroupBlock
@@ -40,8 +38,7 @@ open class SqlKeywordGroupBlock(
 
     fun updateTopKeywordBlocks(block: SqlBlock) {
         val lastChild =
-            getChildBlocksDropLast()
-                .findLast { it !is SqlLineCommentBlock && it !is SqlBlockCommentBlock }
+            getChildBlocksDropLast(skipCommentBlock = true).lastOrNull()
         val topKeywordTypes =
             listOf(
                 SqlKeywordBlock::class,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/create/SqlCreateKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/create/SqlCreateKeywordGroupBlock.kt
@@ -18,8 +18,8 @@ package org.domaframework.doma.intellij.formatter.block.group.keyword.create
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.SqlTableBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.word.SqlTableBlock
 import org.domaframework.doma.intellij.formatter.util.CreateQueryType
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/insert/SqlInsertValueGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/insert/SqlInsertValueGroupBlock.kt
@@ -17,13 +17,13 @@ package org.domaframework.doma.intellij.formatter.block.group.keyword.insert
 
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlValuesParamGroupBlock
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
 class SqlInsertValueGroupBlock(
     node: ASTNode,
     context: SqlBlockFormattingContext,
-) : SqlSubGroupBlock(
+) : SqlValuesParamGroupBlock(
         node,
         context,
     ) {
@@ -41,4 +41,6 @@ class SqlInsertValueGroupBlock(
             return parent.indent.groupIndentLen.plus(1)
         } ?: return 1
     }
+
+    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = false
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlFromGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlFromGroupBlock.kt
@@ -17,21 +17,19 @@ package org.domaframework.doma.intellij.formatter.block.group.keyword.second
 
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertQueryGroupBlock
-import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlValuesParamGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlDeleteQueryGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlSelectQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
-class SqlValuesGroupBlock(
+class SqlFromGroupBlock(
     node: ASTNode,
     context: SqlBlockFormattingContext,
 ) : SqlSecondKeywordBlock(node, context) {
-    val valueGroupBlocks: MutableList<SqlValuesParamGroupBlock> = mutableListOf()
+    val tableBlocks: MutableList<SqlBlock> = mutableListOf()
 
     override fun setParentPropertyBlock(lastGroup: SqlBlock?) {
-        if (lastGroup is SqlInsertQueryGroupBlock) {
-            lastGroup.valueKeywordBlock = this
-        }
+        (lastGroup as? SqlSelectQueryGroupBlock)?.secondGroupBlocks?.add(this)
     }
 
-    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = parentBlock is SqlInsertQueryGroupBlock
+    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = parentBlock !is SqlDeleteQueryGroupBlock && super.isSaveSpace(lastGroup)
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlSecondKeywordBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/second/SqlSecondKeywordBlock.kt
@@ -19,6 +19,7 @@ import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlKeywordBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 import org.domaframework.doma.intellij.formatter.util.SqlKeywordUtil
@@ -40,6 +41,8 @@ open class SqlSecondKeywordBlock(
             val groupLen = parent.indent.groupIndentLen
             return if (parent.indent.indentLevel == IndentType.FILE) {
                 offset
+            } else if (parent is SqlSubGroupBlock) {
+                groupLen.plus(1)
             } else {
                 groupLen.minus(this.getNodeText().length)
             }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/with/SqlWithCommonTableGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/with/SqlWithCommonTableGroupBlock.kt
@@ -18,9 +18,9 @@ package org.domaframework.doma.intellij.formatter.block.group.keyword.with
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.common.util.TypeUtil
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.SqlWordBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlBlockCommentBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
+import org.domaframework.doma.intellij.formatter.block.word.SqlWordBlock
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
 class SqlWithCommonTableGroupBlock(

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlParallelListBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlParallelListBlock.kt
@@ -16,8 +16,6 @@
 package org.domaframework.doma.intellij.formatter.block.group.subgroup
 
 import com.intellij.lang.ASTNode
-import org.domaframework.doma.intellij.formatter.block.comment.SqlBlockCommentBlock
-import org.domaframework.doma.intellij.formatter.block.comment.SqlLineCommentBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
@@ -44,8 +42,7 @@ class SqlParallelListBlock(
     override fun createBlockIndentLen(): Int {
         parentBlock?.let { parent ->
             return parent
-                .getChildBlocksDropLast()
-                .filter { it !is SqlLineCommentBlock && it !is SqlBlockCommentBlock }
+                .getChildBlocksDropLast(skipCommentBlock = true)
                 .sumOf { it.getNodeText().length.plus(1) }
                 .plus(parent.indent.indentLen)
                 .plus(parent.getNodeText().length)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubGroupBlock.kt
@@ -27,6 +27,7 @@ import org.domaframework.doma.intellij.formatter.block.conflict.SqlDoGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.SqlNewGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlLateralGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateViewGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlFromGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlJoinQueriesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithCommonTableGroupBlock
@@ -69,6 +70,9 @@ abstract class SqlSubGroupBlock(
     override fun setParentPropertyBlock(lastGroup: SqlBlock?) {
         (lastGroup as? SqlDoGroupBlock)?.doQueryBlock = this
         (lastGroup as? SqlLateralGroupBlock)?.subQueryGroupBlock = this
+        if (lastGroup is SqlFromGroupBlock) {
+            if (lastGroup.tableBlocks.isEmpty()) lastGroup.tableBlocks.add(this)
+        }
     }
 
     override fun addChildBlock(childBlock: SqlBlock) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlValuesParamGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlValuesParamGroupBlock.kt
@@ -13,30 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block
+package org.domaframework.doma.intellij.formatter.block.group.subgroup
 
 import com.intellij.lang.ASTNode
-import com.intellij.psi.formatter.common.AbstractBlock
-import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateKeywordGroupBlock
-import org.domaframework.doma.intellij.formatter.util.CreateQueryType
+import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlValuesGroupBlock
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
-class SqlTableBlock(
+open class SqlValuesParamGroupBlock(
     node: ASTNode,
     context: SqlBlockFormattingContext,
-) : SqlWordBlock(
-        node,
-        context,
-    ) {
-    override fun setParentGroupBlock(lastGroup: SqlBlock?) {
-        super.setParentGroupBlock(lastGroup)
-    }
-
+) : SqlSubGroupBlock(node, context) {
     override fun setParentPropertyBlock(lastGroup: SqlBlock?) {
-        if (lastGroup is SqlCreateKeywordGroupBlock && lastGroup.createType == CreateQueryType.TABLE) {
-            lastGroup.tableBlock = this
-        }
+        (lastGroup as? SqlValuesGroupBlock)?.valueGroupBlocks?.add(this)
     }
 
-    override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
+    override fun createBlockIndentLen(): Int {
+        parentBlock?.let { parent ->
+            return parent.indent.indentLen
+        }
+
+        return offset
+    }
+
+    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = parentBlock is SqlValuesGroupBlock
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/word/SqlAliasBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/word/SqlAliasBlock.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.formatter.block.word
+
+import com.intellij.lang.ASTNode
+import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
+
+class SqlAliasBlock(
+    node: ASTNode,
+    context: SqlBlockFormattingContext,
+) : SqlWordBlock(node, context)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/word/SqlTableBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/word/SqlTableBlock.kt
@@ -13,45 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block.group.keyword
+package org.domaframework.doma.intellij.formatter.block.word
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlFromGroupBlock
-import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
-import org.domaframework.doma.intellij.formatter.util.IndentType
+import org.domaframework.doma.intellij.formatter.util.CreateQueryType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
-class SqlLateralGroupBlock(
+class SqlTableBlock(
     node: ASTNode,
     context: SqlBlockFormattingContext,
-) : SqlKeywordGroupBlock(
+) : SqlWordBlock(
         node,
-        IndentType.OPTIONS,
         context,
     ) {
-    var subQueryGroupBlock: SqlSubGroupBlock? = null
-
     override fun setParentGroupBlock(lastGroup: SqlBlock?) {
         super.setParentGroupBlock(lastGroup)
-        indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = createGroupIndentLen()
     }
 
     override fun setParentPropertyBlock(lastGroup: SqlBlock?) {
+        if (lastGroup is SqlCreateKeywordGroupBlock && lastGroup.createType == CreateQueryType.TABLE) {
+            lastGroup.tableBlock = this
+        }
         if (lastGroup is SqlFromGroupBlock) {
             if (lastGroup.tableBlocks.isEmpty()) lastGroup.tableBlocks.add(this)
         }
     }
 
-    override fun createBlockIndentLen(): Int {
-        parentBlock?.let { parent ->
-            return parent.indent.groupIndentLen.plus(1)
-        }
-        return 0
-    }
-
-    override fun createGroupIndentLen(): Int = indent.indentLen.plus(getNodeText().length)
-
-    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = false
+    override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/word/SqlWordBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/word/SqlWordBlock.kt
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.formatter.block
+package org.domaframework.doma.intellij.formatter.block.word
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
+import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithCommonTableGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
@@ -123,27 +123,29 @@ class SqlCustomSpacingBuilder {
     }
 
     fun getSpacingRightPattern(block: SqlRightPatternBlock): Spacing? {
-        val paramBlock = block.parentBlock
-        return when {
-            paramBlock is SqlCreateTableColumnDefinitionGroupBlock ||
-                paramBlock is SqlUpdateColumnGroupBlock ||
-                (paramBlock is SqlUpdateValueGroupBlock) -> {
-                return getSpacing(block)
-            }
+        val parentBlock = block.parentBlock
 
-            paramBlock is SqlParallelListBlock -> {
-                val lastKeywordGroup = paramBlock.getChildBlocksDropLast().lastOrNull()
-                return if (lastKeywordGroup is SqlKeywordGroupBlock) {
-                    normalSpacing
-                } else {
-                    nonSpacing
-                }
-            }
-
-            paramBlock is SqlDataTypeParamBlock -> nonSpacing
-
-            block.preSpaceRight -> normalSpacing
-            else -> nonSpacing
+        if (block.isSaveSpace(null)) {
+            return getSpacing(block)
         }
+
+        if (parentBlock is SqlCreateTableColumnDefinitionGroupBlock ||
+            parentBlock is SqlUpdateColumnGroupBlock ||
+            parentBlock is SqlUpdateValueGroupBlock
+        ) {
+            return getSpacing(block)
+        }
+
+        if (parentBlock is SqlParallelListBlock) {
+            val lastKeywordGroup = parentBlock.getChildBlocksDropLast().lastOrNull()
+            return if (lastKeywordGroup is SqlKeywordGroupBlock) {
+                normalSpacing
+            } else {
+                nonSpacing
+            }
+        }
+
+        if (parentBlock is SqlDataTypeParamBlock || !block.preSpaceRight) return nonSpacing
+        return normalSpacing
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/InsertClauseUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/InsertClauseUtil.kt
@@ -32,7 +32,7 @@ object InsertClauseUtil {
         if (lastGroup is SqlInsertQueryGroupBlock) {
             return SqlInsertColumnGroupBlock(child, sqlBlockFormattingCtx)
         }
-        if (lastGroup is SqlValuesGroupBlock) {
+        if (lastGroup is SqlValuesGroupBlock && lastGroup.parentBlock is SqlInsertQueryGroupBlock) {
             return SqlInsertValueGroupBlock(child, sqlBlockFormattingCtx)
         }
         return null

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/visitor/SqlFormatVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/visitor/SqlFormatVisitor.kt
@@ -36,6 +36,11 @@ class SqlFormatVisitor : PsiRecursiveElementVisitor() {
             lastElement = element
         }
 
+        if (element.elementType == SqlTypes.BLOCK_COMMENT_START) {
+            replaces.add(element)
+            return
+        }
+
         if (PsiTreeUtil.getParentOfType(element, SqlBlockComment::class.java) == null) {
             when (element.elementType) {
                 SqlTypes.KEYWORD, SqlTypes.COMMA, SqlTypes.LEFT_PAREN, SqlTypes.RIGHT_PAREN, SqlTypes.WORD -> {
@@ -60,6 +65,8 @@ class SqlFormatVisitor : PsiRecursiveElementVisitor() {
                     ) {
                         replaces.add(element)
                     }
+
+                SqlTypes.BLOCK_COMMENT_START -> replaces.add(element)
             }
         }
     }
@@ -67,18 +74,6 @@ class SqlFormatVisitor : PsiRecursiveElementVisitor() {
     override fun visitWhiteSpace(space: PsiWhiteSpace) {
         super.visitWhiteSpace(space)
         if (PsiTreeUtil.getParentOfType(space, SqlBlockComment::class.java) == null) {
-            replaces.add(space)
-        }
-        return
-
-        val nextElement = space.nextSibling
-        if (nextElement != null &&
-            (
-                space.text.contains("\n") ||
-                    nextElement.elementType == SqlTypes.LINE_COMMENT ||
-                    nextElement.elementType == SqlTypes.BLOCK_COMMENT
-            )
-        ) {
             replaces.add(space)
         }
     }

--- a/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
@@ -66,6 +66,14 @@ class SqlFormatterTest : BasePlatformTestCase() {
         formatSqlFile("SelectJoinLateral.sql", "SelectJoinLateral$formatDataPrefix.sql")
     }
 
+    fun testSelectFromValuesFormatter() {
+        formatSqlFile("SelectFromValues.sql", "SelectFromValues$formatDataPrefix.sql")
+    }
+
+    fun testSelectFromValuesUserDirectiveFormatter() {
+        formatSqlFile("SelectFromValuesUserDirective.sql", "SelectFromValuesUserDirective$formatDataPrefix.sql")
+    }
+
     fun testCreateTableFormatter() {
         formatSqlFile("CreateTable.sql", "CreateTable$formatDataPrefix.sql")
     }

--- a/src/test/testData/sql/formatter/SelectFromValues.sql
+++ b/src/test/testData/sql/formatter/SelectFromValues.sql
@@ -1,0 +1,7 @@
+SELECT user_id
+  FROM ( SELECT user_id
+                , name
+           FROM employee
+                , ( VALUES (20000000001, 'John')    , (20000000002 'Tom')
+                    , (20000000003, 'Anna')
+) T (user_id, name) ) u 

--- a/src/test/testData/sql/formatter/SelectFromValuesUserDirective.sql
+++ b/src/test/testData/sql/formatter/SelectFromValuesUserDirective.sql
@@ -1,0 +1,4 @@
+SELECT user_id
+  FROM ( SELECT user_id, name
+           FROM employee emp, ( VALUES /*# usersList */) T(user_id, name)
+) u 

--- a/src/test/testData/sql/formatter/SelectFromValuesUserDirective_format.sql
+++ b/src/test/testData/sql/formatter/SelectFromValuesUserDirective_format.sql
@@ -1,0 +1,7 @@
+SELECT user_id
+  FROM ( SELECT user_id
+                , name
+           FROM employee emp
+                , ( VALUES
+                    /*# usersList */
+                  ) T (user_id, name) ) u 

--- a/src/test/testData/sql/formatter/SelectFromValues_format.sql
+++ b/src/test/testData/sql/formatter/SelectFromValues_format.sql
@@ -1,0 +1,9 @@
+SELECT user_id
+  FROM ( SELECT user_id
+                , name
+           FROM employee
+                , ( VALUES
+                    (20000000001, 'John')
+                    , (20000000002 'Tom')
+                    , (20000000003, 'Anna')
+                  ) T (user_id, name) ) u 


### PR DESCRIPTION
Implemented formatting rules for SQL statements that use "VALUES" as a data source instead of a table reference.

---

# VALUES Clause Formatting

* When "VALUES" is used inside a "FRO"` clause:

    * Each **value group** is **line-broken** and **aligned with the indentation level of "VALUES"**.
    * If a **Doma embedded variable directive** (e.g., `/*# usersList */`) is used, it is also aligned under "VALUES" with a line break.

## Example:

```sql
SELECT user_id
  FROM (
         SELECT user_id
              , name
           FROM employee emp
                , ( VALUES
                      /*# usersList */
                  ) T (user_id, name)
       ) u
```

---

## Additional Formatting Rule

* Defined "WORD" elements following "FROM" as **alias blocks** when they represent table aliases.
* Implemented a formatting rule for "column_alias" groups (e.g., `T (user_id, name)`):

    * **No line breaks**
    * Compact inline formatting for clarity.
