### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This pull request unifies newline settings across Spotless, Git configuration, and IntelliJ to ensure consistency. By standardizing newline characters, only intentional code changes are shown without spurious newline-only diffs.

**Changes include:**
- Configuring Spotless to enforce a consistent newline code (LF).
- Updating Git settings to standardize commit newline codes.
- Adjusting IntelliJ settings to align with the project-wide LF standard.

These changes improve code readability and reduce unnecessary diff noise.