### PR TITLE
Apply Formatting to Injected SQL

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
@@ -16,7 +16,6 @@
 package org.domaframework.doma.intellij.common.psi
 
 import com.intellij.lang.Language
-import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -150,7 +149,6 @@ class PsiDaoMethod(
         }
         // the injection part as a custom language file
         getSqlAnnotation()?.let { annotation ->
-            InjectedLanguageManager.getInstance(psiProject)
             annotation.parameterList.children
                 .firstOrNull { it is PsiNameValuePair }
                 ?.let { sql ->

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/util/InjectionSqlUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/util/InjectionSqlUtil.kt
@@ -13,26 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.domaframework.doma.intellij.inspection.sql.visitor
+package org.domaframework.doma.intellij.common.util
 
+import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiLiteralExpression
-import org.domaframework.doma.intellij.common.util.InjectionSqlUtil
-import org.domaframework.doma.intellij.psi.SqlVisitor
+import org.domaframework.doma.intellij.common.isJavaOrKotlinFileType
 
-open class SqlVisitorBase : SqlVisitor() {
-    /**
-     * For processing inside Sql annotations, get it as an injected custom language
-     */
-    protected fun initInjectionElement(
+object InjectionSqlUtil {
+    fun initInjectionElement(
         basePsiFile: PsiFile,
         project: Project,
         literal: PsiLiteralExpression,
     ): PsiFile? =
-        InjectionSqlUtil.initInjectionElement(
-            basePsiFile,
-            project,
-            literal,
-        )
+        if (isJavaOrKotlinFileType(basePsiFile)) {
+            val injectedLanguageManager = InjectedLanguageManager.getInstance(project)
+            injectedLanguageManager
+                .getInjectedPsiFiles(literal)
+                ?.firstOrNull()
+                ?.first as? PsiFile
+        } else {
+            null
+        }
+
+    fun isInjectedSqlFile(source: PsiFile): Boolean {
+        val injectedLanguageManager = InjectedLanguageManager.getInstance(source.project)
+        return injectedLanguageManager.isInjectedFragment(source)
+    }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/util/StringUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/util/StringUtil.kt
@@ -16,6 +16,8 @@
 package org.domaframework.doma.intellij.common.util
 
 object StringUtil {
+    const val LINE_SEPARATE: String = "\n"
+
     fun getSqlElClassText(text: String): String =
         text
             .substringAfter("@")

--- a/src/main/kotlin/org/domaframework/doma/intellij/document/ForItemElementDocumentationProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/document/ForItemElementDocumentationProvider.kt
@@ -18,6 +18,7 @@ package org.domaframework.doma.intellij.document
 import com.intellij.lang.documentation.AbstractDocumentationProvider
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
+import org.domaframework.doma.intellij.common.util.StringUtil
 import org.domaframework.doma.intellij.document.generator.DocumentDaoParameterGenerator
 import org.domaframework.doma.intellij.document.generator.DocumentStaticFieldGenerator
 import org.domaframework.doma.intellij.psi.SqlElIdExpr
@@ -62,7 +63,7 @@ class ForItemElementDocumentationProvider : AbstractDocumentationProvider() {
 
         generator.generateDocument()
 
-        return result.joinToString("\n")
+        return result.joinToString(StringUtil.LINE_SEPARATE)
     }
 
     override fun generateHoverDoc(
@@ -77,6 +78,6 @@ class ForItemElementDocumentationProvider : AbstractDocumentationProvider() {
         val result: MutableList<String?> = LinkedList<String?>()
         val typeDocument = generateDoc(element, originalElement)
         result.add(typeDocument)
-        return result.joinToString("\n")
+        return result.joinToString(StringUtil.LINE_SEPARATE)
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlBlockCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlBlockCommentBlock.kt
@@ -17,6 +17,7 @@ package org.domaframework.doma.intellij.formatter.block.comment
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.util.PsiTreeUtil
+import org.domaframework.doma.intellij.common.util.StringUtil
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
@@ -27,5 +28,6 @@ open class SqlBlockCommentBlock(
         node,
         context,
     ) {
-    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = PsiTreeUtil.prevLeaf(node.psi)?.text?.contains("\n") == true
+    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean =
+        PsiTreeUtil.prevLeaf(node.psi)?.text?.contains(StringUtil.LINE_SEPARATE) == true
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlDefaultCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlDefaultCommentBlock.kt
@@ -18,6 +18,7 @@ package org.domaframework.doma.intellij.formatter.block.comment
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import com.intellij.psi.util.PsiTreeUtil
+import org.domaframework.doma.intellij.common.util.StringUtil
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
@@ -60,5 +61,5 @@ abstract class SqlDefaultCommentBlock(
             }
     }
 
-    override fun isSaveSpace(lastGroup: SqlBlock?) = PsiTreeUtil.prevLeaf(node.psi)?.text?.contains("\n") == true
+    override fun isSaveSpace(lastGroup: SqlBlock?) = PsiTreeUtil.prevLeaf(node.psi)?.text?.contains(StringUtil.LINE_SEPARATE) == true
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlElConditionLoopCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlElConditionLoopCommentBlock.kt
@@ -22,6 +22,7 @@ import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.formatter.common.AbstractBlock
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
+import org.domaframework.doma.intellij.common.util.StringUtil
 import org.domaframework.doma.intellij.common.util.TypeUtil
 import org.domaframework.doma.intellij.extension.expr.isConditionOrLoopDirective
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
@@ -108,7 +109,7 @@ class SqlElConditionLoopCommentBlock(
                 // If the child is a condition loop directive, align its indentation with the parent directive
                 child.indent.indentLen = indent.indentLen.plus(2)
             } else if (child is SqlLineCommentBlock) {
-                if (PsiTreeUtil.prevLeaf(child.node.psi, false)?.text?.contains("\n") == true) {
+                if (PsiTreeUtil.prevLeaf(child.node.psi, false)?.text?.contains(StringUtil.LINE_SEPARATE) == true) {
                     child.indent.indentLen = indent.groupIndentLen
                 } else {
                     child.indent.indentLen = 1

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
@@ -19,6 +19,7 @@ import com.intellij.formatting.ASTBlock
 import com.intellij.formatting.Block
 import com.intellij.formatting.Spacing
 import com.intellij.psi.tree.IElementType
+import org.domaframework.doma.intellij.common.util.StringUtil
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlRightPatternBlock
 import org.domaframework.doma.intellij.formatter.block.SqlWhitespaceBlock
@@ -79,8 +80,8 @@ class SqlCustomSpacingBuilder {
             null -> return nonSpacing
             is SqlWhitespaceBlock -> {
                 val indentLen: Int = child2.indent.indentLen
-                val afterNewLine = child1.getNodeText().substringAfterLast("\n", "")
-                if (child1.getNodeText().contains("\n")) {
+                val afterNewLine = child1.getNodeText().substringAfterLast(StringUtil.LINE_SEPARATE, "")
+                if (child1.getNodeText().contains(StringUtil.LINE_SEPARATE)) {
                     val currentIndent = afterNewLine.length
                     val newIndent =
                         if (currentIndent != indentLen) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlFormattingModelBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlFormattingModelBuilder.kt
@@ -38,25 +38,35 @@ import org.domaframework.doma.intellij.setting.state.DomaToolsFormatEnableSettin
 class SqlFormattingModelBuilder : FormattingModelBuilder {
     override fun createModel(formattingContext: FormattingContext): FormattingModel {
         val codeStyleSettings = formattingContext.codeStyleSettings
+
+        return createRegularSQLModel(formattingContext, codeStyleSettings)
+    }
+
+    private fun createRegularSQLModel(
+        formattingContext: FormattingContext,
+        settings: CodeStyleSettings,
+    ): FormattingModel {
         val setting = DomaToolsFormatEnableSettings.getInstance()
         val isEnableFormat = setting.state.isEnableSqlFormat == true
         val formatMode = formattingContext.formattingMode
-        val spacingBuilder = createSpaceBuilder(codeStyleSettings)
+        val spacingBuilder = createSpaceBuilder(settings)
         val customSpacingBuilder = createCustomSpacingBuilder()
 
+        val block =
+            SqlFileBlock(
+                formattingContext.node,
+                Wrap.createWrap(WrapType.NONE, false),
+                Alignment.createAlignment(),
+                customSpacingBuilder,
+                spacingBuilder,
+                isEnableFormat,
+                formatMode,
+            )
         return FormattingModelProvider
             .createFormattingModelForPsiFile(
                 formattingContext.containingFile,
-                SqlFileBlock(
-                    formattingContext.node,
-                    Wrap.createWrap(WrapType.NONE, false),
-                    Alignment.createAlignment(),
-                    customSpacingBuilder,
-                    spacingBuilder,
-                    isEnableFormat,
-                    formatMode,
-                ),
-                codeStyleSettings,
+                block,
+                settings,
             )
     }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPostProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPostProcessor.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.formatter.processor
+
+import com.intellij.lang.injection.InjectedLanguageManager
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import org.domaframework.doma.intellij.setting.SqlLanguage
+
+class SqlFormatPostProcessor : SqlPostProcessor() {
+    override fun processElement(
+        source: PsiElement,
+        settings: CodeStyleSettings,
+    ): PsiElement = source
+
+    override fun processText(
+        source: PsiFile,
+        rangeToReformat: TextRange,
+        settings: CodeStyleSettings,
+    ): TextRange {
+        if (!isSqlFile(source) || isInjectedSqlFile(source)) {
+            return rangeToReformat
+        }
+
+        val document = getDocument(source) ?: return rangeToReformat
+        val processedText = processDocumentText(document.text, true)
+
+        if (document.text == processedText) {
+            return rangeToReformat
+        }
+
+        updateDocument(source.project, document, processedText)
+        return TextRange(0, processedText.length)
+    }
+
+    private fun isSqlFile(source: PsiFile): Boolean = source.language == SqlLanguage.INSTANCE
+
+    private fun isInjectedSqlFile(source: PsiFile): Boolean {
+        val injectedLanguageManager = InjectedLanguageManager.getInstance(source.project)
+        return injectedLanguageManager.isInjectedFragment(source)
+    }
+
+    private fun getDocument(source: PsiFile) = PsiDocumentManager.getInstance(source.project).getDocument(source)
+
+    private fun updateDocument(
+        project: Project,
+        document: Document,
+        newText: String,
+    ) {
+        ApplicationManager.getApplication().invokeAndWait {
+            WriteCommandAction.runWriteCommandAction(project) {
+                document.setText(newText)
+                PsiDocumentManager.getInstance(project).commitDocument(document)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
@@ -26,7 +26,9 @@ import com.intellij.psi.TokenType
 import com.intellij.psi.impl.source.codeStyle.PreFormatProcessor
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
+import org.domaframework.doma.intellij.common.util.InjectionSqlUtil.isInjectedSqlFile
 import org.domaframework.doma.intellij.common.util.PluginLoggerUtil
+import org.domaframework.doma.intellij.common.util.StringUtil
 import org.domaframework.doma.intellij.formatter.util.CreateQueryType
 import org.domaframework.doma.intellij.formatter.util.SqlKeywordUtil
 import org.domaframework.doma.intellij.formatter.visitor.SqlFormatVisitor
@@ -58,7 +60,10 @@ class SqlFormatPreProcessor : PreFormatProcessor {
         rangeToReformat: TextRange,
     ): TextRange {
         // Turn on by default the code formatter that only runs when explicitly invoked by the user.
-        if (source.language != SqlLanguage.INSTANCE) return rangeToReformat
+        // Handle both direct SQL files and injected SQL in Java files
+        if (source.language != SqlLanguage.INSTANCE && !isInjectedSqlFile(source)) {
+            return rangeToReformat
+        }
 
         logging()
 
@@ -151,7 +156,6 @@ class SqlFormatPreProcessor : PreFormatProcessor {
         element: PsiWhiteSpace,
     ) {
         val singleSpace = " "
-        val newLine = "\n"
         val range = element.textRange
         val originalText = document.getText(range)
         val nextElement = element.nextSibling
@@ -162,24 +166,28 @@ class SqlFormatPreProcessor : PreFormatProcessor {
             newText = originalText.replace(originalText, singleSpace)
         } else {
             newText =
-                when (nextElement.elementType) {
-                    SqlTypes.LINE_COMMENT -> {
-                        if (nextElementText.startsWith(newLine)) {
-                            originalText.replace(originalText, singleSpace)
-                        } else if (originalText.contains(newLine)) {
-                            originalText.replace(Regex("\\s*\\n\\s*"), newLine)
-                        } else {
-                            originalText.replace(originalText, singleSpace)
+                if (element.prevSibling == null) {
+                    ""
+                } else {
+                    when (nextElement.elementType) {
+                        SqlTypes.LINE_COMMENT -> {
+                            if (nextElementText.startsWith(StringUtil.LINE_SEPARATE)) {
+                                originalText.replace(originalText, singleSpace)
+                            } else if (originalText.contains(StringUtil.LINE_SEPARATE)) {
+                                originalText.replace(Regex("\\s*\\n\\s*"), StringUtil.LINE_SEPARATE)
+                            } else {
+                                originalText.replace(originalText, singleSpace)
+                            }
                         }
-                    }
 
-                    else -> {
-                        if (nextElementText.contains(newLine) == true) {
-                            originalText.replace(originalText, singleSpace)
-                        } else if (originalText.contains(newLine)) {
-                            originalText.replace(Regex("\\s*\\n\\s*"), newLine)
-                        } else {
-                            originalText.replace(originalText, newLine)
+                        else -> {
+                            if (nextElementText.contains(StringUtil.LINE_SEPARATE) == true) {
+                                originalText.replace(originalText, singleSpace)
+                            } else if (originalText.contains(StringUtil.LINE_SEPARATE)) {
+                                originalText.replace(Regex("\\s*\\n\\s*"), StringUtil.LINE_SEPARATE)
+                            } else {
+                                originalText.replace(originalText, StringUtil.LINE_SEPARATE)
+                            }
                         }
                     }
                 }
@@ -264,8 +272,8 @@ class SqlFormatPreProcessor : PreFormatProcessor {
         prevElement: PsiElement?,
         text: String,
     ): String =
-        if (prevElement?.text?.contains("\n") == false) {
-            "\n$text"
+        if (prevElement?.text?.contains(StringUtil.LINE_SEPARATE) == false) {
+            "${StringUtil.LINE_SEPARATE}$text"
         } else {
             text
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
@@ -272,7 +272,9 @@ class SqlFormatPreProcessor : PreFormatProcessor {
         prevElement: PsiElement?,
         text: String,
     ): String =
-        if (prevElement?.text?.contains(StringUtil.LINE_SEPARATE) == false) {
+        if (prevElement?.text?.contains(StringUtil.LINE_SEPARATE) == false &&
+            PsiTreeUtil.prevLeaf(prevElement) != null
+        ) {
             "${StringUtil.LINE_SEPARATE}$text"
         } else {
             text

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlInjectionPostProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlInjectionPostProcessor.kt
@@ -20,12 +20,11 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleSettings
-import com.intellij.psi.impl.source.codeStyle.PostFormatProcessor
 import org.domaframework.doma.intellij.common.dao.getDaoClass
 import org.domaframework.doma.intellij.common.isJavaOrKotlinFileType
 import org.domaframework.doma.intellij.formatter.visitor.DaoInjectionSqlVisitor
 
-class SqlInjectionPostProcessor : PostFormatProcessor {
+class SqlInjectionPostProcessor : SqlPostProcessor() {
     override fun processElement(
         element: PsiElement,
         settings: CodeStyleSettings,
@@ -46,6 +45,8 @@ class SqlInjectionPostProcessor : PostFormatProcessor {
         val project: Project = element.project
         val visitor = DaoInjectionSqlVisitor(element, project)
         element.accept(visitor)
-        visitor.processAll()
+        visitor.processAll { text, skipFinalLineBreak ->
+            processDocumentText(text, skipFinalLineBreak)
+        }
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlInjectionPostProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlInjectionPostProcessor.kt
@@ -21,6 +21,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.impl.source.codeStyle.PostFormatProcessor
+import org.domaframework.doma.intellij.common.dao.getDaoClass
 import org.domaframework.doma.intellij.common.isJavaOrKotlinFileType
 import org.domaframework.doma.intellij.formatter.visitor.DaoInjectionSqlVisitor
 
@@ -35,7 +36,7 @@ class SqlInjectionPostProcessor : PostFormatProcessor {
         rangeToReformat: TextRange,
         settings: CodeStyleSettings,
     ): TextRange {
-        if (!isJavaOrKotlinFileType(source)) return rangeToReformat
+        if (!isJavaOrKotlinFileType(source) || getDaoClass(source) == null) return rangeToReformat
 
         processInjected(source)
         return rangeToReformat

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlInjectionPostProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlInjectionPostProcessor.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.formatter.processor
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import com.intellij.psi.impl.source.codeStyle.PostFormatProcessor
+import org.domaframework.doma.intellij.common.isJavaOrKotlinFileType
+import org.domaframework.doma.intellij.formatter.visitor.DaoInjectionSqlVisitor
+
+class SqlInjectionPostProcessor : PostFormatProcessor {
+    override fun processElement(
+        element: PsiElement,
+        settings: CodeStyleSettings,
+    ): PsiElement = element
+
+    override fun processText(
+        source: PsiFile,
+        rangeToReformat: TextRange,
+        settings: CodeStyleSettings,
+    ): TextRange {
+        if (!isJavaOrKotlinFileType(source)) return rangeToReformat
+
+        processInjected(source)
+        return rangeToReformat
+    }
+
+    private fun processInjected(element: PsiFile) {
+        val project: Project = element.project
+        val visitor = DaoInjectionSqlVisitor(element, project)
+        element.accept(visitor)
+        visitor.processAll()
+    }
+}

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlPostProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlPostProcessor.kt
@@ -15,7 +15,6 @@
  */
 package org.domaframework.doma.intellij.formatter.processor
 
-import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlPostProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlPostProcessor.kt
@@ -15,8 +15,10 @@
  */
 package org.domaframework.doma.intellij.formatter.processor
 
+import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiDocumentManager
@@ -24,11 +26,13 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.impl.source.codeStyle.PostFormatProcessor
+import org.domaframework.doma.intellij.common.util.InjectionSqlUtil.isInjectedSqlFile
+import org.domaframework.doma.intellij.common.util.StringUtil
 import org.domaframework.doma.intellij.setting.SqlLanguage
 
 class SqlPostProcessor : PostFormatProcessor {
     companion object {
-        private const val FILE_END_PADDING = " \n"
+        private const val FILE_END_PADDING = " ${StringUtil.LINE_SEPARATE}"
     }
 
     private val trailingSpacesRegex = Regex(" +(\r?\n)")
@@ -43,12 +47,13 @@ class SqlPostProcessor : PostFormatProcessor {
         rangeToReformat: TextRange,
         settings: CodeStyleSettings,
     ): TextRange {
-        if (!isSqlFile(source)) {
+        if (!isSqlFile(source) || isInjectedSqlFile(source)) {
             return rangeToReformat
         }
 
-        val document = getDocument(source) ?: return rangeToReformat
-        val processedText = processDocumentText(document.text)
+        val originalDocument = getDocument(source)
+        val document = originalDocument ?: source.fileDocument
+        val processedText = processDocumentText(document.text, originalDocument != null)
 
         if (document.text == processedText) {
             return rangeToReformat
@@ -62,18 +67,26 @@ class SqlPostProcessor : PostFormatProcessor {
 
     private fun getDocument(source: PsiFile) = PsiDocumentManager.getInstance(source.project).getDocument(source)
 
-    private fun processDocumentText(originalText: String): String {
+    private fun processDocumentText(
+        originalText: String,
+        existsOriginalDocument: Boolean,
+    ): String {
         val withoutTrailingSpaces = removeTrailingSpaces(originalText)
-        return ensureProperFileEnding(withoutTrailingSpaces)
+        return ensureProperFileEnding(withoutTrailingSpaces, existsOriginalDocument)
     }
 
     private fun removeTrailingSpaces(text: String): String = text.replace(trailingSpacesRegex, "$1")
 
-    private fun ensureProperFileEnding(text: String): String = text.trimEnd() + FILE_END_PADDING
+    private fun ensureProperFileEnding(
+        text: String,
+        isEndSpace: Boolean,
+    ): String =
+        text.trimEnd() +
+            if (isEndSpace) FILE_END_PADDING else ""
 
     private fun updateDocument(
         project: Project,
-        document: com.intellij.openapi.editor.Document,
+        document: Document,
         newText: String,
     ) {
         ApplicationManager.getApplication().invokeAndWait {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/visitor/DaoInjectionSqlVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/visitor/DaoInjectionSqlVisitor.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.formatter.visitor
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.JavaRecursiveElementVisitor
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.codeStyle.CodeStyleManager
+import org.domaframework.doma.intellij.common.util.InjectionSqlUtil
+import org.domaframework.doma.intellij.common.util.StringUtil
+
+class DaoInjectionSqlVisitor(
+    private val element: PsiFile,
+    private val project: Project,
+) : JavaRecursiveElementVisitor() {
+    private data class FormattingTask(
+        val expression: PsiLiteralExpression,
+        val formattedText: String,
+    )
+
+    companion object {
+        private const val TEMP_FILE_PREFIX = "temp_format"
+        private const val SQL_FILE_EXTENSION = ".sql"
+    }
+
+    private val formattingTasks = mutableListOf<FormattingTask>()
+
+    override fun visitLiteralExpression(expression: PsiLiteralExpression) {
+        super.visitLiteralExpression(expression)
+        val injected: PsiFile? = InjectionSqlUtil.initInjectionElement(element, project, expression)
+        if (injected != null) {
+            // Format SQL and store the task
+            val formattedSql = formatInjectedSql(injected)
+            val originalText = expression.value?.toString() ?: return
+            if (formattedSql != originalText) {
+                formattingTasks.add(FormattingTask(expression, formattedSql))
+            }
+        }
+    }
+
+    fun processAll() {
+        if (formattingTasks.isEmpty()) return
+
+        // Apply all formatting tasks in a single write action
+        WriteCommandAction.runWriteCommandAction(project, "Format Injected SQL", null, {
+            // Sort by text range in descending order to maintain offsets
+            formattingTasks.sortedByDescending { it.expression.textRange.startOffset }.forEach { task ->
+                if (task.expression.isValid) {
+                    replaceHostStringLiteral(task.expression, task.formattedText)
+                }
+            }
+        })
+    }
+
+    private fun formatInjectedSql(injectedFile: PsiFile): String =
+        try {
+            val originalSqlText = injectedFile.text
+            formatAsTemporarySqlFile(originalSqlText)
+        } catch (_: Exception) {
+            injectedFile.text
+        }
+
+    /**
+     * Execute formatting as a temporary SQL file
+     */
+    private fun formatAsTemporarySqlFile(sqlText: String): String =
+        try {
+            val tempFileName = "${TEMP_FILE_PREFIX}${SQL_FILE_EXTENSION}"
+            val fileType = FileTypeManager.getInstance().getFileTypeByExtension("sql")
+
+            val tempSqlFile =
+                PsiFileFactory
+                    .getInstance(project)
+                    .createFileFromText(tempFileName, fileType, sqlText)
+
+            val codeStyleManager = CodeStyleManager.getInstance(project)
+            val textRange = TextRange(0, tempSqlFile.textLength)
+            codeStyleManager.reformatText(tempSqlFile, textRange.startOffset, textRange.endOffset)
+
+            tempSqlFile.text
+        } catch (_: Exception) {
+            sqlText
+        }
+
+    /**
+     * Directly replace host Java string literal
+     */
+    private fun replaceHostStringLiteral(
+        literalExpression: PsiLiteralExpression,
+        formattedSqlText: String,
+    ) {
+        try {
+            // Create new string literal
+            val newLiteralText = createFormattedLiteralText(formattedSqlText)
+
+            // Replace PSI element
+            val elementFactory =
+                com.intellij.psi.JavaPsiFacade
+                    .getElementFactory(project)
+            val newLiteral = elementFactory.createExpressionFromText(newLiteralText, literalExpression)
+            val manager = PsiDocumentManager.getInstance(literalExpression.project)
+            val document = manager.getDocument(literalExpression.containingFile) ?: return
+            document.replaceString(literalExpression.textRange.startOffset, literalExpression.textRange.endOffset, newLiteral.text)
+        } catch (_: Exception) {
+            // Host literal replacement failed: ${e.message}
+        }
+    }
+
+    /**
+     * Create appropriate Java string literal from formatted SQL
+     */
+    private fun createFormattedLiteralText(formattedSqlText: String): String {
+        val lines = formattedSqlText.split(StringUtil.LINE_SEPARATE)
+        return "\"\"\"${StringUtil.LINE_SEPARATE}${lines.joinToString(StringUtil.LINE_SEPARATE)}\"\"\""
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -67,6 +67,7 @@
       implementationClass="org.domaframework.doma.intellij.formatter.builder.SqlFormattingModelBuilder"/>
     <preFormatProcessor implementation="org.domaframework.doma.intellij.formatter.processor.SqlFormatPreProcessor" />
     <postFormatProcessor implementation="org.domaframework.doma.intellij.formatter.processor.SqlPostProcessor" />
+    <postFormatProcessor implementation="org.domaframework.doma.intellij.formatter.processor.SqlInjectionPostProcessor" />
 
     <!-- CustomLanguage -->
     <fileType

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -66,7 +66,7 @@
     <lang.formatter language="DomaSql"
       implementationClass="org.domaframework.doma.intellij.formatter.builder.SqlFormattingModelBuilder"/>
     <preFormatProcessor implementation="org.domaframework.doma.intellij.formatter.processor.SqlFormatPreProcessor" />
-    <postFormatProcessor implementation="org.domaframework.doma.intellij.formatter.processor.SqlPostProcessor" />
+    <postFormatProcessor implementation="org.domaframework.doma.intellij.formatter.processor.SqlFormatPostProcessor" />
     <postFormatProcessor implementation="org.domaframework.doma.intellij.formatter.processor.SqlInjectionPostProcessor" />
 
     <!-- CustomLanguage -->


### PR DESCRIPTION
This update enables formatting for SQL code injected via `@Sql` annotations.

---

# Implementation Details

* A **custom formatting model** for the SQL language is applied individually to SQL written inside `@Sql` annotations.
* After the Java file itself is formatted, a **PostProcessor** re-formats the SQL segments extracted from `PsiLiteralExpression` elements.

---

# Note

In some cases, formatting may not be applied cleanly if:

- The lines inside a text block are not consistently aligned to the left
- Leading whitespace is inconsistent across lines

## Before
```java
@Dao
public interface InjectionDao {
	/**
	 * Aligned to the left
	 * @return
	 */
	@Select
	@Sql("""
SELECT * from tableName where id = 0""")
	Emp selectInjection();

	/**
	 * The tops are aligned
	 * @param id
	 * @return
	 */
	@Select
	@Sql("""
    SELECT *  from tableName where id = 
    /* id */1""")
	Emp selectInjection2(Integer id);

	/**
	 * Uneven lines
	 * @param id
	 * @return
	 */
	@Select
	@Sql("""
       /** TopBlock */
    select Count(distinct (x))
       , o.* , log(nbor.nearest
         , 999) AS nearest -- column Line commen
  /** From */ from user""")
	Emp selectInjection3(Integer id);
}
```

## Formatted
```java
@Dao
public interface InjectionDao {
	/**
	 * Aligned to the left
	 *
	 * @return
	 */
	@Select
	@Sql("""
SELECT *
  FROM tableName
 WHERE id = 0""")
	Emp selectInjection();

	/**
	 * The tops are aligned
	 *
	 * @param id
	 * @return
	 */
	@Select
	@Sql("""
    SELECT *
      FROM tableName
     WHERE id = /* id */1""")
	Emp selectInjection2(Integer id);

	/**
	 * Uneven lines
	 *
	 * @param id
	 * @return
	 */
	@Select
	@Sql("""
/** TopBlock */
  SELECT Count(DISTINCT (x))
         , o.*
       , log(nbor.nearest
               , 999) AS nearest -- column Line commen
        /** From */
  FROM user""")
	Emp selectInjection3(Integer id);
}
```
