### PR TITLE
Line Breaks for Nested Subgroup Blocks

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
@@ -93,23 +93,7 @@ class SqlFormatPreProcessor : PreFormatProcessor {
                     }
 
                     SqlTypes.LEFT_PAREN -> {
-                        newKeyword =
-                            if (createQueryType == CreateQueryType.TABLE) {
-                                getNewLineString(it.prevSibling, getUpperText(it))
-                            } else if (keywordIndex > 0) {
-                                if (listOf(
-                                        "insert",
-                                        "into",
-                                        "all",
-                                    ).contains(replaceKeywordList[keywordIndex - 1].text.lowercase())
-                                ) {
-                                    getNewLineString(it.prevSibling, getUpperText(it))
-                                } else {
-                                    getUpperText(it)
-                                }
-                            } else {
-                                getUpperText(it)
-                            }
+                        newKeyword = getNewLineString(it.prevSibling, getUpperText(it))
                     }
 
                     SqlTypes.RIGHT_PAREN -> {

--- a/src/test/testData/sql/formatter/WithUnionAll.sql
+++ b/src/test/testData/sql/formatter/WithUnionAll.sql
@@ -1,7 +1,7 @@
-with tables AS ( ( SELECT top, no_pre_as AS AS_NAME, pre_as, clm3 from demo
+with tables AS (( SELECT top, no_pre_as AS AS_NAME, pre_as, clm3 from demo
 WHERE id = /*# "block" */ )
 UNION ALL ( SELECT id2, no_pre_as2 AS AS_NAME2, pre_as2 FROM demo2
-          WHERE id2 = /*# "block2" */ ) )
+          WHERE id2 = /*# "block2" */ ))
 SELECT query.id3
        , query.no_pre_as3 AS AS_NAME3
        , query.pre_as3


### PR DESCRIPTION
When nested sub-group blocks are present without spacing between them, the `PreProcessor` may fail to insert line breaks, causing sub-groups that should be formatted on new lines to remain improperly inlined.

# Fix

Ensure that a **line break is always inserted before the opening parenthesis `(`** that denotes the start of a sub-group block.

This guarantees that nested sub-group blocks are properly separated and formatted, even when there’s no space between blocks in the original SQL.
