### PR TITLE
Fix: Freeze During SQL Formatting

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElParametersBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElParametersBlock.kt
@@ -71,7 +71,7 @@ class SqlElParametersBlock(
             return when (childBlock1) {
                 is SqlElSymbolBlock -> SqlCustomSpacingBuilder.nonSpacing
                 is SqlElCommaBlock -> SqlCustomSpacingBuilder.normalSpacing
-                else -> return SqlCustomSpacingBuilder.normalSpacing
+                else -> return SqlCustomSpacingBuilder.nonSpacing
             }
         }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElParametersBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElParametersBlock.kt
@@ -71,7 +71,7 @@ class SqlElParametersBlock(
             return when (childBlock1) {
                 is SqlElSymbolBlock -> SqlCustomSpacingBuilder.nonSpacing
                 is SqlElCommaBlock -> SqlCustomSpacingBuilder.normalSpacing
-                else -> return SqlCustomSpacingBuilder.nonSpacing
+                else -> SqlCustomSpacingBuilder.nonSpacing
             }
         }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElParametersBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElParametersBlock.kt
@@ -63,14 +63,16 @@ class SqlElParametersBlock(
         val childBlock1 = child1 as? SqlBlock
         val childBlock2 = child2 as? SqlBlock
 
-        if (childBlock1 == null) return SqlCustomSpacingBuilder.nonSpacing
+        if (childBlock1 == null || childBlock1.node.elementType == SqlTypes.LEFT_PAREN) {
+            return SqlCustomSpacingBuilder.nonSpacing
+        }
         if (childBlock2 != null) {
             if (childBlock2.node.elementType == SqlTypes.RIGHT_PAREN) {
                 return SqlCustomSpacingBuilder.nonSpacing
             }
             return when (childBlock1) {
-                is SqlElSymbolBlock -> SqlCustomSpacingBuilder.nonSpacing
                 is SqlElCommaBlock -> SqlCustomSpacingBuilder.normalSpacing
+                is SqlElSymbolBlock -> SqlCustomSpacingBuilder.nonSpacing
                 else -> SqlCustomSpacingBuilder.nonSpacing
             }
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElPrimaryBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElPrimaryBlock.kt
@@ -18,15 +18,35 @@ package org.domaframework.doma.intellij.formatter.block.expr
 import com.intellij.formatting.Block
 import com.intellij.formatting.Spacing
 import com.intellij.lang.ASTNode
+import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.SqlUnknownBlock
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
+import org.domaframework.doma.intellij.psi.SqlTypes
 
 class SqlElPrimaryBlock(
     node: ASTNode,
-    context: SqlBlockFormattingContext,
+    private val context: SqlBlockFormattingContext,
 ) : SqlExprBlock(
         node,
         context,
     ) {
+    override fun getBlock(child: ASTNode): SqlBlock =
+        when (child.elementType) {
+            SqlTypes.LEFT_PAREN, SqlTypes.RIGHT_PAREN ->
+                SqlElSymbolBlock(child, context)
+
+            SqlTypes.EL_PRIMARY_EXPR ->
+                SqlElPrimaryBlock(child, context)
+
+            SqlTypes.COMMA ->
+                SqlElCommaBlock(child, context)
+
+            SqlTypes.EL_PRIMARY_EXPR, SqlTypes.EL_NUMBER, SqlTypes.EL_STRING, SqlTypes.BOOLEAN, SqlTypes.EL_NULL ->
+                SqlElPrimaryBlock(child, context)
+
+            else -> SqlUnknownBlock(child, context)
+        }
+
     override fun getSpacing(
         child1: Block?,
         child2: Block,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElPrimaryBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElPrimaryBlock.kt
@@ -19,6 +19,7 @@ import com.intellij.formatting.Block
 import com.intellij.formatting.Spacing
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.SqlLiteralBlock
 import org.domaframework.doma.intellij.formatter.block.SqlUnknownBlock
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 import org.domaframework.doma.intellij.psi.SqlTypes
@@ -41,8 +42,8 @@ class SqlElPrimaryBlock(
             SqlTypes.COMMA ->
                 SqlElCommaBlock(child, context)
 
-            SqlTypes.EL_PRIMARY_EXPR, SqlTypes.EL_NUMBER, SqlTypes.EL_STRING, SqlTypes.BOOLEAN, SqlTypes.EL_NULL ->
-                SqlElPrimaryBlock(child, context)
+            SqlTypes.EL_NUMBER, SqlTypes.EL_STRING, SqlTypes.BOOLEAN, SqlTypes.EL_NULL ->
+                SqlLiteralBlock(child, context)
 
             else -> SqlUnknownBlock(child, context)
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElStaticFieldAccessBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlElStaticFieldAccessBlock.kt
@@ -22,7 +22,6 @@ import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.PsiTreeUtil
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlUnknownBlock
-import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlParallelListBlock
 import org.domaframework.doma.intellij.formatter.builder.SqlCustomSpacingBuilder
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 import org.domaframework.doma.intellij.psi.SqlElClass
@@ -56,7 +55,7 @@ class SqlElStaticFieldAccessBlock(
                 SqlElIdentifierBlock(child, context)
 
             SqlTypes.EL_PARAMETERS ->
-                SqlParallelListBlock(child, context)
+                SqlElParametersBlock(child, context)
 
             else -> SqlUnknownBlock(child, context)
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlExprBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/expr/SqlExprBlock.kt
@@ -21,6 +21,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.builder.SqlCustomSpacingBuilder
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
 abstract class SqlExprBlock(
@@ -39,8 +40,7 @@ abstract class SqlExprBlock(
         var child = node.firstChildNode
         while (child != null) {
             if (child !is PsiWhiteSpace) {
-                val block = getBlock(child)
-                blocks.add(block)
+                blocks.add(getBlock(child))
             }
             child = child.treeNext
         }
@@ -50,5 +50,5 @@ abstract class SqlExprBlock(
     override fun getSpacing(
         child1: Block?,
         child2: Block,
-    ): Spacing? = null
+    ): Spacing? = SqlCustomSpacingBuilder.nonSpacing
 }

--- a/src/test/testData/sql/formatter/Select.sql
+++ b/src/test/testData/sql/formatter/Select.sql
@@ -26,7 +26,7 @@ AS nearest
           WHERE p.TYPE = 'Star'
              -- Line3
              OR ( p.flags & FPHOTOFLAGS('EDGE') = 0 AND (p.psfmag_g - p.extinction_g) BETWEEN 15 AND 20)
-            /*%if status == 2 */
+            /*%if status == 2 && employee.employeeParams(1,null, true ,"A") */
             -- Line4
             and u.propermotion > 2.0
             /** And  Group */

--- a/src/test/testData/sql/formatter/Select_format.sql
+++ b/src/test/testData/sql/formatter/Select_format.sql
@@ -30,7 +30,7 @@ SELECT COUNT(DISTINCT x) AS count_x
              -- Line3
              OR (p.flags & FPHOTOFLAGS('EDGE') = 0
                  AND (p.psfmag_g - p.extinction_g) BETWEEN 15 AND 20)
-            /*%if status == 2 */
+            /*%if status == 2 && employee.employeeParams(1, null, true, "A") */
             -- Line4
             AND u.propermotion > 2.0
             /** And  Group */

--- a/src/test/testData/sql/formatter/StaticFieldAccess.sql
+++ b/src/test/testData/sql/formatter/StaticFieldAccess.sql
@@ -2,4 +2,4 @@ SELECT *
 FROM configurations
 WHERE
 config_key = /*@ com.example.Constants @CONFIG_KEY */'system.timeout'
-  AND value = /*@ com.example.Utils @ util. getDefaultValue () */'30'
+  AND value = /*@ com.example.Utils @ util. getDefaultValue (0) */'30'

--- a/src/test/testData/sql/formatter/StaticFieldAccess.sql
+++ b/src/test/testData/sql/formatter/StaticFieldAccess.sql
@@ -2,4 +2,4 @@ SELECT *
 FROM configurations
 WHERE
 config_key = /*@ com.example.Constants @CONFIG_KEY */'system.timeout'
-  AND value = /*@ com.example.Utils @ util. getDefaultValue (0) */'30'
+  AND value = /*@ com.example.Utils @ util. getDefaultValue (0 , "x") */'30'

--- a/src/test/testData/sql/formatter/StaticFieldAccess.sql
+++ b/src/test/testData/sql/formatter/StaticFieldAccess.sql
@@ -2,4 +2,4 @@ SELECT *
 FROM configurations
 WHERE
 config_key = /*@ com.example.Constants @CONFIG_KEY */'system.timeout'
-  AND value = /*@ com.example.Utils @ util. getDefaultValue (0 , "x") */'30'
+  AND value = /*@ com.example.Utils @ util. getDefaultValue (0,null,true , "0") */'30'

--- a/src/test/testData/sql/formatter/StaticFieldAccess_format.sql
+++ b/src/test/testData/sql/formatter/StaticFieldAccess_format.sql
@@ -1,4 +1,4 @@
 SELECT *
   FROM configurations
  WHERE config_key = /* @com.example.Constants@CONFIG_KEY */'system.timeout'
-   AND value = /* @com.example.Utils@util.getDefaultValue() */'30'
+   AND value = /* @com.example.Utils@util.getDefaultValue(0) */'30'

--- a/src/test/testData/sql/formatter/StaticFieldAccess_format.sql
+++ b/src/test/testData/sql/formatter/StaticFieldAccess_format.sql
@@ -1,4 +1,4 @@
 SELECT *
   FROM configurations
  WHERE config_key = /* @com.example.Constants@CONFIG_KEY */'system.timeout'
-   AND value = /* @com.example.Utils@util.getDefaultValue(0) */'30'
+   AND value = /* @com.example.Utils@util.getDefaultValue(0, "x") */'30'

--- a/src/test/testData/sql/formatter/StaticFieldAccess_format.sql
+++ b/src/test/testData/sql/formatter/StaticFieldAccess_format.sql
@@ -1,4 +1,4 @@
 SELECT *
   FROM configurations
  WHERE config_key = /* @com.example.Constants@CONFIG_KEY */'system.timeout'
-   AND value = /* @com.example.Utils@util.getDefaultValue(0, "x") */'30'
+   AND value = /* @com.example.Utils@util.getDefaultValue(0, null, true, "0") */'30'


### PR DESCRIPTION
Running the SQL formatter on certain SQL statements causes IntelliJ IDEA to freeze.

This issue occurs specifically when a literal value (number, string, boolean, etc.) is passed as a parameter in a method call.

- Problem case: Literals used as method call parameters.

- Not affected: Cases where DAO method parameters are used, or when literals are used outside of method parameters.

**Example that triggers the freeze:**

```sql
SELECT *
FROM employee
WHERE id = /* employee.getParam(1) */0
```

The formatter now handles this case without causing IDEA to hang.

### Fix Details

Properly implemented child block parsing within parameter blocks.

Ensured a Primary block is generated so that spacing settings do not return null.