### PR TITLE
Fix primitive type validation for DAO method return types

### DIFF
--- a/.claude/setting.json
+++ b/.claude/setting.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew test:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh auth:*)",
+      "Bash(gh api:*)",
+      "WebFetch(domain:github.com)",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(./gradlew:*)",
+      "Bash(git add:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.claude/setting.json
+++ b/.claude/setting.json
@@ -1,18 +1,1 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(./gradlew test:*)",
-      "Bash(gh issue view:*)",
-      "Bash(gh repo view:*)",
-      "Bash(gh issue list:*)",
-      "Bash(gh auth:*)",
-      "Bash(gh api:*)",
-      "WebFetch(domain:github.com)",
-      "Bash(git checkout:*)",
-      "Bash(git pull:*)",
-      "Bash(./gradlew:*)",
-      "Bash(git add:*)"
-    ],
-    "deny": []
-  }
-}
+

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiTypeChecker.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiTypeChecker.kt
@@ -60,8 +60,9 @@ object PsiTypeChecker {
     fun isBaseClassType(psiType: PsiType?): Boolean {
         if (psiType == null) return false
         // Check if the type is a primitive type
-        if (psiType is PsiPrimitiveType && psiType.canonicalText == "char") {
-            return false
+        if (psiType is PsiPrimitiveType) {
+            // char is not supported, but other primitive types are
+            return psiType.canonicalText != "char"
         }
 
         // Check if the type is a wrapper class

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/returntype/SelectReturnTypeCheckProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/returntype/SelectReturnTypeCheckProcessor.kt
@@ -17,6 +17,7 @@ package org.domaframework.doma.intellij.inspection.dao.processor.returntype
 
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiType
+import com.intellij.psi.PsiTypes
 import org.domaframework.doma.intellij.common.psi.PsiDaoMethod
 import org.domaframework.doma.intellij.common.util.DomaClassName
 import org.domaframework.doma.intellij.common.util.TypeUtil
@@ -77,7 +78,7 @@ class SelectReturnTypeCheckProcessor(
                 shortName,
                 checkTypeCanonicalText,
             )
-        if (checkType == null) return result
+        if (checkType == null || checkType == PsiTypes.voidType()) return result
 
         if (TypeUtil.isBaseOrOptionalWrapper(checkType)) {
             return null

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/FunctionReturnTypeTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/FunctionReturnTypeTestDao.java
@@ -16,10 +16,31 @@ import org.seasar.doma.jdbc.Reference;
 public interface FunctionReturnTypeTestDao {
 
   @Function
-  int <error descr="The return type int is invalid">primitiveFunction</error>(@In int id);
+  int primitiveFunction(@In int id);
 
   @Function
   void voidFunction(@In int id);
+
+  @Function
+  long primitiveLongFunction(@In long id);
+
+  @Function
+  boolean primitiveBooleanFunction(@In boolean flag);
+
+  @Function
+  double primitiveDoubleFunction(@In double value);
+
+  @Function
+  float primitiveFloatFunction(@In float value);
+
+  @Function
+  byte primitiveByteFunction(@In byte value);
+
+  @Function
+  short primitiveShortFunction(@In short value);
+
+  @Function
+  char <error descr="The return type char is invalid">primitiveCharFunction</error>(@In char value);
 
   @Function
   String executeFunction(

--- a/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/SelectReturnTypeTestDao.java
+++ b/src/test/testData/src/main/java/doma/example/dao/inspection/returntype/SelectReturnTypeTestDao.java
@@ -139,4 +139,38 @@ public interface SelectReturnTypeTestDao {
   @Sql("select * from emp where salary > /* salary */0")
   String selectHogeFunction(BigDecimal salary, HogeFunction function);
 
+  // Test cases for primitive return types - these should be valid (except char)
+  @Select
+  @Sql("select count(*) from EMPLOYEE")
+  int selectCountAsInt();
+
+  @Select
+  @Sql("select count(*) from EMPLOYEE")
+  long selectCountAsLong();
+
+  @Select
+  @Sql("select exists(select 1 from EMPLOYEE where EMPLOYEE_ID = /* id */1)")
+  boolean selectExistsAsBoolean(Integer id);
+
+  @Select
+  @Sql("select avg(SALARY) from EMPLOYEE")
+  double selectAverageAsDouble();
+
+  @Select
+  @Sql("select avg(SALARY) from EMPLOYEE")
+  float selectAverageAsFloat();
+
+  @Select
+  @Sql("select age from EMPLOYEE where EMPLOYEE_ID = /* id */1")
+  byte selectAgeAsByte(Integer id);
+
+  @Select
+  @Sql("select department_id from EMPLOYEE where EMPLOYEE_ID = /* id */1")
+  short selectDepartmentIdAsShort(Integer id);
+
+  // This should show an error - char is not supported
+  @Select
+  @Sql("select initial from EMPLOYEE where EMPLOYEE_ID = /* id */1")
+  char <error descr="The return type char is invalid">selectInitialAsChar</error>(Integer id);
+
 }


### PR DESCRIPTION
## Summary
- Fixed PsiTypeChecker to correctly validate primitive return types for DAO methods
- All primitive types except `char` are now accepted as valid return types
- Previously, all primitive types were incorrectly rejected due to a logic error

## Changes
- Updated `PsiTypeChecker.isBaseClassType()` to return `true` for all primitive types except `char`
- Added comprehensive test cases for all primitive return types in `SelectReturnTypeTestDao`
- Updated test cases in `FunctionReturnTypeTestDao` to reflect the correct validation behavior

## Test Plan
- [x] Added test methods for all primitive return types (int, long, boolean, double, float, byte, short)
- [x] Added test method for char return type to verify it still shows an error
- [x] Ran `./gradlew test` to ensure all tests pass
- [x] Ran `./gradlew spotlessApply` to ensure code formatting

Fixes #351

🤖 Generated with [Claude Code](https://claude.ai/code)