### PR TITLE
Adjust Value Group Spacing for INSERT and UPDATE Statements

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
@@ -40,8 +40,10 @@ import org.domaframework.doma.intellij.formatter.block.group.column.SqlColumnRaw
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.inline.SqlInlineGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.inline.SqlInlineSecondGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertValueGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateColumnAssignmentSymbolBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateSetGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateValueGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithCommonTableGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithQueryGroupBlock
@@ -483,8 +485,15 @@ class SqlFileBlock(
             return SqlCustomSpacingBuilder.normalSpacing
         }
 
-        if (childBlock1 is SqlSubGroupBlock && childBlock2 is SqlSubGroupBlock) {
-            return SqlCustomSpacingBuilder.nonSpacing
+        if (childBlock1 is SqlSubGroupBlock) {
+            if (childBlock2 is SqlSubGroupBlock) {
+                return SqlCustomSpacingBuilder.nonSpacing
+            }
+            if (childBlock1 is SqlInsertValueGroupBlock ||
+                childBlock1 is SqlUpdateValueGroupBlock
+            ) {
+                return SqlCustomSpacingBuilder.normalSpacing
+            }
         }
 
         // Do not leave a space after the comment block of the bind variable
@@ -546,8 +555,6 @@ class SqlFileBlock(
                 }
 
                 is SqlDataTypeParamBlock, is SqlFunctionParamBlock -> return SqlCustomSpacingBuilder.nonSpacing
-
-                // else -> return SqlCustomSpacingBuilder.normalSpacing
             }
         }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlRightPatternBlock.kt
@@ -24,6 +24,7 @@ import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordG
 import org.domaframework.doma.intellij.formatter.block.group.keyword.condition.SqlConditionalExpressionGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateTableColumnDefinitionGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertColumnGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertValueGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlValuesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateColumnGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.update.SqlUpdateSetGroupBlock
@@ -66,6 +67,7 @@ open class SqlRightPatternBlock(
                 SqlUpdateColumnGroupBlock::class,
                 SqlUpdateValueGroupBlock::class,
                 SqlCreateTableColumnDefinitionGroupBlock::class,
+                SqlInsertValueGroupBlock::class,
             )
 
         val NOT_INDENT_EXPECTED_TYPES =

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/insert/SqlInsertValueGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/insert/SqlInsertValueGroupBlock.kt
@@ -29,7 +29,7 @@ class SqlInsertValueGroupBlock(
     ) {
     override fun setParentGroupBlock(lastGroup: SqlBlock?) {
         super.setParentGroupBlock(lastGroup)
-        indent.groupIndentLen = createBlockIndentLen()
+        indent.groupIndentLen = createBlockIndentLen().plus(1)
     }
 
     override fun setParentPropertyBlock(lastGroup: SqlBlock?) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/update/SqlUpdateValueGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/update/SqlUpdateValueGroupBlock.kt
@@ -62,7 +62,8 @@ class SqlUpdateValueGroupBlock(
         parentBlock?.let { parent ->
             if (parent is SqlUpdateSetGroupBlock) {
                 val parentGroupIndent = parent.indent.groupIndentLen
-                return parentGroupIndent.plus(3)
+                // Add four spaces after the SET keyword: " = " and "("
+                return parentGroupIndent.plus(4)
             }
         } ?: return offset
         return offset

--- a/src/test/testData/sql/formatter/InsertConflictNothing_format.sql
+++ b/src/test/testData/sql/formatter/InsertConflictNothing_format.sql
@@ -2,6 +2,6 @@ INSERT INTO employee
             (id
              , username)
      VALUES ( /* employees.id */0
-             , /* employees.name */'name')
+              , /* employees.name */'name' )
 ON CONFLICT (username) ON CONSTRAINT
 DO NOTHING 

--- a/src/test/testData/sql/formatter/InsertConflictUpdateWithOutTable_format.sql
+++ b/src/test/testData/sql/formatter/InsertConflictUpdateWithOutTable_format.sql
@@ -1,8 +1,8 @@
 INSERT INTO users
             (username
              , email)
-     VALUES ('user'
-             , 'user@example.com')
+     VALUES ( 'user'
+              , 'user@example.com' )
 ON CONFLICT ON CONSTRAINT
 DO UPDATE
       SET email = EXCLUDED.email

--- a/src/test/testData/sql/formatter/InsertReturning_format.sql
+++ b/src/test/testData/sql/formatter/InsertReturning_format.sql
@@ -7,15 +7,15 @@ INSERT INTO /*# tableName */
              , x3
              , x4)
      VALUES ( /* reportId */1
-             , /* reportId */1
-             /*%for entity : entities */
-             , /* entity.value */'abc'
-             /*%end*/
-             , /* @userId() */1
-             , x5
-             , /* @userId() */1
-             , x6
-             , 1
-             , /* @maxDateTime() */'9999-12-31')
+              , /* reportId */1
+              /*%for entity : entities */
+              , /* entity.value */'abc'
+              /*%end*/
+              , /* @userId() */1
+              , x5
+              , /* @userId() */1
+              , x6
+              , 1
+              , /* @maxDateTime() */'9999-12-31' )
 RETURNING x1
           , x2 

