### PR TITLE
Space Adjustment Within Directive Blocks

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
@@ -425,6 +425,26 @@ class SqlFileBlock(
                 SqlTypes.BLOCK_COMMENT_CONTENT,
                 Spacing.createSpacing(0, 0, 0, true, 0),
             ).withSpacing(
+                SqlTypes.BLOCK_COMMENT_START,
+                SqlTypes.EL_ID_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.BLOCK_COMMENT_START,
+                SqlTypes.EL_PRIMARY_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.BLOCK_COMMENT_START,
+                SqlTypes.EL_STRING,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.BLOCK_COMMENT_START,
+                SqlTypes.EL_NUMBER,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.BLOCK_COMMENT_START,
+                SqlTypes.BOOLEAN,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
                 SqlTypes.BLOCK_COMMENT_CONTENT,
                 SqlTypes.BLOCK_COMMENT_END,
                 Spacing.createSpacing(0, 0, 0, true, 0),

--- a/src/test/testData/sql/formatter/Select.sql
+++ b/src/test/testData/sql/formatter/Select.sql
@@ -50,5 +50,7 @@ AS nearest
          OR n.neighbormode = 'Primary')
      AND ( (x.TYPE = 'Star'
          AND x.TYPE = 'Galaxy') OR x.modelmag_g BETWEEN 10 AND 21)
+         OR status = 
+     /*    status */'active'
    GROUP BY n.objid ) AS nbor ON o.objid = nbor.objid
  WHERE o.objid IN /* params */(1, 2, 3) 

--- a/src/test/testData/sql/formatter/Select_format.sql
+++ b/src/test/testData/sql/formatter/Select_format.sql
@@ -54,6 +54,7 @@ SELECT COUNT(DISTINCT x) AS count_x
                             AND ((x.TYPE = 'Star'
                                   AND x.TYPE = 'Galaxy')
                                   OR x.modelmag_g BETWEEN 10 AND 21)
+                             OR status = /* status */'active'
                           GROUP BY n.objid ) AS nbor
                     ON o.objid = nbor.objid
  WHERE o.objid IN /* params */(1, 2, 3) 


### PR DESCRIPTION
Define clear spacing rules to ensure that within directive blocks, the space between the block's opening element and the next element is always exactly 1 space.

# Fix Implemented
- Resolved an issue where, if a directive block is preceded by a line break, the number of spaces inside the block could unintentionally increase during formatting. 
- Now enforces consistent spacing regardless of whether the directive block is inline or line-broken.