### PR TITLE
Fix: Unnecessary Space in Parser-Level Comments

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlBlockCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlBlockCommentBlock.kt
@@ -21,13 +21,13 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlUnknownBlock
+import org.domaframework.doma.intellij.formatter.block.expr.SqlElSymbolBlock
 import org.domaframework.doma.intellij.formatter.builder.SqlCustomSpacingBuilder
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 import org.domaframework.doma.intellij.psi.SqlTypes
 
 open class SqlBlockCommentBlock(
     node: ASTNode,
-    private val customSpacingBuilder: SqlCustomSpacingBuilder,
     private val context: SqlBlockFormattingContext,
 ) : SqlDefaultCommentBlock(
         node,
@@ -41,16 +41,15 @@ open class SqlBlockCommentBlock(
             SqlTypes.BLOCK_COMMENT_START -> SqlCommentStartBlock(child, context)
             SqlTypes.BLOCK_COMMENT_END -> SqlCommentEndBlock(child, context)
             SqlTypes.BLOCK_COMMENT_CONTENT -> SqlCommentContentBlock(child, context)
+            SqlTypes.EL_PARSER_LEVEL_COMMENT -> SqlElSymbolBlock(child, context)
             else -> SqlUnknownBlock(child, context)
         }
     }
 
-    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = hasLineBreakBefore()
+    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = true
 
     override fun getSpacing(
         child1: Block?,
         child2: Block,
-    ): Spacing? =
-        customSpacingBuilder.getCustomSpacing(child1, child2)
-            ?: SqlCustomSpacingBuilder.normalSpacing
+    ): Spacing? = SqlCustomSpacingBuilder.nonSpacing
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlBlockGenerator.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlBlockGenerator.kt
@@ -17,7 +17,6 @@ package org.domaframework.doma.intellij.formatter.util
 
 import com.intellij.formatting.Alignment
 import com.intellij.formatting.FormattingMode
-import com.intellij.formatting.Spacing
 import com.intellij.formatting.SpacingBuilder
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
@@ -518,14 +517,15 @@ class SqlBlockGenerator(
         lastGroupBlock: SqlBlock?,
     ): SqlBlock {
         val rootBlock = getRootBlock(lastGroupBlock)
-        return when {
-            rootBlock is SqlTableModifySecondGroupBlock ||
-                rootBlock is SqlTableModificationKeyword -> {
+        return when (rootBlock) {
+            is SqlTableModifySecondGroupBlock, is SqlTableModificationKeyword -> {
                 SqlTableModifySecondGroupBlock(child, sqlBlockFormattingCtx)
             }
-            rootBlock is SqlExistsGroupBlock -> {
+
+            is SqlExistsGroupBlock -> {
                 SqlKeywordBlock(child, IndentType.ATTACHED, sqlBlockFormattingCtx)
             }
+
             else -> SqlConflictClauseBlock(child, sqlBlockFormattingCtx)
         }
     }
@@ -552,7 +552,7 @@ class SqlBlockGenerator(
         blockCommentSpacingBuilder: SqlCustomSpacingBuilder?,
     ): SqlCommentBlock {
         if (PsiTreeUtil.getChildOfType(child.psi, PsiComment::class.java) != null) {
-            return SqlBlockCommentBlock(child, createBlockCommentSpacingBuilder(), sqlBlockFormattingCtx)
+            return SqlBlockCommentBlock(child, sqlBlockFormattingCtx)
         }
         if (child.psi is SqlCustomElCommentExpr &&
             (child.psi as SqlCustomElCommentExpr).isConditionOrLoopDirective()
@@ -569,16 +569,4 @@ class SqlBlockGenerator(
             blockCommentSpacingBuilder,
         )
     }
-
-    private fun createBlockCommentSpacingBuilder(): SqlCustomSpacingBuilder =
-        SqlCustomSpacingBuilder()
-            .withSpacing(
-                SqlTypes.BLOCK_COMMENT_START,
-                SqlTypes.BLOCK_COMMENT_CONTENT,
-                Spacing.createSpacing(0, 0, 0, true, 0),
-            ).withSpacing(
-                SqlTypes.BLOCK_COMMENT_CONTENT,
-                SqlTypes.BLOCK_COMMENT_END,
-                Spacing.createSpacing(0, 0, 0, true, 0),
-            )
 }

--- a/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
@@ -298,6 +298,10 @@ class SqlFormatterTest : BasePlatformTestCase() {
         formatSqlFile("DropTableIfExists.sql", "DropTableIfExists$formatDataPrefix.sql")
     }
 
+    fun testBlockCommentParseFormatter() {
+        formatSqlFile("BlockCommentParse.sql", "BlockCommentParse$formatDataPrefix.sql")
+    }
+
     private fun formatSqlFile(
         beforeFile: String,
         afterFile: String,

--- a/src/test/testData/sql/formatter/BlockCommentParse.sql
+++ b/src/test/testData/sql/formatter/BlockCommentParse.sql
@@ -1,0 +1,8 @@
+/*%! This is Parser Level Comment*/
+select * from table1
+/*%!This is Parser Level Comment*/
+where column1 = /*# value1*/
+/*+
+   * This is Block Comment
+   */
+and column2 = /* value2 */ 'value2'     or column3 = /*^ value3 */ 'value3'

--- a/src/test/testData/sql/formatter/BlockCommentParse.sql
+++ b/src/test/testData/sql/formatter/BlockCommentParse.sql
@@ -1,8 +1,9 @@
-/*%! This is Parser Level Comment*/
+
+ /*%! This is Parser Level Comment*/
 select * from table1
 /*%!This is Parser Level Comment*/
 where column1 = /*# value1*/
 /*+
    * This is Block Comment
    */
-and column2 = /* value2 */ 'value2'     or column3 = /*^ value3 */ 'value3'
+and column2 = /* value2 */ 'value2' /** line break */    or column3 = /*^ value3 */ 'value3'

--- a/src/test/testData/sql/formatter/BlockCommentParse_format.sql
+++ b/src/test/testData/sql/formatter/BlockCommentParse_format.sql
@@ -7,4 +7,5 @@ SELECT *
    * This is Block Comment
    */
    AND column2 = /* value2 */'value2'
+    /** line break */
     OR column3 = /*^ value3 */'value3'

--- a/src/test/testData/sql/formatter/BlockCommentParse_format.sql
+++ b/src/test/testData/sql/formatter/BlockCommentParse_format.sql
@@ -1,0 +1,10 @@
+/*%! This is Parser Level Comment*/
+SELECT *
+  FROM table1
+ /*%!This is Parser Level Comment*/
+ WHERE column1 = /*# value1 */
+   /*+
+   * This is Block Comment
+   */
+   AND column2 = /* value2 */'value2'
+    OR column3 = /*^ value3 */'value3'


### PR DESCRIPTION
### Summary
This PR resolves the issue where parser-level comments (/*%! ... */) were incorrectly formatted with extra spaces, preventing them from being recognized correctly.

### Relation
https://github.com/domaframework/doma-tools-for-intellij/issues/437

### Changes

- Unified spacing rules for parser-level comment blocks by applying nonSpacing consistently.
- Updated the pre-processor to always insert a line break before multi-line blocks.
- Added a condition to skip line breaks for the first element in a file, ensuring that leading comments are not preceded by unnecessary blank lines.

### Impact

- Parser-level comments are now correctly recognized and formatted without extra spaces.
- Multi-line parser-level comments maintain consistent formatting.
- File-level top elements remain clean without unintended line breaks.