### PR TITLE
Fix Last Column Non Line Break

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
@@ -136,13 +136,24 @@ open class SqlBlock(
                 .firstOrNull()
                 ?.childBlocks
 
-        val firstConditionBlock = (prevChildren?.firstOrNull() as? SqlElConditionLoopCommentBlock)
-        val endBlock = firstConditionBlock?.conditionEnd
+        val firstConditionBlock = prevChildren?.firstOrNull { it is SqlElConditionLoopCommentBlock } as? SqlElConditionLoopCommentBlock
+        val endBlock =
+            findConditionEndBlock(firstConditionBlock)
         if (endBlock == null) return false
         val lastBlock = prevBlocks.lastOrNull()
 
         return endBlock.node.startOffset > (lastBlock?.node?.startOffset ?: 0)
     }
+
+    private fun findConditionEndBlock(firstConditionBlock: SqlElConditionLoopCommentBlock?): SqlElConditionLoopCommentBlock? =
+        (
+            firstConditionBlock?.conditionEnd
+                ?: (
+                    firstConditionBlock?.childBlocks?.lastOrNull {
+                        it is SqlElConditionLoopCommentBlock
+                    } as? SqlElConditionLoopCommentBlock
+                )?.conditionEnd
+        )
 
     protected fun isFirstChildConditionLoopDirective(): Boolean = childBlocks.firstOrNull() is SqlElConditionLoopCommentBlock
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlElConditionLoopCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlElConditionLoopCommentBlock.kt
@@ -137,7 +137,7 @@ class SqlElConditionLoopCommentBlock(
     }
 
     override fun setParentPropertyBlock(lastGroup: SqlBlock?) {
-        if (lastGroup is SqlElConditionLoopCommentBlock && conditionType.isEnd()) {
+        if (lastGroup is SqlElConditionLoopCommentBlock && !conditionType.isStartDirective()) {
             lastGroup.conditionEnd = this
         }
     }
@@ -195,7 +195,7 @@ class SqlElConditionLoopCommentBlock(
                 is SqlSubGroupBlock -> return calculateSubGroupBlockIndent(parent, openConditionLoopDirectiveCount)
 
                 is SqlElConditionLoopCommentBlock -> {
-                    if (conditionType.isEnd()) {
+                    if (!conditionType.isStartDirective()) {
                         parent.conditionEnd = this
                         conditionStart = parent
                         return parent.indent.indentLen

--- a/src/test/testData/sql/formatter/CalculationDirectives.sql
+++ b/src/test/testData/sql/formatter/CalculationDirectives.sql
@@ -3,6 +3,11 @@ SELECT employee_id
        , salary
        , salary * /* yearBonusRate */1.2 AS yearly_bonus
        , salary + (salary * /* @raiseRate() */0.05) AS new_salary
+       , /*%if parent*/
+         number1.d,
+         /*%else*/
+         number2.e,
+         /*%end*/   number.x
   FROM employee
  WHERE department_id = /* departmentId */1
    /*%if  @minSalary() +extraAmount*/

--- a/src/test/testData/sql/formatter/CalculationDirectives_format.sql
+++ b/src/test/testData/sql/formatter/CalculationDirectives_format.sql
@@ -3,6 +3,14 @@ SELECT employee_id
        , salary
        , salary * /* yearBonusRate */1.2 AS yearly_bonus
        , salary + (salary * /* @raiseRate() */0.05) AS new_salary
+       , /*%if parent*/
+         number1.d
+          ,
+         /*%else*/
+         number2.e
+          ,
+         /*%end*/
+         number.x
   FROM employee
  WHERE department_id = /* departmentId */1
    /*%if  @minSalary() + extraAmount*/


### PR DESCRIPTION
### Description:
Fixed the issue where the last column was not moved to a new line when a column appeared after a closed conditional directive.

If a condition start directive (/*%if*/) includes an /*%else*/ directive, set the condition end block for the start directive using the /*%else*/ directive.