### PR TITLE
Support for Using `@DataType`-Annotated Records in DAO Method Return and Parameter Types

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/util/DomaClassName.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/util/DomaClassName.kt
@@ -67,6 +67,7 @@ enum class DomaClassName(
     SELECT_TYPE("org.seasar.doma.SelectType"),
 
     ENTITY("org.seasar.doma.Entity"),
+    DATATYPE("org.seasar.doma.DataType"),
     ;
 
     fun isTargetClassNameStartsWith(paramTypeCanonicalNames: String): Boolean = paramTypeCanonicalNames.startsWith(this.className)

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/util/TypeUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/util/TypeUtil.kt
@@ -22,6 +22,7 @@ import com.intellij.psi.PsiType
 import org.domaframework.doma.intellij.common.psi.PsiTypeChecker
 import org.domaframework.doma.intellij.extension.getJavaClazz
 import org.domaframework.doma.intellij.extension.psi.getClassAnnotation
+import org.domaframework.doma.intellij.extension.psi.isDataType
 import org.domaframework.doma.intellij.extension.psi.isDomain
 import org.domaframework.doma.intellij.extension.psi.isEntity
 
@@ -71,6 +72,17 @@ object TypeUtil {
     ): Boolean {
         val clazz = type?.canonicalText?.let { project.getJavaClazz(it) }
         return clazz?.isDomain() == true
+    }
+
+    /**
+     * Checks if the given type is a data type.
+     */
+    fun isDataType(
+        type: PsiType?,
+        project: Project,
+    ): Boolean {
+        val clazz = type?.canonicalText?.let { project.getJavaClazz(it) }
+        return clazz?.isDataType() == true
     }
 
     /**

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiClassExtension.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiClassExtension.kt
@@ -50,7 +50,7 @@ fun PsiClass.isEntity(): Boolean = this.getClassAnnotation(DomaClassName.ENTITY.
 
 fun PsiClass.isDomain(): Boolean = this.getClassAnnotation(DomaClassName.DOMAIN.className) != null
 
-fun PsiClass.isDataType(): Boolean = this.getClassAnnotation(DomaClassName.DATATYPE.className) != null
+fun PsiClass.isDataType(): Boolean = this.getClassAnnotation(DomaClassName.DATATYPE.className) != null && this.isRecord
 
 fun PsiClassType.getSuperType(superClassName: String): PsiClassType? {
     var parent: PsiClassType? = this

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiClassExtension.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiClassExtension.kt
@@ -50,6 +50,8 @@ fun PsiClass.isEntity(): Boolean = this.getClassAnnotation(DomaClassName.ENTITY.
 
 fun PsiClass.isDomain(): Boolean = this.getClassAnnotation(DomaClassName.DOMAIN.className) != null
 
+fun PsiClass.isDataType(): Boolean = this.getClassAnnotation(DomaClassName.DATATYPE.className) != null
+
 fun PsiClassType.getSuperType(superClassName: String): PsiClassType? {
     var parent: PsiClassType? = this
     while (parent != null && !parent.canonicalText.startsWith(superClassName)) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/TypeCheckerProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/TypeCheckerProcessor.kt
@@ -26,6 +26,7 @@ import org.domaframework.doma.intellij.common.psi.PsiTypeChecker
 import org.domaframework.doma.intellij.common.util.DomaClassName
 import org.domaframework.doma.intellij.extension.getJavaClazz
 import org.domaframework.doma.intellij.extension.psi.getSuperType
+import org.domaframework.doma.intellij.extension.psi.isDataType
 import org.domaframework.doma.intellij.extension.psi.isDomain
 
 /**
@@ -90,12 +91,12 @@ abstract class TypeCheckerProcessor(
             val optionalParam = paramClassType.parameters.firstOrNull()
             return optionalParam?.let {
                 val optionalParamClass = project.getJavaClazz(it.canonicalText)
-                optionalParamClass?.isDomain() == true || PsiTypeChecker.isBaseClassType(it)
+                optionalParamClass?.isDomain() == true || optionalParamClass?.isDataType() == true || PsiTypeChecker.isBaseClassType(it)
             } == true
         }
 
         val paramClass = project.getJavaClazz(paramType.canonicalText)
-        return paramClass?.isDomain() == true
+        return paramClass?.isDomain() == true || paramClass?.isDataType() == true
     }
 
     protected fun checkMapType(paramTypeCanonicalText: String): Boolean {

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/cheker/ProcedureFunctionResultSetParamAnnotationTypeChecker.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/cheker/ProcedureFunctionResultSetParamAnnotationTypeChecker.kt
@@ -26,6 +26,7 @@ import org.domaframework.doma.intellij.common.util.DomaClassName
 import org.domaframework.doma.intellij.common.validation.result.ValidationMethodParamsSupportGenericParamResult
 import org.domaframework.doma.intellij.common.validation.result.ValidationMethodProcedureParamTypeResult
 import org.domaframework.doma.intellij.extension.getJavaClazz
+import org.domaframework.doma.intellij.extension.psi.isDataType
 import org.domaframework.doma.intellij.extension.psi.isDomain
 import org.domaframework.doma.intellij.extension.psi.isEntity
 
@@ -46,6 +47,7 @@ class ProcedureFunctionResultSetParamAnnotationTypeChecker(
                 val optionalParamClass = project.getJavaClazz(it.canonicalText)
                 optionalParamClass?.isDomain() == true ||
                     optionalParamClass?.isEntity() == true ||
+                    optionalParamClass?.isDataType() == true ||
                     PsiTypeChecker.isBaseClassType(
                         it,
                     )
@@ -53,7 +55,7 @@ class ProcedureFunctionResultSetParamAnnotationTypeChecker(
         }
 
         val paramClass = project.getJavaClazz(paramType.canonicalText)
-        return paramClass?.isDomain() == true
+        return paramClass?.isDomain() == true || paramClass?.isDataType() == true
     }
 
     override fun checkParam(
@@ -101,7 +103,7 @@ class ProcedureFunctionResultSetParamAnnotationTypeChecker(
 
         val paramClass = project.getJavaClazz(listParamType.canonicalText)
 
-        if (checkParamType(listParamType) || paramClass?.isEntity() == true) return
+        if (checkParamType(listParamType) || paramClass?.isEntity() == true || paramClass?.isDataType() == true) return
         result.highlightElement(holder)
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/paramtype/BatchParamTypeCheckProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/paramtype/BatchParamTypeCheckProcessor.kt
@@ -86,8 +86,19 @@ class BatchParamTypeCheckProcessor(
 
         val iterableClassType = param.type as? PsiClassType
         iterableClassType?.parameters?.firstOrNull()?.let { iterableParam ->
-            if (!TypeUtil.isEntity(iterableParam, project)) {
-                resultParamType.highlightElement(holder)
+            // Check if @Sql annotation is present or sqlFile=true
+            if (psiDaoMethod.useSqlAnnotation() || psiDaoMethod.sqlFileOption) {
+                if (!TypeUtil.isEntity(iterableParam, project) &&
+                    !TypeUtil.isDomain(iterableParam, project) &&
+                    !TypeUtil.isDataType(iterableParam, project)
+                ) {
+                    resultParamType.highlightElement(holder)
+                }
+            } else {
+                // When @Sql annotation is present or sqlFile=true, only Entity types are allowed
+                if (!TypeUtil.isEntity(iterableParam, project)) {
+                    resultParamType.highlightElement(holder)
+                }
             }
             return
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/paramtype/BatchParamTypeCheckProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/paramtype/BatchParamTypeCheckProcessor.kt
@@ -86,7 +86,6 @@ class BatchParamTypeCheckProcessor(
 
         val iterableClassType = param.type as? PsiClassType
         iterableClassType?.parameters?.firstOrNull()?.let { iterableParam ->
-            // Check if @Sql annotation is present or sqlFile=true
             if (psiDaoMethod.useSqlAnnotation() || psiDaoMethod.sqlFileOption) {
                 if (!TypeUtil.isEntity(iterableParam, project) &&
                     !TypeUtil.isDomain(iterableParam, project) &&
@@ -95,7 +94,6 @@ class BatchParamTypeCheckProcessor(
                     resultParamType.highlightElement(holder)
                 }
             } else {
-                // When @Sql annotation is present or sqlFile=true, only Entity types are allowed
                 if (!TypeUtil.isEntity(iterableParam, project)) {
                     resultParamType.highlightElement(holder)
                 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/paramtype/SelectParamTypeCheckProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/paramtype/SelectParamTypeCheckProcessor.kt
@@ -27,6 +27,7 @@ import org.domaframework.doma.intellij.common.validation.result.ValidationMethod
 import org.domaframework.doma.intellij.common.validation.result.ValidationMethodSelectStrategyParamResult
 import org.domaframework.doma.intellij.extension.getJavaClazz
 import org.domaframework.doma.intellij.extension.psi.getSuperClassType
+import org.domaframework.doma.intellij.extension.psi.isDataType
 import org.domaframework.doma.intellij.extension.psi.isDomain
 import org.domaframework.doma.intellij.extension.psi.isEntity
 import org.domaframework.doma.intellij.inspection.dao.processor.StrategyParam
@@ -49,12 +50,13 @@ class SelectParamTypeCheckProcessor(
                 val optionalParamClass = project.getJavaClazz(it.canonicalText)
                 optionalParamClass?.isDomain() == true ||
                     PsiTypeChecker.isBaseClassType(it) ||
-                    optionalParamClass?.isEntity() == true
+                    optionalParamClass?.isEntity() == true ||
+                    optionalParamClass?.isDataType() == true
             } == true
         }
 
         val paramClass = project.getJavaClazz(paramType.canonicalText)
-        return paramClass?.isDomain() == true || paramClass?.isEntity() == true
+        return paramClass?.isDomain() == true || paramClass?.isEntity() == true || paramClass?.isDataType() == true
     }
 
     override fun checkParams(holder: ProblemsHolder) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/returntype/FunctionReturnTypeCheckProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/returntype/FunctionReturnTypeCheckProcessor.kt
@@ -67,7 +67,7 @@ class FunctionReturnTypeCheckProcessor(
             }
         }
 
-        if (TypeUtil.isDomain(checkType, project) || TypeUtil.isEntity(checkType, project)) {
+        if (TypeUtil.isDomain(checkType, project) || TypeUtil.isEntity(checkType, project) || TypeUtil.isDataType(checkType, project)) {
             return null
         }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/returntype/SelectReturnTypeCheckProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/returntype/SelectReturnTypeCheckProcessor.kt
@@ -91,7 +91,7 @@ class SelectReturnTypeCheckProcessor(
             }
         }
 
-        if (TypeUtil.isDomain(checkType, project) || TypeUtil.isEntity(checkType, project)) {
+        if (TypeUtil.isDomain(checkType, project) || TypeUtil.isEntity(checkType, project) || TypeUtil.isDataType(checkType, project)) {
             return null
         }
 

--- a/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/AnnotationParamTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/AnnotationParamTypeCheckInspectionTest.kt
@@ -32,6 +32,7 @@ class AnnotationParamTypeCheckInspectionTest : DomaSqlTest() {
             "ScriptParamTestDao",
             "SqlProcessorParamTestDao",
             "FactoryParamTestDao",
+            "DataTypeParamTypeTestDao",
         )
     private val daoPackage = "inspection/paramtype"
 
@@ -43,6 +44,7 @@ class AnnotationParamTypeCheckInspectionTest : DomaSqlTest() {
         addOtherJavaFile("collector", "HogeCollector.java")
         addOtherJavaFile("function", "HogeFunction.java")
         addOtherJavaFile("function", "HogeBiFunction.java")
+        addOtherJavaFile("domain", "Salary.java")
         testDaoNames.forEach { daoName ->
             addDaoJavaFile("$daoPackage/$daoName.java")
         }
@@ -85,6 +87,11 @@ class AnnotationParamTypeCheckInspectionTest : DomaSqlTest() {
 
     fun testFactoryParam() {
         val dao = findDaoClass("$daoPackage.FactoryParamTestDao")
+        myFixture.testHighlighting(false, false, false, dao.containingFile.virtualFile)
+    }
+
+    fun testDataTypeParam() {
+        val dao = findDaoClass("$daoPackage.DataTypeParamTypeTestDao")
         myFixture.testHighlighting(false, false, false, dao.containingFile.virtualFile)
     }
 }

--- a/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/AnnotationReturnTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/inspection/dao/AnnotationReturnTypeCheckInspectionTest.kt
@@ -32,6 +32,7 @@ class AnnotationReturnTypeCheckInspectionTest : DomaSqlTest() {
             "ProcedureReturnTypeTestDao",
             "FunctionReturnTypeTestDao",
             "FactoryReturnTypeTestDao",
+            "DataTypeReturnTypeTestDao",
         )
     private val daoPackage = "inspection/returntype"
 
@@ -43,6 +44,7 @@ class AnnotationReturnTypeCheckInspectionTest : DomaSqlTest() {
         addEntityJavaFile("Packet.java")
         addEntityJavaFile("Pckt.java")
         addOtherJavaFile("domain", "Hiredate.java")
+        addOtherJavaFile("domain", "Salary.java")
         addOtherJavaFile("collector", "HogeCollector.java")
         addOtherJavaFile("function", "HogeFunction.java")
         addOtherJavaFile("function", "HogeBiFunction.java")
@@ -86,6 +88,11 @@ class AnnotationReturnTypeCheckInspectionTest : DomaSqlTest() {
 
     fun testFactoryReturnTypeCheckProcessor() {
         val dao = findDaoClass("$daoPackage.FactoryReturnTypeTestDao")
+        myFixture.testHighlighting(false, false, false, dao.containingFile.virtualFile)
+    }
+
+    fun testDataTypeReturnTypeCheckProcessor() {
+        val dao = findDaoClass("$daoPackage.DataTypeReturnTypeTestDao")
         myFixture.testHighlighting(false, false, false, dao.containingFile.virtualFile)
     }
 }

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/paramtype/DataTypeParamTypeTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/paramtype/DataTypeParamTypeTestDao.java
@@ -1,0 +1,76 @@
+package doma.example.dao.inspection.paramtype;
+
+import org.seasar.doma.*;
+import doma.example.domain.Salary;
+import org.seasar.doma.jdbc.Reference;
+import org.seasar.doma.jdbc.Result;
+
+import java.util.List;
+import java.util.Optional;
+
+@Dao
+public interface DataTypeParamTypeTestDao {
+
+  @Select
+  @Sql("select * from salary where id = /*salary.value*/0")
+  Salary selectSalary(Salary salary);
+
+  @Select
+  @Sql("select * from salary where id = /*salary.value*/0")
+  Optional<Salary> selectOptSalary(Salary salary);
+
+  @Update
+  int updateSalary(Salary <error descr="The parameter type must be an entity">salary</error>);
+
+  @Insert
+  int insertSalary(Salary <error descr="The parameter type must be an entity">salary</error>);
+
+  @Delete
+  int deleteSalary(Salary <error descr="The parameter type must be an entity">salary</error>);
+
+  @BatchUpdate
+  int[] batchUpdateSalary(List<Salary> <error descr="The argument must be an Iterable subclass that has an Entity class as a parameter">salary</error>);
+
+  @BatchUpdate
+  int[] batchInsertSalary(List<Salary> <error descr="The argument must be an Iterable subclass that has an Entity class as a parameter">salary</error>);
+
+  @BatchUpdate
+  int[] batchDeleteSalary(List<Salary> <error descr="The argument must be an Iterable subclass that has an Entity class as a parameter">salary</error>);
+
+  @Update
+  @Sql("UPDATE salary SET val = /*salary.value*/0")
+  int updateSalaryWithSql(Salary salary);
+
+  @Insert
+  @Sql("INSERT INTO salary (val) VALUES (/*salary.value*/0)")
+  int insertSalaryWithSql(Salary salary);
+
+  @Delete
+  @Sql("DELETE FROM salary WHERE val = /*salary.value*/0 ")
+  int deleteSalaryWithSql(Salary salary);
+
+  @BatchUpdate
+  @Sql("UPDATE salary SET val = /*salary.value*/0")
+  int[] batchUpdateSalaryWithSql(List<Salary> salary);
+
+  @BatchUpdate
+  @Sql("INSERT INTO salary (val) VALUES (/*salary.value*/0)")
+  int[] batchInsertSalaryWithSql(List<Salary> salary);
+
+  @BatchUpdate
+  @Sql("DELETE FROM salary WHERE val = /*salary.value*/0 ")
+  int[] batchDeleteSalaryWithSql(List<Salary> salary);
+
+  @Function
+  List<Salary> getTopSalaries(@In Salary limit);
+
+  @Function
+  Optional<Salary> getMaxSalary(@InOut Reference<Salary> percentage, @ResultSet List<Salary> resultSet);
+
+  @Procedure
+  void computeBonus(@In Salary employeeId);
+
+  @Procedure
+  void adjustSalaries(@InOut Reference<Salary> percentage, @ResultSet List<Salary> resultSet);
+
+}

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/DataTypeReturnTypeTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/DataTypeReturnTypeTestDao.java
@@ -1,0 +1,33 @@
+package doma.example.dao.inspection.returntype;
+
+import org.seasar.doma.*;
+import doma.example.domain.Salary;
+import org.seasar.doma.jdbc.Reference;
+
+import java.util.List;
+import java.util.Optional;
+
+@Dao
+public interface DataTypeReturnTypeTestDao {
+
+  @Select
+  @Sql("select * from salary where id = /*salary.value*/0")
+  Salary selectSalary(Salary salary);
+
+  @Select
+  @Sql("select * from salary where id = /*salary.value*/0")
+  Optional<Salary> selectOptSalary(Salary salary) ;
+
+  @Function
+  Salary calculateAverageSalary();
+  
+  @Function
+  Optional<Salary> getMaxSalary(@InOut Reference<Salary> percentage, @ResultSet List<Salary> resultSet);
+
+  @Procedure
+  void computeBonus(@In Salary employeeId);
+
+  @Procedure
+  void adjustSalaries(@InOut Reference<Salary> percentage, @ResultSet List<Salary> resultSet);
+
+}

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/DataTypeReturnTypeTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/DataTypeReturnTypeTestDao.java
@@ -3,6 +3,7 @@ package doma.example.dao.inspection.returntype;
 import org.seasar.doma.*;
 import doma.example.domain.Salary;
 import org.seasar.doma.jdbc.Reference;
