### PR TITLE
Handle Blocks with the Same Name as Functions or Keywords as Word Blocks

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/common/util/TypeUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/util/TypeUtil.kt
@@ -27,9 +27,21 @@ import org.domaframework.doma.intellij.extension.psi.isDataType
 import org.domaframework.doma.intellij.extension.psi.isDomain
 import org.domaframework.doma.intellij.extension.psi.isEntity
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
+import org.domaframework.doma.intellij.formatter.block.comma.SqlCommaBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateViewGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithQuerySubGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 import kotlin.reflect.KClass
 
 object TypeUtil {
+    private val TOP_LEVEL_EXPECTED_TYPES =
+        listOf(
+            SqlSubGroupBlock::class,
+            SqlCommaBlock::class,
+            SqlWithQuerySubGroupBlock::class,
+            SqlCreateViewGroupBlock::class,
+        )
+
     /**
      * Unwraps the type parameter from Optional if present, otherwise returns the original type.
      */
@@ -117,6 +129,8 @@ object TypeUtil {
         if (type == null) return false
         return PsiTypeChecker.isBaseClassType(type) || DomaClassName.isOptionalWrapperType(type.canonicalText)
     }
+
+    fun isTopLevelExpectedType(childBlock: SqlBlock?): Boolean = isExpectedClassType(TOP_LEVEL_EXPECTED_TYPES, childBlock)
 
     /**
      * Determines whether the specified class instance matches.

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
@@ -102,7 +102,9 @@ open class SqlBlock(
     protected fun isConditionLoopDirectiveRegisteredBeforeParent(): Boolean {
         val firstPrevBlock = (prevBlocks.lastOrNull() as? SqlElConditionLoopCommentBlock)
         parentBlock?.let { parent ->
-            return firstPrevBlock != null &&
+
+            return (childBlocks.firstOrNull() as? SqlElConditionLoopCommentBlock)?.isBeforeParentBlock() == true ||
+                firstPrevBlock != null &&
                 firstPrevBlock.conditionEnd != null &&
                 firstPrevBlock.node.startOffset > parent.node.startOffset
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
@@ -236,11 +236,12 @@ open class SqlFileBlock(
                 ) {
                     return SqlFunctionGroupBlock(child, defaultFormatCtx)
                 }
-                return SqlKeywordBlock(
-                    child,
-                    IndentType.ATTACHED,
-                    defaultFormatCtx,
-                )
+                // If it is not followed by a left parenthesis, treat it as a word block
+                return if (lastGroup is SqlWithQueryGroupBlock) {
+                    SqlWithCommonTableGroupBlock(child, defaultFormatCtx)
+                } else {
+                    blockUtil.getWordBlock(lastGroup, child)
+                }
             }
 
             SqlTypes.WORD -> {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
@@ -555,7 +555,19 @@ open class SqlFileBlock(
                     SqlCustomSpacingBuilder.nonSpacing
                 }
 
-                else -> SqlCustomSpacingBuilder.normalSpacing
+                is SqlSubGroupBlock -> {
+                    val includeSpaceRight = childBlock1.endPatternBlock?.isPreSpaceRight()
+
+                    if (includeSpaceRight == false) {
+                        SqlCustomSpacingBuilder.nonSpacing
+                    } else {
+                        SqlCustomSpacingBuilder.normalSpacing
+                    }
+                }
+
+                else -> {
+                    SqlCustomSpacingBuilder.normalSpacing
+                }
             }
         }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlElBlockCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlElBlockCommentBlock.kt
@@ -27,6 +27,7 @@ import org.domaframework.doma.intellij.formatter.block.SqlUnknownBlock
 import org.domaframework.doma.intellij.formatter.block.expr.SqlElFieldAccessBlock
 import org.domaframework.doma.intellij.formatter.block.expr.SqlElFunctionCallBlock
 import org.domaframework.doma.intellij.formatter.block.expr.SqlElStaticFieldAccessBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlValuesGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithQuerySubGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubQueryGroupBlock
@@ -168,6 +169,7 @@ open class SqlElBlockCommentBlock(
                     }
                 }
                 is SqlValuesGroupBlock -> parent.indent.indentLen
+                is SqlKeywordGroupBlock -> parent.indent.groupIndentLen.plus(1)
                 else -> parent.indent.groupIndentLen
             }
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlElConditionLoopCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlElConditionLoopCommentBlock.kt
@@ -28,6 +28,7 @@ import org.domaframework.doma.intellij.formatter.block.SqlRightPatternBlock
 import org.domaframework.doma.intellij.formatter.block.SqlUnknownBlock
 import org.domaframework.doma.intellij.formatter.block.group.column.SqlColumnRawGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.condition.SqlConditionalExpressionGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.insert.SqlInsertQueryGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.with.SqlWithCommonTableGroupBlock
@@ -217,9 +218,9 @@ class SqlElConditionLoopCommentBlock(
                             return lastBlock.indent.indentLen
                         }
                     }
-                    return parent.indent.groupIndentLen +
-                        openConditionLoopDirectiveCount * DIRECTIVE_INDENT_STEP +
-                        if (parent !is SqlWithQueryGroupBlock) 1 else 0
+                    val withQuerySpace = if (parent !is SqlWithQueryGroupBlock) 1 else 0
+                    return parent.indent.groupIndentLen.plus(withQuerySpace) +
+                        openConditionLoopDirectiveCount * DIRECTIVE_INDENT_STEP
                 }
                 else -> return parent.indent.indentLen + openConditionLoopDirectiveCount * DIRECTIVE_INDENT_STEP
             }
@@ -302,5 +303,6 @@ class SqlElConditionLoopCommentBlock(
 
     private fun shouldNotIndent(parent: SqlSubGroupBlock): Boolean =
         TypeUtil.isExpectedClassType(SqlRightPatternBlock.NOT_INDENT_EXPECTED_TYPES, parent) ||
-            parent is SqlWithCommonTableGroupBlock
+            parent is SqlWithCommonTableGroupBlock ||
+            parent is SqlConditionalExpressionGroupBlock
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/condition/SqlConditionalExpressionGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/condition/SqlConditionalExpressionGroupBlock.kt
@@ -49,7 +49,18 @@ class SqlConditionalExpressionGroupBlock(
     override fun createBlockIndentLen(): Int =
         parentBlock?.let { parent ->
             if (parent is SqlElConditionLoopCommentBlock) {
-                parent.indent.groupIndentLen
+                val groupIndentLen = parent.indent.groupIndentLen
+                val grand = parent.parentBlock
+                val directiveParentTextLen =
+                    if (grand !is SqlElConditionLoopCommentBlock) {
+                        grand
+                            ?.getNodeText()
+                            ?.length
+                            ?.plus(1) ?: 0
+                    } else {
+                        0
+                    }
+                groupIndentLen + directiveParentTextLen
             } else {
                 parent.indent.groupIndentLen.plus(1)
             }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/create/SqlCreateTableColumnDefinitionGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/create/SqlCreateTableColumnDefinitionGroupBlock.kt
@@ -41,20 +41,23 @@ class SqlCreateTableColumnDefinitionGroupBlock(
         node,
         context,
     ) {
-    // TODO Customize indentation
-    override val offset = 2
-    private val groupOffset = 5
+    companion object {
+        private const val COLUMN_INDENT_OFFSET = 2
+        private const val GROUP_INDENT_OFFSET = 5
+    }
+
+    override val offset = COLUMN_INDENT_OFFSET
     val columnRawGroupBlocks = mutableListOf<SqlColumnDefinitionRawGroupBlock>()
 
     fun getMaxColumnNameLength(): Int =
         columnRawGroupBlocks.maxOfOrNull { raw ->
-            raw.columnBlock?.getNodeText()?.length ?: 0
+            raw.getColumnNameLength()
         } ?: 0
 
     override fun setParentGroupBlock(lastGroup: SqlBlock?) {
         super.setParentGroupBlock(lastGroup)
         indent.indentLen = createBlockIndentLen()
-        indent.groupIndentLen = indent.indentLen.plus(groupOffset)
+        indent.groupIndentLen = indent.indentLen.plus(GROUP_INDENT_OFFSET)
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/top/SqlTopQueryGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/top/SqlTopQueryGroupBlock.kt
@@ -99,4 +99,14 @@ abstract class SqlTopQueryGroupBlock(
 
         return parent.indent.indentLen
     }
+
+    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean {
+        if (TypeUtil.isTopLevelExpectedType(lastGroup) &&
+            lastGroup !is SqlWithQuerySubGroupBlock &&
+            lastGroup !is SqlCreateViewGroupBlock
+        ) {
+            return false
+        }
+        return super.isSaveSpace(lastGroup)
+    }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/word/SqlFunctionGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/word/SqlFunctionGroupBlock.kt
@@ -18,6 +18,7 @@ package org.domaframework.doma.intellij.formatter.block.word
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlDefaultCommentBlock
+import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlFunctionParamBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlBlockRelationBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlBlockRelationBuilder.kt
@@ -68,12 +68,6 @@ class SqlBlockRelationBuilder(
                 SqlExistsGroupBlock::class,
             )
 
-        private val TOP_LEVEL_EXPECTED_TYPES =
-            listOf(
-                SqlSubGroupBlock::class,
-                SqlCreateViewGroupBlock::class,
-            )
-
         private val COLUMN_RAW_EXPECTED_TYPES =
             listOf(
                 SqlColumnRawGroupBlock::class,
@@ -179,7 +173,7 @@ class SqlBlockRelationBuilder(
         context: SetParentContext,
     ) {
         val parentBlock =
-            if (TypeUtil.isExpectedClassType(TOP_LEVEL_EXPECTED_TYPES, lastGroupBlock)) {
+            if (TypeUtil.isTopLevelExpectedType(lastGroupBlock)) {
                 lastGroupBlock
             } else if (childBlock is SqlUpdateQueryGroupBlock) {
                 UpdateClauseHandler.getParentGroupBlock(blockBuilder, childBlock)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/handler/NotQueryGroupHandler.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/handler/NotQueryGroupHandler.kt
@@ -26,6 +26,7 @@ import org.domaframework.doma.intellij.formatter.block.group.keyword.condition.S
 import org.domaframework.doma.intellij.formatter.block.group.keyword.option.SqlInGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlReturningGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlValuesGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlWhereGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlFunctionParamBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlParallelListBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlValuesParamGroupBlock
@@ -55,7 +56,9 @@ object NotQueryGroupHandler {
             else -> null
         }
 
-    private fun lastGroupParentConditionKeywordGroup(lastGroup: SqlBlock?): Boolean = lastGroup is SqlConditionKeywordGroupBlock
+    private fun lastGroupParentConditionKeywordGroup(lastGroup: SqlBlock?): Boolean =
+        lastGroup is SqlConditionKeywordGroupBlock ||
+            lastGroup is SqlWhereGroupBlock
 
     /**
      * Creates a keyword group block for specific keywords.

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
@@ -254,6 +254,7 @@ class SqlFormatPreProcessor : PreFormatProcessor {
         text: String,
     ): String =
         if (prevElement?.elementType == SqlTypes.BLOCK_COMMENT ||
+            prevElement?.elementType == SqlTypes.BLOCK_COMMENT_END ||
             (
                 prevElement?.text?.contains(LINE_SEPARATE) == false &&
                     prevElement.prevSibling != null

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
@@ -28,6 +28,7 @@ import com.intellij.psi.TokenType
 import com.intellij.psi.impl.source.codeStyle.PreFormatProcessor
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
+import com.intellij.psi.util.prevLeafs
 import org.domaframework.doma.intellij.common.util.InjectionSqlUtil.isInjectedSqlFile
 import org.domaframework.doma.intellij.common.util.PluginLoggerUtil
 import org.domaframework.doma.intellij.common.util.StringUtil.LINE_SEPARATE
@@ -97,45 +98,51 @@ class SqlFormatPreProcessor : PreFormatProcessor {
         var index = keywordList.size
         var keywordIndex = replaceKeywordList.size
 
-        visitor.replaces.asReversed().forEach {
-            val textRangeStart = it.startOffset
-            val textRangeEnd = textRangeStart + it.text.length
-            if (it.elementType != TokenType.WHITE_SPACE) {
+        visitor.replaces.asReversed().forEach { current ->
+            val textRangeStart = current.startOffset
+            val textRangeEnd = textRangeStart + current.text.length
+            if (current.elementType != TokenType.WHITE_SPACE) {
                 // Add a newline before any element that needs a newline+indent, without overlapping if there is already a newline
                 index--
-                var newKeyword = getUpperText(it)
-                when (it.elementType) {
+                var newKeyword = getUpperText(current)
+                when (current.elementType) {
                     SqlTypes.KEYWORD -> {
                         keywordIndex--
-                        newKeyword = getKeywordNewText(it)
+                        // Escape-enclosed keywords are treated as regular words and are not converted to uppercase.
+                        val escapes = current.prevLeafs.filter { it.elementType == SqlTypes.OTHER }.toList()
+                        if (hasEscapeBeforeWhiteSpace(escapes, current.node)) {
+                            newKeyword = current.text
+                        } else {
+                            newKeyword = getKeywordNewText(current)
+                        }
                     }
 
                     SqlTypes.LEFT_PAREN -> {
-                        newKeyword = getNewLineLeftParenString(it.prevSibling, getUpperText(it))
+                        newKeyword = getNewLineLeftParenString(current.prevSibling, getUpperText(current))
                     }
 
                     SqlTypes.RIGHT_PAREN -> {
                         newKeyword =
-                            getRightPatternNewText(it)
+                            getRightPatternNewText(current)
                     }
 
                     SqlTypes.WORD, SqlTypes.FUNCTION_NAME -> {
-                        newKeyword = getWordNewText(it, newKeyword)
+                        newKeyword = getWordNewText(current, newKeyword)
                     }
 
                     SqlTypes.COMMA, SqlTypes.OTHER -> {
-                        newKeyword = getNewLineString(it.prevSibling, getUpperText(it))
+                        newKeyword = getNewLineString(current.prevSibling, getUpperText(current))
                     }
 
                     SqlTypes.BLOCK_COMMENT_START -> {
                         newKeyword =
-                            getNewLineString(PsiTreeUtil.prevLeaf(it), getUpperText(it))
+                            getNewLineString(PsiTreeUtil.prevLeaf(current), getUpperText(current))
                     }
                 }
                 document.deleteString(textRangeStart, textRangeEnd)
                 document.insertString(textRangeStart, newKeyword)
             } else {
-                removeSpacesAroundNewline(document, it as PsiWhiteSpace)
+                removeSpacesAroundNewline(document, current as PsiWhiteSpace)
             }
         }
 
@@ -186,6 +193,29 @@ class SqlFormatPreProcessor : PreFormatProcessor {
                 }
         }
         document.replaceString(range.startOffset, range.endOffset, newText)
+    }
+
+    private fun hasEscapeBeforeWhiteSpace(
+        prevBlocks: List<PsiElement>,
+        start: ASTNode,
+    ): Boolean {
+        val countEscape = prevBlocks.filter { it.elementType == SqlTypes.OTHER && it.text in listOf("\"", "[", "`", "]") }
+        if (countEscape.count() % 2 == 0) {
+            return false
+        }
+        var node = start.treeNext
+        while (node != null) {
+            if (node.elementType == SqlTypes.OTHER &&
+                listOf("\"", "`", "]").contains(node.text)
+            ) {
+                return true
+            }
+            if (node.psi is PsiWhiteSpace) {
+                return false
+            }
+            node = node.treeNext
+        }
+        return false
     }
 
     /**

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlKeywordBlockFactory.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlKeywordBlockFactory.kt
@@ -23,6 +23,8 @@ import org.domaframework.doma.intellij.formatter.block.conflict.OnConflictKeywor
 import org.domaframework.doma.intellij.formatter.block.conflict.SqlConflictClauseBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.condition.SqlConditionKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateTableColumnDefinitionGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateTableColumnDefinitionRawGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateViewGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.inline.SqlInlineGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.option.SqlExistsGroupBlock
@@ -123,6 +125,8 @@ class SqlKeywordBlockFactory(
         val shouldCreateExistsGroup =
             when {
                 lastGroupBlock is SqlElConditionLoopCommentBlock && lastGroupBlock.conditionType.isElse() -> true
+                lastGroupBlock is SqlCreateTableColumnDefinitionGroupBlock ||
+                    lastGroupBlock is SqlCreateTableColumnDefinitionRawGroupBlock -> false
                 keywordText == "not" && !isInConditionContext(lastGroupBlock) -> true
                 else -> false
             }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/visitor/SqlFormatVisitor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/visitor/SqlFormatVisitor.kt
@@ -42,6 +42,11 @@ class SqlFormatVisitor : PsiRecursiveElementVisitor() {
         }
 
         if (PsiTreeUtil.getParentOfType(element, SqlBlockComment::class.java) == null) {
+            val prevElement = PsiTreeUtil.prevLeaf(element)
+            if (prevElement.elementType == SqlTypes.BLOCK_COMMENT_END && element !is PsiWhiteSpace) {
+                replaces.add(element)
+                return
+            }
             when (element.elementType) {
                 SqlTypes.KEYWORD, SqlTypes.COMMA, SqlTypes.LEFT_PAREN, SqlTypes.RIGHT_PAREN, SqlTypes.WORD, SqlTypes.FUNCTION_NAME -> {
                     replaces.add(element)

--- a/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
@@ -262,6 +262,10 @@ class SqlFormatterTest : BasePlatformTestCase() {
         formatSqlFile("FunctionKeywordInConditionDirective.sql", "FunctionKeywordInConditionDirective$formatDataPrefix.sql")
     }
 
+    fun testFunctionNameColumnFormatter() {
+        formatSqlFile("FunctionNameColumn.sql", "FunctionNameColumn$formatDataPrefix.sql")
+    }
+
     private fun formatSqlFile(
         beforeFile: String,
         afterFile: String,

--- a/src/test/testData/sql/formatter/CreateTable.sql
+++ b/src/test/testData/sql/formatter/CreateTable.sql
@@ -3,4 +3,7 @@ CREATE TABLE departments
 id INT PRIMARY KEY
             , name VARCHAR(100)
             ,  loc INT NOT NULL
+            , age INTEGER      
+     ,   [abs] INTEGER
+     , "order" VARCHAR(100)
 )

--- a/src/test/testData/sql/formatter/CreateTable_format.sql
+++ b/src/test/testData/sql/formatter/CreateTable_format.sql
@@ -1,6 +1,9 @@
 CREATE TABLE departments
   (
-         id INT PRIMARY KEY
-     , name VARCHAR(100)
-     ,  loc INT NOT NULL
+            id INT PRIMARY KEY
+     ,    name VARCHAR(100)
+     ,     loc INT NOT NULL
+     ,     age INTEGER
+     ,   [abs] INTEGER
+     , "order" VARCHAR(100)
   )

--- a/src/test/testData/sql/formatter/FunctionNameColumn.sql
+++ b/src/test/testData/sql/formatter/FunctionNameColumn.sql
@@ -1,24 +1,15 @@
-SELECT id
-       , [age]
-       , /*%if maxAge*/
-         number + age(/* timestamp1 */'2099-12-31'
-         , /* timestamp2 */'2099-12-31')
-         /*%else*/
-         name
-          ,
-         /*%end*/"  age"
-  FROM employee
+WITH [abs] AS (
+insert into employee(id, name, "left")
+values (1, 'name', select "age" from user where id = 1))
+
+SELECT id, [age]
+       , "age"
+  FROM "order"o, `age`
  WHERE (/*%for age : ages */
-        "  age" 
-      = /* age */30
-          /*%if age_has_next *//*# "and" *//*%else */
-          /*%end */
-        /*%end */)
-   AND (/*%for age : ages */
-        abs               = /* abs */30
-        AND age >= 20
-           /*%if age_has_next */
-/*# "or" */
-           /*%else */
-           /*%end */
+        "age" = /* age */30
+        AND o."Left" = /* left */30
+            /*%if age_has_next */
+/*# "and" */
+            /*%else */
+            /*%end */
         /*%end */)

--- a/src/test/testData/sql/formatter/FunctionNameColumn.sql
+++ b/src/test/testData/sql/formatter/FunctionNameColumn.sql
@@ -1,0 +1,24 @@
+SELECT id
+       , [age]
+       , /*%if maxAge*/
+         number + age(/* timestamp1 */'2099-12-31'
+         , /* timestamp2 */'2099-12-31')
+         /*%else*/
+         name
+          ,
+         /*%end*/"  age"
+  FROM employee
+ WHERE (/*%for age : ages */
+        "  age" 
+      = /* age */30
+          /*%if age_has_next *//*# "and" *//*%else */
+          /*%end */
+        /*%end */)
+   AND (/*%for age : ages */
+        abs               = /* abs */30
+        AND age >= 20
+           /*%if age_has_next */
+/*# "or" */
+           /*%else */
+           /*%end */
+        /*%end */)

--- a/src/test/testData/sql/formatter/FunctionNameColumn_format.sql
+++ b/src/test/testData/sql/formatter/FunctionNameColumn_format.sql
@@ -1,0 +1,26 @@
+SELECT id
+       , [age]
+       , /*%if maxAge*/
+         number + age(/* timestamp1 */'2099-12-31'
+                      , /* timestamp2 */'2099-12-31')
+         /*%else*/
+         name
+          ,
+         /*%end*/
+        "age"
+  FROM employee
+ WHERE (/*%for age : ages */
+        "age" = /* age */30
+          /*%if age_has_next */
+          /*# "and" */
+          /*%else */
+          /*%end */
+        /*%end */)
+   AND (/*%for age : ages */
+        abs = /* abs */30
+        AND age >= 20
+            /*%if age_has_next */
+            /*# "or" */
+            /*%else */
+            /*%end */
+        /*%end */)

--- a/src/test/testData/sql/formatter/FunctionNameColumn_format.sql
+++ b/src/test/testData/sql/formatter/FunctionNameColumn_format.sql
@@ -1,26 +1,24 @@
+WITH [abs] AS (
+    INSERT INTO employee
+                (id
+                 , name
+                 , "left")
+         VALUES ( 1
+                  , 'name'
+                  , SELECT "age"
+                      FROM user
+                     WHERE id = 1 )
+)
 SELECT id
        , [age]
-       , /*%if maxAge*/
-         number + age(/* timestamp1 */'2099-12-31'
-                      , /* timestamp2 */'2099-12-31')
-         /*%else*/
-         name
-          ,
-         /*%end*/
-        "age"
-  FROM employee
+       , "age"
+  FROM "order" o
+       , `age`
  WHERE (/*%for age : ages */
         "age" = /* age */30
-          /*%if age_has_next */
-          /*# "and" */
-          /*%else */
-          /*%end */
-        /*%end */)
-   AND (/*%for age : ages */
-        abs = /* abs */30
-        AND age >= 20
+        AND o."Left" = /* left */30
             /*%if age_has_next */
-            /*# "or" */
+            /*# "and" */
             /*%else */
             /*%end */
         /*%end */)

--- a/src/test/testData/src/main/java/doma/example/dao/sqltoannotation/ScriptWithSqlFileDao.after.java
+++ b/src/test/testData/src/main/java/doma/example/dao/sqltoannotation/ScriptWithSqlFileDao.after.java
@@ -12,7 +12,7 @@ public interface ScriptWithSqlFileDao {
               (
                      id INTEGER PRIMARY KEY
                  , name VARCHAR(100)
-                 , age INTEGER
+                 ,  age INTEGER
               ) ;
             CREATE INDEX idx_employee_name
             ON employee(name) ;


### PR DESCRIPTION
**Summary**
This PR fixes unintended formatting when column names are identical to SQL functions or reserved keywords. Previously, such identifiers were not treated as normal word blocks, leading to incorrect formatting results.

**Relation**
#423 

**Details**

* Columns or identifiers that share names with functions or keywords are now treated as **word blocks**.
* Escaped identifiers (e.g., `"age"`) are also handled consistently to prevent unwanted formatting changes.

**Adjustments for Escaped Identifiers:**

* Disable keyword capitalization for escaped words.
* Do not create keyword groups for them.
* Apply the same spacing rules as for word blocks, including consistent spacing around escape characters.
* When a column definition uses escape characters, align the indentation to the right the same way as with normal column names.
* When enclosed in escape characters, calculate spacing based on the total character length, including the escape characters.

**Impact**

* Prevents unexpected line breaks or keyword formatting when column names overlap with reserved words or functions.
* Ensures escaped identifiers maintain proper indentation and spacing.

