### PR TITLE
Formatting Support for Single-Line Injected SQL in @Sql Annotations

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
@@ -16,16 +16,19 @@
 package org.domaframework.doma.intellij.formatter.processor
 
 import com.intellij.lang.ASTNode
+import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.TokenType
 import com.intellij.psi.impl.source.codeStyle.PreFormatProcessor
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
+import org.domaframework.doma.intellij.common.isInjectionSqlFile
 import org.domaframework.doma.intellij.common.util.InjectionSqlUtil.isInjectedSqlFile
 import org.domaframework.doma.intellij.common.util.PluginLoggerUtil
 import org.domaframework.doma.intellij.common.util.StringUtil.LINE_SEPARATE
@@ -50,6 +53,11 @@ class SqlFormatPreProcessor : PreFormatProcessor {
             SqlTypes.OTHER,
         )
 
+    data class ProcessResult(
+        val document: Document?,
+        val range: TextRange,
+    )
+
     override fun process(
         node: ASTNode,
         rangeToReformat: TextRange,
@@ -65,13 +73,26 @@ class SqlFormatPreProcessor : PreFormatProcessor {
             return rangeToReformat
         }
 
+        // Do not execute processor processing in single-line text state
+        if (isInjectionSqlFile(source)) {
+            val host = InjectedLanguageManager.getInstance(source.project).getInjectionHost(source) as? PsiLiteralExpression
+            if (host?.isTextBlock != true) return rangeToReformat
+        }
+        val result = updateDocument(source, rangeToReformat)
+        return result.range
+    }
+
+    fun updateDocument(
+        source: PsiFile,
+        rangeToReformat: TextRange,
+    ): ProcessResult {
         logging()
 
         val visitor = SqlFormatVisitor()
         source.accept(visitor)
 
         val docManager = PsiDocumentManager.getInstance(source.project)
-        val document = docManager.getDocument(source) ?: return rangeToReformat
+        val document = docManager.getDocument(source) ?: return ProcessResult(null, rangeToReformat)
 
         val keywordList = visitor.replaces.filter { it.elementType != TokenType.WHITE_SPACE }
         val replaceKeywordList = visitor.replaces.filter { it.elementType == SqlTypes.KEYWORD }
@@ -122,7 +143,7 @@ class SqlFormatPreProcessor : PreFormatProcessor {
 
         docManager.commitDocument(document)
 
-        return rangeToReformat.grown(visitor.replaces.size)
+        return ProcessResult(document, rangeToReformat.grown(visitor.replaces.size))
     }
 
     private fun removeSpacesAroundNewline(

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/visitor/DaoInjectionSqlVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/visitor/DaoInjectionSqlVisitor.kt
@@ -15,6 +15,7 @@
  */
 package org.domaframework.doma.intellij.formatter.visitor
 
+import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
@@ -24,23 +25,16 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.codeStyle.CodeStyleManager
-import org.domaframework.doma.intellij.common.util.InjectionSqlUtil
 import org.domaframework.doma.intellij.common.util.StringUtil
-import kotlin.text.isBlank
+import org.domaframework.doma.intellij.formatter.processor.SqlFormatPreProcessor
 
 /**
  * Visitor for processing and formatting SQL injections in DAO files.
  * Formats SQL strings embedded in Java/Kotlin string literals while preserving indentation.
  */
 class DaoInjectionSqlVisitor(
-    private val element: PsiFile,
     private val project: Project,
 ) : JavaRecursiveElementVisitor() {
-    data class FormattingTask(
-        val expression: PsiLiteralExpression,
-        val formattedText: String,
-    )
-
     companion object {
         private const val TEMP_FILE_PREFIX = "temp_format"
         private const val SQL_FILE_EXTENSION = ".sql"
@@ -51,56 +45,98 @@ class DaoInjectionSqlVisitor(
     }
 
     private val formattingTasks = mutableListOf<FormattingTask>()
+    private val injectionManager by lazy { InjectedLanguageManager.getInstance(project) }
+    private val documentManager by lazy { PsiDocumentManager.getInstance(project) }
+    private val codeStyleManager by lazy { CodeStyleManager.getInstance(project) }
+    private val fileTypeManager by lazy { FileTypeManager.getInstance() }
+    private val elementFactory by lazy {
+        com.intellij.psi.JavaPsiFacade
+            .getElementFactory(project)
+    }
+
+    fun initFormattingTasks() {
+        formattingTasks.clear()
+    }
 
     override fun visitLiteralExpression(expression: PsiLiteralExpression) {
         super.visitLiteralExpression(expression)
-        val injected: PsiFile? = InjectionSqlUtil.initInjectionElement(element, project, expression)
-        if (injected != null) {
-            // Format SQL and store the task
-            val originalText = expression.value?.toString() ?: return
+        expression.value?.toString()?.let { originalText ->
             formattingTasks.add(FormattingTask(expression, originalText))
         }
     }
 
-    private fun removeIndentLines(sqlText: String): String {
-        val lines = sqlText.lines()
+    private fun removeIndentLines(sqlText: String): String =
+        sqlText.lines().joinToString(StringUtil.LINE_SEPARATE) { line ->
+            val processedLine =
+                if (COMMENT_START_REGEX.containsMatchIn(line)) {
+                    // Remove spaces between /* and comment content, as IntelliJ Java formatter may insert them
+                    line.replace(COMMENT_START_REGEX, "/**")
+                } else {
+                    line
+                }
+            processedLine.dropWhile { it.isWhitespace() }
+        }
 
-        var blockComment = false
-        val removeIndentLines =
-            lines.map { line ->
-                val baseLine =
-                    if (COMMENT_START_REGEX.containsMatchIn(line)) {
-                        blockComment = true
-                        // Exclude spaces between `/*` and the comment content element,
-                        // as IntelliJ IDEA's Java formatter may insert a space there during formatting.
-                        line.replace(COMMENT_START_REGEX, "/**")
-                    } else {
-                        line
-                    }
-                baseLine.dropWhile { it.isWhitespace() }
-            }
+    fun processAllTextBlock() {
+        if (formattingTasks.isEmpty()) return
 
-        return removeIndentLines.joinToString(StringUtil.LINE_SEPARATE)
+        WriteCommandAction.runWriteCommandAction(project, WRITE_COMMAND_NAME, null, {
+            // Convert PsiLiteralExpression to text blocks first
+            formattingTasks
+                .sortedByDescending { it.expression.textRange.startOffset }
+                .forEach { task ->
+                    convertExpressionToTextBlock(task.expression)
+                }
+        })
     }
+
+    fun convertExpressionToTextBlock(expression: PsiLiteralExpression) {
+        if (!expression.isValid || expression.isTextBlock) return
+
+        val oldText = expression.value?.toString() ?: return
+        val newText = convertToTextBlock(oldText)
+        val document = documentManager.getDocument(expression.containingFile) ?: return
+
+        val range = expression.textRange
+        document.replaceString(range.startOffset, range.endOffset, newText)
+        documentManager.commitDocument(document)
+    }
+
+    private fun convertToTextBlock(content: String): String = "\"\"\"\n${content.replace("\"\"\"", "\\\"\\\"\\\"")}${TRIPLE_QUOTE}"
 
     /**
      * Processes all collected formatting tasks in a single write action.
      * @param removeSpace Function to remove trailing spaces from formatted text
      */
-    fun processAll(removeSpace: (String) -> String) {
+    fun processAllReFormat(removeSpace: (String) -> String) {
         if (formattingTasks.isEmpty()) return
 
-        // Apply all formatting tasks in a single write action
         WriteCommandAction.runWriteCommandAction(project, WRITE_COMMAND_NAME, null, {
-            // Sort by text range in descending order to maintain offsets
             formattingTasks
                 .sortedByDescending { it.expression.textRange.startOffset }
                 .forEach { task ->
                     if (task.expression.isValid) {
-                        replaceHostStringLiteral(task, removeSpace)
+                        processFormattingTask(task, removeSpace)
                     }
                 }
         })
+    }
+
+    fun processFormattingTask(
+        task: FormattingTask,
+        removeSpace: (String) -> String,
+    ) {
+        // Apply PreProcessor to single-line injection SQL
+        val injectionFile =
+            injectionManager
+                .getInjectedPsiFiles(task.expression)
+                ?.firstOrNull()
+                ?.first as? PsiFile ?: return
+
+        val result = SqlFormatPreProcessor().updateDocument(injectionFile, injectionFile.textRange)
+        val formattedText = result.document?.text ?: return
+
+        replaceHostStringLiteral(FormattingTask(task.expression, formattedText), removeSpace)
     }
 
     /**
@@ -108,37 +144,28 @@ class DaoInjectionSqlVisitor(
      * Returns original text if formatting fails.
      */
     private fun formatAsTemporarySqlFile(sqlText: String): String =
-        try {
+        runCatching {
             val tempFileName = "${TEMP_FILE_PREFIX}${SQL_FILE_EXTENSION}"
-            val fileType = FileTypeManager.getInstance().getFileTypeByExtension("sql")
-
+            val fileType = fileTypeManager.getFileTypeByExtension("sql")
             val tempSqlFile =
                 PsiFileFactory
                     .getInstance(project)
                     .createFileFromText(tempFileName, fileType, sqlText)
 
-            CodeStyleManager
-                .getInstance(project)
-                .reformatText(tempSqlFile, 0, tempSqlFile.textLength)
-
+            codeStyleManager.reformatText(tempSqlFile, 0, tempSqlFile.textLength)
             tempSqlFile.text
-        } catch (_: Exception) {
-            sqlText // Return original text on error
-        }
+        }.getOrDefault(sqlText)
 
     /**
      * Replaces the host Java string literal with formatted SQL text.
      */
-    fun replaceHostStringLiteral(
+    private fun replaceHostStringLiteral(
         task: FormattingTask,
         sqlPostProcessorProcess: (String) -> String,
     ) {
-        try {
-            // Keep the current top line indent
+        runCatching {
             val formattedLiteral = createFormattedLiteral(task, sqlPostProcessorProcess)
             replaceInDocument(task.expression, formattedLiteral)
-        } catch (_: Exception) {
-            // Silently ignore formatting failures
         }
     }
 
@@ -146,17 +173,15 @@ class DaoInjectionSqlVisitor(
         task: FormattingTask,
         sqlPostProcessorProcess: (String) -> String,
     ): String {
-        // Retrieve the same formatted string as when formatting a regular SQL file.
-        val removeIndent = removeIndentLines(task.formattedText)
-        val formattedSql = formatAsTemporarySqlFile(removeIndent)
-        val cleanedText = sqlPostProcessorProcess(formattedSql)
-        // Generate text aligned with the literal element using the formatted string.
-        val newLiteralText = createFormattedLiteralText(cleanedText)
-        val normalizedText = normalizeIndentation(newLiteralText)
+        // Format SQL to match regular SQL file formatting
+        val sqlWithoutIndent = removeIndentLines(task.formattedText)
+        val formattedSql = formatAsTemporarySqlFile(sqlWithoutIndent)
+        val processedSql = sqlPostProcessorProcess(formattedSql)
 
-        val elementFactory =
-            com.intellij.psi.JavaPsiFacade
-                .getElementFactory(project)
+        // Create properly aligned literal text
+        val literalText = createFormattedLiteralText(processedSql)
+        val normalizedText = normalizeIndentation(literalText)
+
         val newLiteral = elementFactory.createExpressionFromText(normalizedText, task.expression)
         return newLiteral.text
     }
@@ -165,27 +190,23 @@ class DaoInjectionSqlVisitor(
         expression: PsiLiteralExpression,
         newText: String,
     ) {
-        val document =
-            PsiDocumentManager
-                .getInstance(project)
-                .getDocument(expression.containingFile) ?: return
-
+        val document = documentManager.getDocument(expression.containingFile) ?: return
         val range = expression.textRange
+
         document.replaceString(range.startOffset, range.endOffset, newText)
+        documentManager.commitDocument(document)
     }
 
     /**
      * Creates a Java text block (triple-quoted string) from formatted SQL.
      */
-    private fun createFormattedLiteralText(formattedSqlText: String): String {
-        val lines = formattedSqlText.split(StringUtil.LINE_SEPARATE)
-        return buildString {
+    private fun createFormattedLiteralText(formattedSqlText: String): String =
+        buildString {
             append(TRIPLE_QUOTE)
             append(StringUtil.LINE_SEPARATE)
-            append(lines.joinToString(StringUtil.LINE_SEPARATE))
+            append(formattedSqlText)
             append(TRIPLE_QUOTE)
         }
-    }
 
     /**
      * Normalizes indentation by removing base indent and reapplying it consistently.
@@ -194,15 +215,12 @@ class DaoInjectionSqlVisitor(
         val lines = sqlText.lines()
         if (lines.isEmpty()) return sqlText
 
-        val literalSeparator = lines.first()
-        val contentLines = lines.drop(1)
-
+        val (literalSeparator, contentLines) = lines.first() to lines.drop(1)
         val normalizedLines =
             contentLines.map { line ->
                 when {
                     line.isBlank() -> line
-                    line.startsWith(BASE_INDENT) -> BASE_INDENT + line.removePrefix(BASE_INDENT)
-                    else -> BASE_INDENT + line
+                    else -> BASE_INDENT + line.removePrefix(BASE_INDENT)
                 }
             }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/visitor/FormattingTask.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/visitor/FormattingTask.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Tools Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.domaframework.doma.intellij.formatter.visitor
+
+import com.intellij.psi.PsiLiteralExpression
+
+data class FormattingTask(
+    val expression: PsiLiteralExpression,
+    val formattedText: String,
+)


### PR DESCRIPTION

This update ensures proper formatting for SQL written as a **single-line string** inside `@Sql` annotations.

---

# Implementation Details

* The **`SqlFormatPreProcessor`**, which handles formatting preparation for SQL, is **skipped for single-line injected SQL**.
* Instead, formatting is handled in the **`SqlInjectionPostProcessor`**, which is designed for DAO context.

## `SqlInjectionPostProcessor` Workflow:

1. **Convert non-text block `PsiLiteralExpression`**
   When encountering a single-line string literal, convert it into a **text block** to enable multiline formatting.

2. **Re-acquire the modified `PsiLiteralExpression`**
   After conversion, the updated DAO file is parsed again to retrieve the new element.

3. **Apply `SqlFormatPreProcessor`**
   Now that the element is in the correct format, invoke the previously skipped formatting logic.

4. **Execute reformatting**
   Finally, the injected SQL is formatted as intended using the complete formatting process.

---

# Important Note

After performing the document transformation, be sure to call `commitDocument()`—
**Without committing the document, the updated elements may not be accurately recognized**, which could cause formatting to fail or apply incorrectly.

---