+import org.seasar.doma.jdbc.Result;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,9 +19,57 @@ public interface DataTypeReturnTypeTestDao {
   @Sql("select * from salary where id = /*salary.value*/0")
   Optional<Salary> selectOptSalary(Salary salary) ;
 
+  @Update
+  @Sql("UPDATE salary SET val = /*salary.value*/0")
+  int updateSalaryWithSql1(Salary salary);
+
+  @Update
+  @Sql("UPDATE salary SET val = /*salary.value*/0")
+  Result<Salary> <error descr="The return type must be \"int\"">updateSalaryWithSql2</error>(Salary salary);
+
+  @Insert
+  @Sql("INSERT INTO salary (val) VALUES (/*salary.value*/0)")
+  int insertSalaryWithSql(Salary salary);
+
+  @Insert
+  @Sql("INSERT INTO salary (val) VALUES (/*salary.value*/0)")
+  Result<Salary> <error descr="The return type must be \"int\"">insertSalaryWithSql2</error>(Salary salary);
+
+  @Delete
+  @Sql("DELETE FROM salary WHERE val = /*salary.value*/0 ")
+  int deleteSalaryWithSql(Salary salary);
+
+  @Delete
+  @Sql("DELETE FROM salary WHERE val = /*salary.value*/0 ")
+  Result<Salary> <error descr="The return type must be \"int\"">deleteSalaryWithSql2</error>(Salary salary);
+
+  @BatchUpdate
+  @Sql("UPDATE salary SET val = /*salary.value*/0")
+  int[] batchUpdateSalaryWithSql(List<Salary> salary);
+
+  @BatchUpdate
+  @Sql("UPDATE salary SET val = /*salary.value*/0")
+  <error descr="Cannot resolve symbol 'BatchResult'">BatchResult</error><Salary> <error descr="The return type must be \"int[]\"">batchUpdateSalaryWithSql2</error>(List<Salary> salary);
+
+  @BatchInsert
+  @Sql("INSERT INTO salary (val) VALUES (/*salary.value*/0)")
+  int[] batchInsertSalaryWithSql(List<Salary> salary);
+
+  @BatchInsert
+  @Sql("INSERT INTO salary (val) VALUES (/*salary.value*/0)")
+  <error descr="Cannot resolve symbol 'BatchResult'">BatchResult</error><Salary> <error descr="The return type must be \"int[]\"">batchInsertSalaryWithSql2</error>(List<Salary> salary);
+
+  @BatchDelete
+  @Sql("DELETE FROM salary WHERE val = /*salary.value*/0 ")
+  int[] batchDeleteSalaryWithSql(List<Salary> salary);
+
+  @BatchDelete
+  @Sql("DELETE FROM salary WHERE val = /*salary.value*/0 ")
+  <error descr="Cannot resolve symbol 'BatchResult'">BatchResult</error><Salary> <error descr="The return type must be \"int[]\"">batchDeleteSalaryWithSql2</error>(List<Salary> salary);
+
   @Function
-  Salary calculateAverageSalary();
-  
+  List<Salary> getTopSalaries(@In Salary limit);
+
   @Function
   Optional<Salary> getMaxSalary(@InOut Reference<Salary> percentage, @ResultSet List<Salary> resultSet);
 

--- a/src/test/testData/src/main/java/doma/example/domain/Salary.java
+++ b/src/test/testData/src/main/java/doma/example/domain/Salary.java
@@ -1,0 +1,8 @@
+package doma.example.domain;
+
+import java.math.BigDecimal;
+import org.seasar.doma.DataType;
+
+@DataType
+public record Salary(BigDecimal value) {
+}


### PR DESCRIPTION
This update enables support for Java `record` types annotated with `@DataType` when used as return types or parameter types in DAO methods.

---

# Issue

Previously, the code inspection mechanism would erroneously highlight `@DataType` records as errors when used as DAO method return types.

---

# Fix Overview

The inspection logic has been updated to recognize `@DataType`-annotated records as valid in the following cases:

* **For `@Select`-annotated DAO methods**:
  No error highlight for using `@DataType` records as either return type or parameter type.

* **For `@Factory`-annotated DAO methods**:
  `@DataType` records are accepted as both return type and parameter type.

* **For `@Procedure`-annotated DAO methods**:
  `@DataType` records are allowed as parameter types.

* **For `@Update`, `@Insert`, and `@Delete` DAO methods**:
  If the annotation has the option `sqlFile = true` or is used in combination with `@Sql`, then `@DataType` records are allowed as parameter types.

* **For Batch annotations (e.g., `@BatchInsert`, `@BatchUpdate`, etc.)**:
  If `sqlFile = true` is specified or `@Sql` is present, then using a `@DataType` record as the **element type** of the parameter is accepted and not highlighted as an error.

---

This change improves support for domain-style value types and ensures compatibility with custom record-based models in Doma DAO method signatures.

---
**Related Issue**
N/A

---
**Type of Change**
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)
- [ ] Refactor
- [x] Test
- [ ] Build system change
- [ ] Chore
- [ ] Performance improvement
- [ ] Code style update
- [ ] Security fix
- [ ] Other (please specify)

---