### PR TITLE
Exception Analyzer Support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginName = Doma Tools for IntelliJ
 pluginRepositoryUrl = https://github.com/domaframework/doma-tools-for-intellij
 pluginVersion = 2.1.2-beta
 
-pluginSinceBuild=231
+pluginSinceBuild=233
 
 platformType = IC
 platformVersion = 2024.3.1

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/paramtype/SqlProcessorParamTypeCheckProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/dao/processor/paramtype/SqlProcessorParamTypeCheckProcessor.kt
@@ -15,7 +15,6 @@
  */
 package org.domaframework.doma.intellij.inspection.dao.processor.paramtype
 
-import androidx.compose.compiler.plugins.kotlin.lower.fastForEachIndexed
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiType
@@ -64,7 +63,7 @@ class SqlProcessorParamTypeCheckProcessor(
 
         val biFunctionClassType = (biFunctionParam.type as? PsiClassType)
         val identifier = biFunctionParam.nameIdentifier ?: return
-        biFunctionClassType?.parameters?.fastForEachIndexed { index, param ->
+        biFunctionClassType?.parameters?.forEachIndexed { index, param ->
             if (param == null || !checkBiFunctionParam(index, param)) {
                 ValidationMethodBiFunctionParamResult(
                     identifier,

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
   <depends>org.intellij.intelliLang</depends>
   <depends>org.toml.lang</depends>
   <depends optional="true" config-file="kotlin.xml">org.jetbrains.kotlin</depends>
-  <idea-version since-build="231"/>
+  <idea-version since-build="233"/>
 
   <resource-bundle>messages.DomaToolsBundle</resource-bundle>
   <resource-bundle>messages.LLMInstallerBundle</resource-bundle>
@@ -22,6 +22,7 @@
   </projectListeners>
 
   <extensions defaultExtensionNs="com.intellij">
+    <errorHandler implementation="com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter"/>
     <postStartupActivity implementation="org.domaframework.doma.intellij.setting.DomaToolStartupActivity"/>
 
     <applicationService

--- a/src/test/kotlin/org/domaframework/doma/intellij/document/SqlSymbolDocumentTestCase.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/document/SqlSymbolDocumentTestCase.kt
@@ -205,6 +205,7 @@ class SqlSymbolDocumentTestCase : DomaSqlTest() {
             return forDirective.elExprList.firstOrNull { it.text == searchElementName }
         }
 
-        return fieldAccessExpr.accessElements.firstOrNull { it?.text == searchElementName }
+        val accesses = fieldAccessExpr.accessElements
+        return accesses.firstOrNull { it?.text == searchElementName }
     }
 }


### PR DESCRIPTION
This PR enables users to send error reports for exceptions that occur in this plugin, making them visible in the JetBrains Marketplace dashboard.

### Changes:

- Added plugin configuration to support the JetBrains Exception Analyzer (EA).
- Raised the supported IntelliJ platform version to 2023.3 or later.
- Exception Analyzer has already been enabled.
- Fixed several errors that occurred as a result of raising the version.