### PR TITLE
Support code reformatting on injected SQL

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlInjectionPostProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlInjectionPostProcessor.kt
@@ -15,10 +15,12 @@
  */
 package org.domaframework.doma.intellij.formatter.processor
 
+import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import org.domaframework.doma.intellij.common.dao.getDaoClass
 import org.domaframework.doma.intellij.common.isJavaOrKotlinFileType
@@ -35,17 +37,49 @@ class SqlInjectionPostProcessor : SqlPostProcessor() {
         rangeToReformat: TextRange,
         settings: CodeStyleSettings,
     ): TextRange {
-        if (!isJavaOrKotlinFileType(source) || getDaoClass(source) == null) return rangeToReformat
+        if (!shouldProcessFile(source)) {
+            return rangeToReformat
+        }
 
-        processInjected(source)
+        val manager = InjectedLanguageManager.getInstance(source.project)
+        if (manager.isInjectedFragment(source)) {
+            processInjectedFragment(source, manager)
+        } else {
+            processRegularFile(source)
+        }
+
         return rangeToReformat
     }
 
-    private fun processInjected(element: PsiFile) {
-        val project: Project = element.project
-        val visitor = DaoInjectionSqlVisitor(element, project)
-        element.accept(visitor)
-        visitor.processAll { text, skipFinalLineBreak ->
+    private fun shouldProcessFile(source: PsiFile): Boolean {
+        val manager = InjectedLanguageManager.getInstance(source.project)
+        val isInjectedSql = manager.isInjectedFragment(source)
+        val isDaoFile = isJavaOrKotlinFileType(source) && getDaoClass(source) != null
+        
+        return isInjectedSql || isDaoFile
+    }
+
+    private fun processInjectedFragment(
+        source: PsiFile,
+        manager: InjectedLanguageManager,
+    ) {
+        val host = manager.getInjectionHost(source) as? PsiLiteralExpression ?: return
+        val hostDaoFile = host.containingFile
+        val originalText = host.value?.toString() ?: return
+
+        val visitor = DaoInjectionSqlVisitor(hostDaoFile, source.project)
+        val formattingTask = DaoInjectionSqlVisitor.FormattingTask(host, originalText)
+        
+        visitor.replaceHostStringLiteral(formattingTask) { text ->
+            processDocumentText(text)
+        }
+    }
+
+    private fun processRegularFile(source: PsiFile) {
+        val visitor = DaoInjectionSqlVisitor(source, source.project)
+        source.accept(visitor)
+        
+        visitor.processAll { text ->
             processDocumentText(text)
         }
     }


### PR DESCRIPTION
## Summary
- Added support for code reformatting on injected SQL in IntelliJ
- Refactored SQL formatter components to handle injection scenarios
- Updated multiple formatter blocks and processors for better SQL handling

## Test plan
- [ ] Verify SQL formatting works correctly in DAO methods
- [ ] Test injection SQL formatting in various contexts
- [ ] Ensure existing SQL formatting functionality remains intact
- [ ] Check that multi-line comments are handled properly

🤖 Generated with [Claude Code](https://claude.ai/code)