--- a/src/test/testData/sql/formatter/InsertWithBindVariable_format.sql
+++ b/src/test/testData/sql/formatter/InsertWithBindVariable_format.sql
@@ -7,13 +7,13 @@ INSERT INTO /*# tableName */
              , x3
              , x4)
      VALUES ( /* reportId */1
-             , /* reportId */1
-             /*%for entity : entities */
-             , /* entity.value */'abc'
-             /*%end*/
-             , /* @userId() */1
-             , x5
-             , /* @userId() */1
-             , x6
-             , 1
-             , /* @maxDateTime() */'9999-12-31') 
+              , /* reportId */1
+              /*%for entity : entities */
+              , /* entity.value */'abc'
+              /*%end*/
+              , /* @userId() */1
+              , x5
+              , /* @userId() */1
+              , x6
+              , 1
+              , /* @maxDateTime() */'9999-12-31' ) 

--- a/src/test/testData/sql/formatter/Insert_format.sql
+++ b/src/test/testData/sql/formatter/Insert_format.sql
@@ -7,13 +7,13 @@ INSERT INTO /*# tableName */
              , x3
              , x4)
      VALUES ( /* reportId */1
-             , /* reportId */1
-             /*%for entity : entities */
-             , /* entity.value */'abc'
-             /*%end*/
-             , /* @userId() */1
-             , x5
-             , /* @userId() */1
-             , x6
-             , 1
-             , /* @maxDateTime() */'9999-12-31') 
+              , /* reportId */1
+              /*%for entity : entities */
+              , /* entity.value */'abc'
+              /*%end*/
+              , /* @userId() */1
+              , x5
+              , /* @userId() */1
+              , x6
+              , 1
+              , /* @maxDateTime() */'9999-12-31' ) 

--- a/src/test/testData/sql/formatter/UpdateTupleAssignment_format.sql
+++ b/src/test/testData/sql/formatter/UpdateTupleAssignment_format.sql
@@ -7,10 +7,10 @@ UPDATE /*# tableName */
         /*%end*/
        )
        = ( /* @userId() */1
-          , x
-          , x + 1
-          /*%for entity : entities */
-          , /* entity.value */'abc'
-          /*%end*/
+           , x
+           , x + 1
+           /*%for entity : entities */
+           , /* entity.value */'abc'
+           /*%end*/
          )
  WHERE x = /* reportId */1 

--- a/src/test/testData/sql/formatter/WithInsert_format.sql
+++ b/src/test/testData/sql/formatter/WithInsert_format.sql
@@ -2,8 +2,8 @@ WITH new_user AS (
     INSERT INTO users
                 (name
                  , email)
-         VALUES ('Alice Example'
-                 , 'alice@example.com')
+         VALUES ( 'Alice Example'
+                  , 'alice@example.com' )
     RETURNING id
               , name
 )


### PR DESCRIPTION
Add spaces after "(" and before ")" in value groups for INSERT and bulk UPDATE SQL statements. Also align the indentation of values from the second line onwards to match the position of the first value element.
# Example:
```sql
INSERT INTO /*# tableName */
            (x1
             , x2
             /*%for entity : entities */
             , /*# entity.itemIdentifier */
             /*%end*/
             , x3
             , x4)
     VALUES ( /* reportId */1
              , /* reportId */1
              /*%for entity : entities */
              , /* entity.value */'abc'
              /*%end*/
              , /* @userId() */1
              , x5
              , /* @userId() */1
              , x6
              , 1
              , /* @maxDateTime() */'9999-12-31' )
```