### PR TITLE
Execute Grammar-Kit Tasks Before Build

### DIFF
--- a/.claude/commands/create_pr.md
+++ b/.claude/commands/create_pr.md
@@ -8,7 +8,6 @@ This document describes the format and rules for creating a Pull Request (PR) on
 
 ## PR Guidelines
 - If there are unstaged changes when creating a pull request, please split them appropriately and commit them separately.
-- When using the gh command, first authenticate with ```gh auth login```.
 - Use the [PR Template](../templates/PR_TEMPLATE.md) for PR descriptions
 - PR titles should be concise and descriptive
 - Ensure all tests pass before submitting a PR

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,6 +180,28 @@ tasks {
     publishPlugin {
         dependsOn(patchChangelog)
     }
+
+    // Ensure generateLexer and generateParser run before compilation
+    compileJava {
+        dependsOn(generateLexer, generateParser)
+    }
+
+    compileKotlin {
+        dependsOn(generateLexer, generateParser)
+    }
+
+    compileTestJava {
+        dependsOn(generateLexer, generateParser)
+    }
+
+    compileTestKotlin {
+        dependsOn(generateLexer, generateParser)
+    }
+
+    // Ensure build task depends on grammar generation
+    build {
+        dependsOn(generateLexer, generateParser)
+    }
 }
 
 tasks.register("encodeBase64") {


### PR DESCRIPTION
To avoid forgetting to regenerate custom language source code after editing .flex or .bnf files—or when switching branches—this update adds a build dependency to ensure Grammar-Kit tasks are executed before compilation or build.

# Implementation Summary
Add a task dependency so that Grammar-Kit runs automatically before compileJava or build-related tasks.

Ensures the latest lexer/parser classes are always generated based on the current grammar definitions.

# Benefits
Prevents build failures or runtime errors due to stale generated code

Improves reliability when switching between branches with different grammar definitions

Reduces manual regeneration steps for developers