### PR TITLE
Fix Line-Breaking Conditions for Elements Inside Conditional Directives

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
@@ -136,7 +136,16 @@ open class SqlBlock(
                 (prevBlock.conditionType.isElse() || prevBlock.conditionType.isEnd())
         val hasNoChildrenExceptLast = parent.childBlocks.dropLast(1).isEmpty()
 
-        return isPrevBlockElseOrEnd || hasNoChildrenExceptLast
+        if (parent.conditionType.isElse()) {
+            return prevBlocks.isEmpty()
+        }
+
+        val isConditionDirectiveParentGroup =
+            parent.parentBlock?.let { grand ->
+                grand is SqlNewGroupBlock
+            } == true
+
+        return isPrevBlockElseOrEnd || (hasNoChildrenExceptLast && isConditionDirectiveParentGroup)
     }
 
     private fun shouldSaveSpaceForNewGroup(parent: SqlNewGroupBlock): Boolean {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
@@ -166,7 +166,7 @@ class SqlFileBlock(
             }
 
             SqlTypes.LEFT_PAREN -> {
-                return blockUtil.getSubGroupBlock(lastGroup, child)
+                return blockUtil.getSubGroupBlock(lastGroup, child, blockBuilder.getGroupTopNodeIndexHistory())
             }
 
             SqlTypes.OTHER -> {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
@@ -493,6 +493,42 @@ class SqlFileBlock(
                 SqlTypes.EL_STATIC_FIELD_ACCESS_EXPR,
                 Spacing.createSpacing(1, 1, 0, true, 0),
             ).withSpacing(
+                SqlTypes.BLOCK_COMMENT_START,
+                SqlTypes.CARET,
+                Spacing.createSpacing(0, 0, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.CARET,
+                SqlTypes.EL_ID_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.CARET,
+                SqlTypes.EL_PRIMARY_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.CARET,
+                SqlTypes.EL_STRING,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.CARET,
+                SqlTypes.EL_NUMBER,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.CARET,
+                SqlTypes.BOOLEAN,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.CARET,
+                SqlTypes.EL_NULL,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.CARET,
+                SqlTypes.EL_FIELD_ACCESS_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.CARET,
+                SqlTypes.EL_STATIC_FIELD_ACCESS_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
                 SqlTypes.BLOCK_COMMENT_CONTENT,
                 SqlTypes.BLOCK_COMMENT_END,
                 Spacing.createSpacing(0, 0, 0, true, 0),

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
@@ -445,6 +445,18 @@ class SqlFileBlock(
                 SqlTypes.BOOLEAN,
                 Spacing.createSpacing(1, 1, 0, true, 0),
             ).withSpacing(
+                SqlTypes.BLOCK_COMMENT_START,
+                SqlTypes.EL_NULL,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.BLOCK_COMMENT_START,
+                SqlTypes.EL_FIELD_ACCESS_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.BLOCK_COMMENT_START,
+                SqlTypes.EL_STATIC_FIELD_ACCESS_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
                 SqlTypes.BLOCK_COMMENT_CONTENT,
                 SqlTypes.BLOCK_COMMENT_END,
                 Spacing.createSpacing(0, 0, 0, true, 0),
@@ -457,9 +469,37 @@ class SqlFileBlock(
                 SqlTypes.OTHER,
                 Spacing.createSpacing(1, 1, 0, false, 0),
             ).withSpacing(
-                SqlTypes.BLOCK_COMMENT_CONTENT,
-                SqlTypes.BLOCK_COMMENT_START,
-                Spacing.createSpacing(0, 0, 0, true, 0),
+                SqlTypes.EL_ID_EXPR,
+                SqlTypes.BLOCK_COMMENT_END,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.EL_PRIMARY_EXPR,
+                SqlTypes.BLOCK_COMMENT_END,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.STRING,
+                SqlTypes.BLOCK_COMMENT_END,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.EL_NUMBER,
+                SqlTypes.BLOCK_COMMENT_END,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.EL_NULL,
+                SqlTypes.BLOCK_COMMENT_END,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.BOOLEAN,
+                SqlTypes.BLOCK_COMMENT_END,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.EL_FIELD_ACCESS_EXPR,
+                SqlTypes.BLOCK_COMMENT_END,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.EL_STATIC_FIELD_ACCESS_EXPR,
+                SqlTypes.BLOCK_COMMENT_END,
+                Spacing.createSpacing(1, 1, 0, true, 0),
             ).withSpacing(
                 SqlTypes.BLOCK_COMMENT_CONTENT,
                 SqlTypes.BLOCK_COMMENT_END,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
@@ -457,6 +457,42 @@ class SqlFileBlock(
                 SqlTypes.EL_STATIC_FIELD_ACCESS_EXPR,
                 Spacing.createSpacing(1, 1, 0, true, 0),
             ).withSpacing(
+                SqlTypes.BLOCK_COMMENT_START,
+                SqlTypes.HASH,
+                Spacing.createSpacing(0, 0, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.HASH,
+                SqlTypes.EL_ID_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.HASH,
+                SqlTypes.EL_PRIMARY_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.HASH,
+                SqlTypes.EL_STRING,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.HASH,
+                SqlTypes.EL_NUMBER,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.HASH,
+                SqlTypes.BOOLEAN,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.HASH,
+                SqlTypes.EL_NULL,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.HASH,
+                SqlTypes.EL_FIELD_ACCESS_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
+                SqlTypes.HASH,
+                SqlTypes.EL_STATIC_FIELD_ACCESS_EXPR,
+                Spacing.createSpacing(1, 1, 0, true, 0),
+            ).withSpacing(
                 SqlTypes.BLOCK_COMMENT_CONTENT,
                 SqlTypes.BLOCK_COMMENT_END,
                 Spacing.createSpacing(0, 0, 0, true, 0),

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/condition/SqlConditionalExpressionGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/condition/SqlConditionalExpressionGroupBlock.kt
@@ -17,6 +17,7 @@ package org.domaframework.doma.intellij.formatter.block.group.keyword.condition
 
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
@@ -45,7 +46,15 @@ class SqlConditionalExpressionGroupBlock(
         }
     }
 
-    override fun createBlockIndentLen(): Int = parentBlock?.indent?.groupIndentLen?.plus(1) ?: 1
+    override fun createBlockIndentLen(): Int =
+        parentBlock?.let { parent ->
+            if (parent is SqlElConditionLoopCommentBlock) {
+                parent.indent.groupIndentLen
+            } else {
+                parent.indent.groupIndentLen.plus(1)
+            }
+        }
+            ?: offset
 
     override fun createGroupIndentLen(): Int = indent.indentLen.plus(1)
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlSubGroupBlock.kt
@@ -50,6 +50,7 @@ abstract class SqlSubGroupBlock(
                 SqlWithCommonTableGroupBlock::class,
                 SqlWithColumnGroupBlock::class,
                 SqlCreateViewGroupBlock::class,
+                SqlElConditionLoopCommentBlock::class,
             )
     }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlCustomSpacingBuilder.kt
@@ -131,7 +131,8 @@ class SqlCustomSpacingBuilder {
         }
 
         if (child.directiveType == SqlElCommentDirectiveType.NORMAL ||
-            child.directiveType == SqlElCommentDirectiveType.LITERAL
+            child.directiveType == SqlElCommentDirectiveType.LITERAL ||
+            child.directiveType == SqlElCommentDirectiveType.EXPAND
         ) {
             return nonSpacing
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/handler/NotQueryGroupHandler.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/handler/NotQueryGroupHandler.kt
@@ -18,6 +18,7 @@ package org.domaframework.doma.intellij.formatter.handler
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlCommaBlock
+import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.block.conflict.SqlConflictClauseBlock
 import org.domaframework.doma.intellij.formatter.block.conflict.SqlConflictExpressionSubGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.condition.SqlConditionKeywordGroupBlock
@@ -45,15 +46,19 @@ object NotQueryGroupHandler {
         lastGroup: SqlBlock?,
         child: ASTNode,
         sqlBlockFormattingCtx: SqlBlockFormattingContext,
+        groups: List<SqlBlock>,
     ): SqlBlock? =
         when {
             hasInKeyword(lastGroup) -> SqlParallelListBlock(child, sqlBlockFormattingCtx)
-            lastGroup is SqlConditionKeywordGroupBlock -> createConditionalExpressionGroup(child, sqlBlockFormattingCtx)
+            lastGroupParentConditionKeywordGroup(groups) -> createConditionalExpressionGroup(child, sqlBlockFormattingCtx)
             hasFunctionOrAliasContext(lastGroup) -> createFunctionOrValueBlock(lastGroup, child, sqlBlockFormattingCtx)
             lastGroup is SqlConflictClauseBlock -> SqlConflictExpressionSubGroupBlock(child, sqlBlockFormattingCtx)
             hasValuesContext(lastGroup) -> SqlValuesParamGroupBlock(child, sqlBlockFormattingCtx)
             else -> null
         }
+
+    private fun lastGroupParentConditionKeywordGroup(groups: List<SqlBlock>): Boolean =
+        groups.lastOrNull { it !is SqlElConditionLoopCommentBlock } is SqlConditionKeywordGroupBlock
 
     /**
      * Creates a keyword group block for specific keywords.

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlBlockGenerator.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlBlockGenerator.kt
@@ -341,6 +341,7 @@ class SqlBlockGenerator(
     fun getSubGroupBlock(
         lastGroup: SqlBlock?,
         child: ASTNode,
+        groups: List<SqlBlock>,
     ): SqlBlock {
         when (lastGroup) {
             is SqlKeywordGroupBlock -> {
@@ -365,7 +366,7 @@ class SqlBlockGenerator(
 
                 // List-type test data for IN clause
                 NotQueryGroupHandler
-                    .getSubGroup(lastGroup, child, sqlBlockFormattingCtx)
+                    .getSubGroup(lastGroup, child, sqlBlockFormattingCtx, groups)
                     ?.let { return it }
 
                 return SqlSubQueryGroupBlock(child, sqlBlockFormattingCtx)
@@ -382,7 +383,7 @@ class SqlBlockGenerator(
                 }
 
                 NotQueryGroupHandler
-                    .getSubGroup(lastGroup, child, sqlBlockFormattingCtx)
+                    .getSubGroup(lastGroup, child, sqlBlockFormattingCtx, groups)
                     ?.let { return it }
 
                 return SqlSubQueryGroupBlock(child, sqlBlockFormattingCtx)

--- a/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
@@ -174,6 +174,10 @@ class SqlFormatterTest : BasePlatformTestCase() {
         formatSqlFile("SelectCaseEndWithCondition.sql", "SelectCaseEndWithCondition$formatDataPrefix.sql")
     }
 
+    fun testSelectDirectiveTestDataFormatter() {
+        formatSqlFile("SelectDirectiveTestData.sql", "SelectDirectiveTestData$formatDataPrefix.sql")
+    }
+
     private fun formatSqlFile(
         beforeFile: String,
         afterFile: String,

--- a/src/test/testData/sql/formatter/InsertConflictUpdate_format.sql
+++ b/src/test/testData/sql/formatter/InsertConflictUpdate_format.sql
@@ -4,8 +4,8 @@ INSERT INTO employees
 SELECT name
        , user_id
   FROM user_settings
- WHERE user_id = /*employee.id*/0
-   AND name = /*employee.name*/'name'
+ WHERE user_id = /* employee.id */0
+   AND name = /* employee.name */'name'
 ON CONFLICT (id)
 DO UPDATE
       SET name = EXCLUDED.name

--- a/src/test/testData/sql/formatter/SelectDirectiveTestData.sql
+++ b/src/test/testData/sql/formatter/SelectDirectiveTestData.sql
@@ -4,6 +4,8 @@ SELECT /*%expand */ *
   FROM ( SELECT * FROM users ) AS u
                , ( SELECT tag  FROM post WHERE u.usr_id = /*authr.id*/0 ) AS tag          , employee
 where common_id = /*@example.status.CommonStatus@id*/1
-and 
-(post = /*#null */
+and /*%if insertCondition */ post_title = /*title*/'title'
+/*%else */
+  (post = /*#null */
    or sub_title = /*^subTitle*/'subTitle')
+/*%end*/

--- a/src/test/testData/sql/formatter/SelectDirectiveTestData.sql
+++ b/src/test/testData/sql/formatter/SelectDirectiveTestData.sql
@@ -3,3 +3,8 @@ SELECT /*%expand */ *
 , extra
   FROM ( SELECT * FROM users ) AS u
                , ( SELECT tag  FROM post WHERE u.usr_id = /*authr.id*/0 ) AS tag          , employee
+where common_id = /*@example.status.CommonStatus@id*/1
+and /*%if insertCondition */ post_title = /*title*/'title'
+/*%else */
+  post = /*#null */
+/*%end*/

--- a/src/test/testData/sql/formatter/SelectDirectiveTestData.sql
+++ b/src/test/testData/sql/formatter/SelectDirectiveTestData.sql
@@ -1,0 +1,5 @@
+SELECT /*%expand */ *
+, /*%populate */
+, extra
+  FROM ( SELECT * FROM users ) AS u
+               , ( SELECT tag  FROM post WHERE u.usr_id = /*authr.id*/0 ) AS tag          , employee

--- a/src/test/testData/sql/formatter/SelectDirectiveTestData.sql
+++ b/src/test/testData/sql/formatter/SelectDirectiveTestData.sql
@@ -4,7 +4,6 @@ SELECT /*%expand */ *
   FROM ( SELECT * FROM users ) AS u
                , ( SELECT tag  FROM post WHERE u.usr_id = /*authr.id*/0 ) AS tag          , employee
 where common_id = /*@example.status.CommonStatus@id*/1
-and /*%if insertCondition */ post_title = /*title*/'title'
-/*%else */
-  post = /*#null */
-/*%end*/
+and 
+(post = /*#null */
+   or sub_title = /*^subTitle*/'subTitle')

--- a/src/test/testData/sql/formatter/SelectDirectiveTestData_format.sql
+++ b/src/test/testData/sql/formatter/SelectDirectiveTestData_format.sql
@@ -8,5 +8,10 @@ SELECT /*%expand */*
             WHERE u.usr_id = /* authr.id */0 ) AS tag
        , employee
  WHERE common_id = /* @example.status.CommonStatus@id */1
-   AND (post = /*# null */
+   AND
+       /*%if insertCondition */
+       post_title = /* title */'title'
+       /*%else */
+       (post = /*# null */
          OR sub_title = /*^ subTitle */'subTitle')
+       /*%end*/

--- a/src/test/testData/sql/formatter/SelectDirectiveTestData_format.sql
+++ b/src/test/testData/sql/formatter/SelectDirectiveTestData_format.sql
@@ -1,0 +1,9 @@
+SELECT /*%expand */*
+       , /*%populate */
+       , extra
+  FROM ( SELECT *
+           FROM users ) AS u
+       , ( SELECT tag
+             FROM post
+            WHERE u.usr_id = /* authr.id */0 ) AS tag
+       , employee

--- a/src/test/testData/sql/formatter/SelectDirectiveTestData_format.sql
+++ b/src/test/testData/sql/formatter/SelectDirectiveTestData_format.sql
@@ -8,9 +8,5 @@ SELECT /*%expand */*
             WHERE u.usr_id = /* authr.id */0 ) AS tag
        , employee
  WHERE common_id = /* @example.status.CommonStatus@id */1
-   AND
-       /*%if insertCondition */
-       post_title = /* title */'title'
-       /*%else */
-       post = /*# null */
-       /*%end*/
+   AND (post = /*# null */
+         OR sub_title = /*^ subTitle */'subTitle')

--- a/src/test/testData/sql/formatter/SelectDirectiveTestData_format.sql
+++ b/src/test/testData/sql/formatter/SelectDirectiveTestData_format.sql
@@ -7,3 +7,10 @@ SELECT /*%expand */*
              FROM post
             WHERE u.usr_id = /* authr.id */0 ) AS tag
        , employee
+ WHERE common_id = /* @example.status.CommonStatus@id */1
+   AND
+       /*%if insertCondition */
+       post_title = /* title */'title'
+       /*%else */
+       post = /*# null */
+       /*%end*/

--- a/src/test/testData/sql/formatter/UpdateReturning_format.sql
+++ b/src/test/testData/sql/formatter/UpdateReturning_format.sql
@@ -1,6 +1,6 @@
 UPDATE user
    SET name = /* user.name */'name'
-       , rank = /*user.rank */3
+       , rank = /* user.rank */3
  WHERE id = /* user.id */1
 RETURNING id
           , name

--- a/src/test/testData/sql/formatter/Update_format.sql
+++ b/src/test/testData/sql/formatter/Update_format.sql
@@ -1,4 +1,4 @@
 UPDATE user
    SET name = /* user.name */'name'
-       , rank = /*user.rank */3
+       , rank = /* user.rank */3
  WHERE id = /* user.id */1


### PR DESCRIPTION
Resolved unintended formatting issues within conditional directive blocks where:

Operators like = were being incorrectly line-broken within standard conditions.

Elements following an else directive were not line-broken as expected.

# Example
```sql
AND
    /*%if includeCondition */
    post 
 = /* post */'post'
    /*%else */     (post = /*# null */
      OR sub = true)
    /*%end */
```

# Fix Summary

Adjusted the logic that determines whether elements inside if, elseif, or else directive blocks should trigger a line break.

Ensures that:

- Line breaks are applied only where structurally appropriate. 
- Expressions involving operations like = remain compact. 
- Elements following else are properly indented and line-broken.

```sql
   AND
       /*%if includeCondition */
       post = /* post */'post'
       /*%else */
       (post = /*# null */
         OR sub =true)
       /*%end*/
```