### PR TITLE
Fix error on code completion for SQL file with unrecognized DAO method

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/provider/SqlParameterCompletionProvider.kt
@@ -189,7 +189,7 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
         val daoMethod = findDaoMethod(originalFile)
         val searchText = cleanString(getSearchElementText(position))
         var topElementType: PsiType? = null
-        if (elements.isEmpty() && daoMethod != null) {
+        if (elements.isEmpty()) {
             getElementTypeByFieldAccess(originalFile, position, elements, daoMethod, result)
             return
         }
@@ -303,15 +303,15 @@ class SqlParameterCompletionProvider : CompletionProvider<CompletionParameters>(
         originalFile: PsiFile,
         position: PsiElement,
         elements: List<PsiElement>,
-        daoMethod: PsiMethod,
+        daoMethod: PsiMethod?,
         result: CompletionResultSet,
     ): PsiType? {
         val topElement = elements.firstOrNull()
         val topText = cleanString(getSearchElementText(topElement))
-        val matchParams = daoMethod.searchParameter(topText)
-        val findParam = matchParams.find { it.name == topText }
+        val matchParams = daoMethod?.searchParameter(topText)
+        val findParam = matchParams?.find { it.name == topText }
         if (elements.size <= 1 && findParam == null) {
-            matchParams.map { match ->
+            matchParams?.map { match ->
                 result.addElement(LookupElementBuilder.create(match.name))
             }
             // Add ForDirective Items

--- a/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlSpecificParamTypeCompleteTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/complate/sql/SqlSpecificParamTypeCompleteTest.kt
@@ -92,7 +92,6 @@ class SqlSpecificParamTypeCompleteTest : DomaSqlTest() {
         myFixture.configureFromExistingVirtualFile(sqlFile)
         val lookupElements = myFixture.completeBasic()
         val suggestions = lookupElements.map { it.lookupString }
-        println(suggestions.map { it })
         expectedSuggestions.forEach { expected ->
             assertTrue(
                 "Expected '$expected' in completion suggestions: $suggestions",


### PR DESCRIPTION
## Overview
This PR fixes an issue where invoking code completion on an SQL file that does not recognize the corresponding DAO method results in an error. The error occurs when the system attempts to retrieve the first element from an empty list during the suggestion of the top binding variable.

## Bug Description
- When code completion is executed on an SQL file without a recognized DAO method, an error occurs due to attempting to get the first element from an empty suggestion list.
- This issue may also occur if the DAO class file is not located within the source directory or when working with temporary SQL files.

## Changes
- Removed the precondition check for the DAO method.
- Added a condition to skip processing when the list of code completion targets is empty.
- Adjusted the logic in `SqlParameterCompletionProvider` to prevent error scenarios during code completion.

## Expected Behavior
- Code completion will not continue if no available target elements are found.
- The error is prevented by checking for empty suggestions before accessing the first element.