### PR TITLE
Fix Indentation Issues for Injected SQL and Correct Java Indent Size Retrieval

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/InjectionSqlFormatter.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/InjectionSqlFormatter.kt
@@ -16,6 +16,7 @@
 package org.domaframework.doma.intellij.formatter.processor
 
 import com.intellij.application.options.CodeStyle
+import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document
@@ -45,7 +46,7 @@ class InjectionSqlFormatter(
 
     private fun createSpaceIndent(project: Project): String {
         val settings = CodeStyle.getSettings(project)
-        val java = settings.indentOptions
+        val java = settings.getIndentOptions(JavaFileType.INSTANCE)
         val indentSize = java.INDENT_SIZE
         val prefixLen = "@Sql(\"\"\"".length
         return StringUtil.SINGLE_SPACE.repeat(indentSize.plus(prefixLen))


### PR DESCRIPTION
### Description:
This pull request addresses two issues:


- Injected SQL Indentation Fix:
Resolved a bug where unnecessary spaces were added when formatting code containing SQL injected via the @Sql annotation. The formatting logic has been updated to ensure proper indentation without extra spaces.


- Correct Java Indent Size Retrieval:
Fixed an issue where the indent size was not correctly retrieved from the Java code style settings. The process now explicitly specifies a Java file to obtain the correct indent size as configured in the Java code style settings screen.