### PR TITLE
Improve SQL CASE Statement Formatting

### DIFF
--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
@@ -105,7 +105,6 @@ open class SqlBlock(
     protected fun isConditionLoopDirectiveRegisteredBeforeParent(): Boolean {
         val firstPrevBlock = (prevBlocks.lastOrNull() as? SqlElConditionLoopCommentBlock)
         parentBlock?.let { parent ->
-
             return (childBlocks.firstOrNull() as? SqlElConditionLoopCommentBlock)?.isBeforeParentBlock() == true ||
                 firstPrevBlock != null &&
                 firstPrevBlock.conditionEnd != null &&
@@ -132,7 +131,7 @@ open class SqlBlock(
     protected fun isElementAfterConditionLoopDirective(): Boolean =
         (parentBlock as? SqlElConditionLoopCommentBlock)?.let { parent ->
             parent.childBlocks.firstOrNull() == this &&
-                (parent.parentBlock is SqlNewGroupBlock || parent.parentBlock is SqlElConditionLoopCommentBlock)
+                (parent.parentBlock is SqlNewGroupBlock || parent.isParentConditionLoopDirective())
         } == true
 
     protected fun isElementAfterConditionLoopEnd(): Boolean {
@@ -159,6 +158,8 @@ open class SqlBlock(
                     } as? SqlElConditionLoopCommentBlock
                 )?.conditionEnd
         )
+
+    fun isParentConditionLoopDirective(): Boolean = parentBlock is SqlElConditionLoopCommentBlock
 
     protected fun isFirstChildConditionLoopDirective(): Boolean = childBlocks.firstOrNull() is SqlElConditionLoopCommentBlock
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlFileBlock.kt
@@ -359,7 +359,6 @@ open class SqlFileBlock(
             }
 
             is SqlInlineGroupBlock -> {
-                // case-end
                 blockRelationBuilder.updateGroupBlockParentAndAddGroup(
                     childBlock,
                 )
@@ -471,7 +470,7 @@ open class SqlFileBlock(
             return SqlCustomSpacingBuilder().getSpacing(childBlock2)
         }
 
-        if (childBlock1 is SqlWhitespaceBlock && childBlock2.parentBlock is SqlElConditionLoopCommentBlock) {
+        if (childBlock1 is SqlWhitespaceBlock && childBlock2.isParentConditionLoopDirective()) {
             val child1 = childBlock2.parentBlock as SqlElConditionLoopCommentBlock
             SqlCustomSpacingBuilder()
                 .getSpacingElDirectiveComment(child1, childBlock2)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlKeywordBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlKeywordBlock.kt
@@ -17,7 +17,6 @@ package org.domaframework.doma.intellij.formatter.block
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
-import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.block.conflict.SqlDoGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.SqlNewGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
@@ -96,7 +95,7 @@ open class SqlKeywordBlock(
             }
 
             else -> {
-                if (parentBlock is SqlElConditionLoopCommentBlock) {
+                if (isParentConditionLoopDirective()) {
                     parentBlock?.indent?.groupIndentLen ?: 1
                 } else {
                     parentBlock?.indent?.groupIndentLen?.plus(1) ?: 1

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlLiteralBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlLiteralBlock.kt
@@ -41,11 +41,18 @@ open class SqlLiteralBlock(
     override fun setParentGroupBlock(lastGroup: SqlBlock?) {
         super.setParentGroupBlock(lastGroup)
         indent.indentLevel = IndentType.NONE
-        indent.indentLen = 0
-        indent.groupIndentLen = 0
+        indent.indentLen = createBlockIndentLen()
+        indent.groupIndentLen = createGroupIndentLen()
     }
 
     override fun buildChildren(): MutableList<AbstractBlock> = mutableListOf()
 
     override fun isLeaf(): Boolean = true
+
+    override fun createBlockIndentLen(): Int =
+        if (isFirstChildConditionLoopDirective() || isParentConditionLoopDirective()) {
+            parentBlock?.indent?.indentLen ?: 0
+        } else {
+            0
+        }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comma/SqlArrayCommaBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comma/SqlArrayCommaBlock.kt
@@ -18,7 +18,6 @@ package org.domaframework.doma.intellij.formatter.block.comma
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
@@ -49,5 +48,5 @@ class SqlArrayCommaBlock(
 
     override fun createGroupIndentLen(): Int = indent.indentLen.plus(1)
 
-    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = parentBlock is SqlElConditionLoopCommentBlock
+    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = isParentConditionLoopDirective()
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlBlockCommentBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/comment/SqlBlockCommentBlock.kt
@@ -21,13 +21,13 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.SqlUnknownBlock
+import org.domaframework.doma.intellij.formatter.block.expr.SqlElSymbolBlock
 import org.domaframework.doma.intellij.formatter.builder.SqlCustomSpacingBuilder
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 import org.domaframework.doma.intellij.psi.SqlTypes
 
 open class SqlBlockCommentBlock(
     node: ASTNode,
-    private val customSpacingBuilder: SqlCustomSpacingBuilder,
     private val context: SqlBlockFormattingContext,
 ) : SqlDefaultCommentBlock(
         node,
@@ -41,16 +41,15 @@ open class SqlBlockCommentBlock(
             SqlTypes.BLOCK_COMMENT_START -> SqlCommentStartBlock(child, context)
             SqlTypes.BLOCK_COMMENT_END -> SqlCommentEndBlock(child, context)
             SqlTypes.BLOCK_COMMENT_CONTENT -> SqlCommentContentBlock(child, context)
+            SqlTypes.EL_PARSER_LEVEL_COMMENT -> SqlElSymbolBlock(child, context)
             else -> SqlUnknownBlock(child, context)
         }
     }
 
-    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = hasLineBreakBefore()
+    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = true
 
     override fun getSpacing(
         child1: Block?,
         child2: Block,
-    ): Spacing? =
-        customSpacingBuilder.getCustomSpacing(child1, child2)
-            ?: SqlCustomSpacingBuilder.normalSpacing
+    ): Spacing? = SqlCustomSpacingBuilder.nonSpacing
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/SqlKeywordGroupBlock.kt
@@ -182,7 +182,7 @@ open class SqlKeywordGroupBlock(
 
     override fun isSaveSpace(lastGroup: SqlBlock?): Boolean {
         val conditionLastGroup =
-            if (parentBlock is SqlElConditionLoopCommentBlock) {
+            if (isParentConditionLoopDirective()) {
                 parentBlock?.parentBlock
             } else {
                 lastGroup

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/condition/SqlConditionKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/condition/SqlConditionKeywordGroupBlock.kt
@@ -57,6 +57,7 @@ class SqlConditionKeywordGroupBlock(
         return when (parent) {
             is SqlElConditionLoopCommentBlock -> parent.indent.groupIndentLen
             is SqlSubGroupBlock -> calculateSubGroupIndent(groupLen)
+            is SqlInlineSecondGroupBlock -> calculateInlineSecondIndent(groupLen)
             else -> parent.indent.groupIndentLen - getNodeText().length
         }
     }
@@ -66,6 +67,13 @@ class SqlConditionKeywordGroupBlock(
             groupLen
         } else {
             groupLen + 1
+        }
+
+    private fun calculateInlineSecondIndent(groupLen: Int): Int =
+        if (getNodeText() == "and") {
+            groupLen.plus(1)
+        } else {
+            groupLen.plus(2)
         }
 
     override fun createGroupIndentLen(): Int {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/condition/SqlConditionKeywordGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/condition/SqlConditionKeywordGroupBlock.kt
@@ -19,6 +19,7 @@ import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.inline.SqlInlineSecondGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.option.SqlSecondOptionKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlWhereGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/inline/SqlInlineGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/inline/SqlInlineGroupBlock.kt
@@ -60,4 +60,11 @@ open class SqlInlineGroupBlock(
         } ?: 1
 
     override fun createGroupIndentLen(): Int = indent.indentLen.plus(getNodeText().length)
+
+    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean {
+        if (lastGroup is SqlInlineSecondGroupBlock) {
+            return true
+        }
+        return super.isSaveSpace(lastGroup)
+    }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/inline/SqlInlineGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/inline/SqlInlineGroupBlock.kt
@@ -18,7 +18,6 @@ package org.domaframework.doma.intellij.formatter.block.group.keyword.inline
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.block.group.SqlNewGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType
@@ -51,7 +50,7 @@ open class SqlInlineGroupBlock(
 
     override fun createBlockIndentLen(): Int =
         parentBlock?.let { parent ->
-            if (parent is SqlElConditionLoopCommentBlock || childBlocks.firstOrNull() is SqlElConditionLoopCommentBlock ||
+            if (isParentConditionLoopDirective() || isFirstChildConditionLoopDirective() ||
                 parent is SqlSubGroupBlock
             ) {
                 parent.indent.groupIndentLen

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/inline/SqlInlineGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/inline/SqlInlineGroupBlock.kt
@@ -20,6 +20,7 @@ import com.intellij.psi.formatter.common.AbstractBlock
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.block.group.SqlNewGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.subgroup.SqlSubGroupBlock
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlBlockFormattingContext
 
@@ -50,7 +51,9 @@ open class SqlInlineGroupBlock(
 
     override fun createBlockIndentLen(): Int =
         parentBlock?.let { parent ->
-            if (parent is SqlElConditionLoopCommentBlock) {
+            if (parent is SqlElConditionLoopCommentBlock || childBlocks.firstOrNull() is SqlElConditionLoopCommentBlock ||
+                parent is SqlSubGroupBlock
+            ) {
                 parent.indent.groupIndentLen
             } else {
                 parent.indent.groupIndentLen.plus(1)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/inline/SqlInlineSecondGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/inline/SqlInlineSecondGroupBlock.kt
@@ -66,6 +66,5 @@ open class SqlInlineSecondGroupBlock(
 
     override fun createGroupIndentLen(): Int = indent.indentLen.plus(getNodeText().length)
 
-    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean =
-        (parentBlock as? SqlInlineGroupBlock)?.inlineConditions?.dropLast(1)?.isEmpty() != true
+    override fun isSaveSpace(lastGroup: SqlBlock?): Boolean = true
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/option/SqlExistsGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/option/SqlExistsGroupBlock.kt
@@ -17,7 +17,6 @@ package org.domaframework.doma.intellij.formatter.block.group.keyword.option
 
 import com.intellij.lang.ASTNode
 import org.domaframework.doma.intellij.formatter.block.SqlBlock
-import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.inline.SqlInlineSecondGroupBlock
@@ -38,7 +37,7 @@ class SqlExistsGroupBlock(
 
     override fun createBlockIndentLen(): Int {
         parentBlock?.let { parent ->
-            if (parent.parentBlock is SqlElConditionLoopCommentBlock) {
+            if (parent.isParentConditionLoopDirective()) {
                 return parent.indent.groupIndentLen
             }
         }
@@ -47,9 +46,14 @@ class SqlExistsGroupBlock(
 
     override fun createGroupIndentLen(): Int {
         // If this group is not the top of a line, there must be one space between it and the block before it.
-       val correctionSpace = if(childBlocks.firstOrNull() is SqlElConditionLoopCommentBlock){
-            0
-        }else 1
+        val correctionSpace =
+            if (isFirstChildConditionLoopDirective() ||
+                isParentConditionLoopDirective()
+            ) {
+                0
+            } else {
+                1
+            }
         val parentGroupIndent = parentBlock?.indent?.groupIndentLen ?: 0
         return getTotalTopKeywordLength().plus(parentGroupIndent).plus(correctionSpace)
     }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/option/SqlExistsGroupBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/keyword/option/SqlExistsGroupBlock.kt
@@ -20,6 +20,7 @@ import org.domaframework.doma.intellij.formatter.block.SqlBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.create.SqlCreateKeywordGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.keyword.inline.SqlInlineSecondGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.second.SqlTableModifySecondGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.top.SqlTableModificationKeyword
 import org.domaframework.doma.intellij.formatter.util.IndentType
@@ -45,14 +46,19 @@ class SqlExistsGroupBlock(
     }
 
     override fun createGroupIndentLen(): Int {
+        // If this group is not the top of a line, there must be one space between it and the block before it.
+       val correctionSpace = if(childBlocks.firstOrNull() is SqlElConditionLoopCommentBlock){
+            0
+        }else 1
         val parentGroupIndent = parentBlock?.indent?.groupIndentLen ?: 0
-        return getTotalTopKeywordLength().plus(parentGroupIndent)
+        return getTotalTopKeywordLength().plus(parentGroupIndent).plus(correctionSpace)
     }
 
     override fun isSaveSpace(lastGroup: SqlBlock?): Boolean {
         if (lastGroup is SqlTableModificationKeyword ||
             lastGroup is SqlTableModifySecondGroupBlock ||
-            lastGroup is SqlCreateKeywordGroupBlock
+            lastGroup is SqlCreateKeywordGroupBlock ||
+            lastGroup is SqlInlineSecondGroupBlock
         ) {
             return false
         }

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlFunctionParamBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/group/subgroup/SqlFunctionParamBlock.kt
@@ -90,7 +90,7 @@ class SqlFunctionParamBlock(
             }
                 ?: emptyList()
         val parentText =
-            if (parentBlock is SqlElConditionLoopCommentBlock) {
+            if (isParentConditionLoopDirective()) {
                 val grand = parentBlock?.parentBlock
                 grand?.getNodeText() ?: ""
             } else {

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/other/SqlEscapeBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/other/SqlEscapeBlock.kt
@@ -37,7 +37,7 @@ class SqlEscapeBlock(
 
     override fun createBlockIndentLen(): Int {
         val parentEscapeBlock =
-            if (parentBlock is SqlElConditionLoopCommentBlock) {
+            if (isParentConditionLoopDirective()) {
                 if (parentBlock?.parentBlock is SqlEscapeBlock)1 else 0
             } else {
                 0

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlBlockRelationBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlBlockRelationBuilder.kt
@@ -89,7 +89,8 @@ class SqlBlockRelationBuilder(
             )
         val lastGroup = blockBuilder.getLastGroupTopNodeIndexHistory()
         if (lastGroup is SqlElConditionLoopCommentBlock) {
-            updateParentGroupLastConditionLoop(lastGroup, context) { block ->
+            updateParentGroupLastConditionLoop(
+                lastGroup, context, false) { block ->
                 block.indent.indentLevel < childBlock.indent.indentLevel
             }
             return
@@ -170,7 +171,7 @@ class SqlBlockRelationBuilder(
         context: SetParentContext,
         childBlock: SqlKeywordGroupBlock,
     ) {
-        updateParentGroupLastConditionLoop(lastGroupBlock, context) {
+        updateParentGroupLastConditionLoop(lastGroupBlock, context, true) {
             it.indent.indentLevel < childBlock.indent.indentLevel
         }
     }
@@ -424,7 +425,7 @@ class SqlBlockRelationBuilder(
         val lastGroupBlock = blockBuilder.getLastGroupTopNodeIndexHistory()
         if (lastGroupBlock is SqlElConditionLoopCommentBlock) {
             updateParentGroupLastConditionLoop(lastGroupBlock, context) {
-                it.indent.indentLevel == IndentType.INLINE_SECOND
+                it.indent.indentLevel == IndentType.INLINE
             }
             return
         }
@@ -458,6 +459,7 @@ class SqlBlockRelationBuilder(
     private fun updateParentGroupLastConditionLoop(
         lastGroupBlock: SqlElConditionLoopCommentBlock,
         context: SetParentContext,
+        findSubGroup: Boolean = false,
         findDefaultParent: (SqlBlock) -> Boolean,
     ) {
         if (lastGroupBlock.parentBlock != null) {
@@ -465,14 +467,14 @@ class SqlBlockRelationBuilder(
             return
         }
 
-        val findParent = findParentForConditionLoop(findDefaultParent)
+        val findParent = findParentForConditionLoop(findDefaultParent, findSubGroup)
         handleConditionLoopParentAssignment(lastGroupBlock, context, findParent)
     }
 
-    private fun findParentForConditionLoop(findDefaultParent: (SqlBlock) -> Boolean): SqlBlock? =
+    private fun findParentForConditionLoop(findDefaultParent: (SqlBlock) -> Boolean,findSubGroup: Boolean =false): SqlBlock? =
         blockBuilder.getGroupTopNodeIndexHistory().lastOrNull { block ->
             findDefaultParent(block) ||
-                block is SqlSubGroupBlock ||
+                    findSubGroup && block is SqlSubGroupBlock ||
                 (block is SqlElConditionLoopCommentBlock && block.parentBlock != null)
         }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlBlockRelationBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlBlockRelationBuilder.kt
@@ -22,6 +22,7 @@ import org.domaframework.doma.intellij.formatter.block.SqlRightPatternBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlDefaultCommentBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
 import org.domaframework.doma.intellij.formatter.block.conflict.SqlDoGroupBlock
+import org.domaframework.doma.intellij.formatter.block.group.SqlNewGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.column.SqlColumnDefinitionRawGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.column.SqlColumnRawGroupBlock
 import org.domaframework.doma.intellij.formatter.block.group.keyword.SqlKeywordGroupBlock
@@ -89,9 +90,9 @@ class SqlBlockRelationBuilder(
             )
         val lastGroup = blockBuilder.getLastGroupTopNodeIndexHistory()
         if (lastGroup is SqlElConditionLoopCommentBlock) {
-            updateParentGroupLastConditionLoop(
-                lastGroup, context, false) { block ->
-                block.indent.indentLevel < childBlock.indent.indentLevel
+            updateParentGroupLastConditionLoop(lastGroup, context, false) { block ->
+                block.indent.indentLevel < childBlock.indent.indentLevel ||
+                    block is SqlNewGroupBlock
             }
             return
         }
@@ -471,10 +472,13 @@ class SqlBlockRelationBuilder(
         handleConditionLoopParentAssignment(lastGroupBlock, context, findParent)
     }
 
-    private fun findParentForConditionLoop(findDefaultParent: (SqlBlock) -> Boolean,findSubGroup: Boolean =false): SqlBlock? =
+    private fun findParentForConditionLoop(
+        findDefaultParent: (SqlBlock) -> Boolean,
+        findSubGroup: Boolean = false,
+    ): SqlBlock? =
         blockBuilder.getGroupTopNodeIndexHistory().lastOrNull { block ->
             findDefaultParent(block) ||
-                    findSubGroup && block is SqlSubGroupBlock ||
+                findSubGroup && block is SqlSubGroupBlock ||
                 (block is SqlElConditionLoopCommentBlock && block.parentBlock != null)
         }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlBlockRelationBuilder.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/builder/SqlBlockRelationBuilder.kt
@@ -429,9 +429,20 @@ class SqlBlockRelationBuilder(
             return
         }
 
+        val caseBlockIndex =
+            blockBuilder.getGroupTopNodeIndex { block ->
+                block.indent.indentLevel == IndentType.INLINE
+            }
+        val caseBlock =
+            if (caseBlockIndex >= 0) {
+                blockBuilder.getGroupTopNodeIndexHistory()[caseBlockIndex]
+            } else {
+                null
+            }
         val inlineSecondIndex =
             blockBuilder.getGroupTopNodeIndex { block ->
-                block.indent.indentLevel == IndentType.INLINE_SECOND
+                (caseBlock?.node?.startOffset ?: 0) < block.node.startOffset &&
+                    block.indent.indentLevel == IndentType.INLINE_SECOND
             }
         if (inlineSecondIndex >= 0) {
             blockBuilder.clearSubListGroupTopNodeIndexHistory(inlineSecondIndex)

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlBlockGenerator.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/util/SqlBlockGenerator.kt
@@ -17,7 +17,6 @@ package org.domaframework.doma.intellij.formatter.util
 
 import com.intellij.formatting.Alignment
 import com.intellij.formatting.FormattingMode
-import com.intellij.formatting.Spacing
 import com.intellij.formatting.SpacingBuilder
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
@@ -518,14 +517,15 @@ class SqlBlockGenerator(
         lastGroupBlock: SqlBlock?,
     ): SqlBlock {
         val rootBlock = getRootBlock(lastGroupBlock)
-        return when {
-            rootBlock is SqlTableModifySecondGroupBlock ||
-                rootBlock is SqlTableModificationKeyword -> {
+        return when (rootBlock) {
+            is SqlTableModifySecondGroupBlock, is SqlTableModificationKeyword -> {
                 SqlTableModifySecondGroupBlock(child, sqlBlockFormattingCtx)
             }
-            rootBlock is SqlExistsGroupBlock -> {
+
+            is SqlExistsGroupBlock -> {
                 SqlKeywordBlock(child, IndentType.ATTACHED, sqlBlockFormattingCtx)
             }
+
             else -> SqlConflictClauseBlock(child, sqlBlockFormattingCtx)
         }
     }
@@ -552,7 +552,7 @@ class SqlBlockGenerator(
         blockCommentSpacingBuilder: SqlCustomSpacingBuilder?,
     ): SqlCommentBlock {
         if (PsiTreeUtil.getChildOfType(child.psi, PsiComment::class.java) != null) {
-            return SqlBlockCommentBlock(child, createBlockCommentSpacingBuilder(), sqlBlockFormattingCtx)
+            return SqlBlockCommentBlock(child, sqlBlockFormattingCtx)
         }
         if (child.psi is SqlCustomElCommentExpr &&
             (child.psi as SqlCustomElCommentExpr).isConditionOrLoopDirective()
@@ -569,16 +569,4 @@ class SqlBlockGenerator(
             blockCommentSpacingBuilder,
         )
     }
-
-    private fun createBlockCommentSpacingBuilder(): SqlCustomSpacingBuilder =
-        SqlCustomSpacingBuilder()
-            .withSpacing(
-                SqlTypes.BLOCK_COMMENT_START,
-                SqlTypes.BLOCK_COMMENT_CONTENT,
-                Spacing.createSpacing(0, 0, 0, true, 0),
-            ).withSpacing(
-                SqlTypes.BLOCK_COMMENT_CONTENT,
-                SqlTypes.BLOCK_COMMENT_END,
-                Spacing.createSpacing(0, 0, 0, true, 0),
-            )
 }

--- a/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
@@ -298,6 +298,10 @@ class SqlFormatterTest : BasePlatformTestCase() {
         formatSqlFile("DropTableIfExists.sql", "DropTableIfExists$formatDataPrefix.sql")
     }
 
+    fun testBlockCommentParseFormatter() {
+        formatSqlFile("BlockCommentParse.sql", "BlockCommentParse$formatDataPrefix.sql")
+    }
+
     private fun formatSqlFile(
         beforeFile: String,
         afterFile: String,

--- a/src/test/testData/sql/formatter/BlockCommentParse.sql
+++ b/src/test/testData/sql/formatter/BlockCommentParse.sql
@@ -1,0 +1,8 @@
+/*%! This is Parser Level Comment*/
+select * from table1
+/*%!This is Parser Level Comment*/
+where column1 = /*# value1*/
+/*+
+   * This is Block Comment
+   */
+and column2 = /* value2 */ 'value2'     or column3 = /*^ value3 */ 'value3'

--- a/src/test/testData/sql/formatter/BlockCommentParse_format.sql
+++ b/src/test/testData/sql/formatter/BlockCommentParse_format.sql
@@ -1,0 +1,10 @@
+/*%! This is Parser Level Comment*/
+SELECT *
+  FROM table1
+ /*%!This is Parser Level Comment*/
+ WHERE column1 = /*# value1 */
+   /*+
+   * This is Block Comment
+   */
+   AND column2 = /* value2 */'value2'
+    OR column3 = /*^ value3 */'value3'

--- a/src/test/testData/sql/formatter/ComparisonOperators_format.sql
+++ b/src/test/testData/sql/formatter/ComparisonOperators_format.sql
@@ -46,7 +46,8 @@ SELECT id
        , quantity >> 10 AS much_greater
        ,
          -- Complex conditions with multiple operators
-         CASE WHEN json_data ->> 'status' <> 'active' THEN 'inactive'
+         CASE
+              WHEN json_data ->> 'status' <> 'active' THEN 'inactive'
               WHEN json_data ->> 'priority' >= '5' THEN 'high'
               ELSE 'normal'
           END AS status_priority

--- a/src/test/testData/sql/formatter/SelectCaseEnd.sql
+++ b/src/test/testData/sql/formatter/SelectCaseEnd.sql
@@ -1,4 +1,41 @@
-Select case when div = 'A' then 'AAA'
- when div = 'B' then 'BBB'
- else 'CCC' end as divName
-from users
+SELECT *
+       , CASE
+              /** case-end */
+WHEN SUM(CASE WHEN name = 'apple' THEN 1
+                            WHEN name = 'berry' THEN 3
+                            ELSE 0
+                        END) > 0 THEN 'x'
+              -- active check
+              WHEN SUM(CASE
+                            WHEN NOT EXISTS ( SELECT number
+                                                FROM users
+                                               WHERE status = 1 ) THEN 1
+                            ELSE 0
+                        END) > 0 THEN 'y'
+              WHEN SUM(CASE
+                            WHEN position > 100
+                                 AND count(*) > 10 THEN 1
+                                  OR number > 10 THEN 1
+                            WHEN position <= 100
+                                  OR count(*) > 10 THEN 1
+                            ELSE 0
+                        END) > 0 THEN 'z'
+              ELSE 0
+          END AS user_status
+  FROM active_users
+ ORDER BY CASE
+               WHEN orders = 1 THEN 1
+               ELSE 2
+           END
+, CASE
+                WHEN pickup IS NULL THEN
+CASE
+                          WHEN case_status THEN 0
+                          ELSE 1
+                      END
+                ELSE
+CASE
+                          WHEN case_static_status THEN 0
+                          ELSE 1
+                     END
+            END

--- a/src/test/testData/sql/formatter/SelectCaseEndWithCondition.sql
+++ b/src/test/testData/sql/formatter/SelectCaseEndWithCondition.sql
@@ -1,4 +1,11 @@
-Select case when div = 'A' then 'AAA'
+Select case /*%if isCheckStatus */
+    WHEN status = '1' THEN 1
+    /*%else */
+      /*%if hasPoint */
+      WHEN status = '2' THEN 2
+      /*%end*/
+    /*%end*/
+when div = 'A' then 'AAA'
 /*%if addCondition*/
  /*%if conditionType == 1 */when div = 'B' then 'BBB1'
 /*%elseif conditionType == 2 */
@@ -7,3 +14,19 @@ when div = 'B' then 'BBB2'
 /*%end*/
  else 'CCC' end as divName
 from users
+ ORDER BY CASE
+WHEN pickup IS NULL THEN
+/*%if isCase*/
+CASE
+     WHEN case_status = 1 THEN 0
+     ELSE 1
+ END
+/*%elseif isCaseEnd*/
+                    CASE
+WHEN case_status = 2 THEN 0 ELSE 1  END
+ /*%else*/
+0
+/*%end*/
+ELSE CASE
+WHEN case_static_status THEN 0          ELSE 1
+END END

--- a/src/test/testData/sql/formatter/SelectCaseEndWithCondition_format.sql
+++ b/src/test/testData/sql/formatter/SelectCaseEndWithCondition_format.sql
@@ -1,4 +1,12 @@
-SELECT CASE WHEN div = 'A' THEN 'AAA'
+SELECT CASE
+            /*%if isCheckStatus */
+            WHEN status = '1' THEN 1
+            /*%else */
+              /*%if hasPoint */
+              WHEN status = '2' THEN 2
+              /*%end*/
+            /*%end*/
+            WHEN div = 'A' THEN 'AAA'
             /*%if addCondition*/
               /*%if conditionType == 1 */
               WHEN div = 'B' THEN 'BBB1'
@@ -9,3 +17,24 @@ SELECT CASE WHEN div = 'A' THEN 'AAA'
             ELSE 'CCC'
         END AS divName
   FROM users
+ ORDER BY CASE
+               WHEN pickup IS NULL THEN
+                    /*%if isCase*/
+                    CASE
+                         WHEN case_status = 1 THEN 0
+                         ELSE 1
+                     END
+                    /*%elseif isCaseEnd*/
+                    CASE
+                         WHEN case_status = 2 THEN 0
+                         ELSE 1
+                     END
+                    /*%else*/
+                    0
+                    /*%end*/
+               ELSE
+                    CASE
+                         WHEN case_static_status THEN 0
+                         ELSE 1
+                     END
+           END

--- a/src/test/testData/sql/formatter/SelectCaseEnd_format.sql
+++ b/src/test/testData/sql/formatter/SelectCaseEnd_format.sql
@@ -1,5 +1,42 @@
-SELECT CASE WHEN div = 'A' THEN 'AAA'
-            WHEN div = 'B' THEN 'BBB'
-            ELSE 'CCC'
-        END AS divName
-  FROM users
+SELECT *
+       , CASE
+              /** case-end */
+              WHEN SUM(CASE
+                            WHEN name = 'apple' THEN 1
+                            WHEN name = 'berry' THEN 3
+                            ELSE 0
+                        END) > 0 THEN 'x'
+              -- active check
+              WHEN SUM(CASE
+                            WHEN NOT EXISTS ( SELECT number
+                                                FROM users
+                                               WHERE status = 1 ) THEN 1
+                            ELSE 0
+                        END) > 0 THEN 'y'
+              WHEN SUM(CASE
+                            WHEN position > 100
+                                 AND count(*) > 10 THEN 1
+                                  OR number > 10 THEN 1
+                            WHEN position <= 100
+                                  OR count(*) > 10 THEN 1
+                            ELSE 0
+                        END) > 0 THEN 'z'
+              ELSE 0
+          END AS user_status
+  FROM active_users
+ ORDER BY CASE
+               WHEN orders = 1 THEN 1
+               ELSE 2
+           END
+          , CASE
+                 WHEN pickup IS NULL THEN
+                      CASE
+                           WHEN case_status THEN 0
+                           ELSE 1
+                       END
+                 ELSE
+                      CASE
+                           WHEN case_static_status THEN 0
+                           ELSE 1
+                       END
+             END


### PR DESCRIPTION
## Related Issue
 #438

## Summary
This pull request improves the formatting and handling of SQL CASE statements within the plugin. The changes enhance readability and consistency, especially when CASE statements are nested or used within conditional loop directives.

## Changes
- Improved formatting for SQL CASE statements for better readability and consistency
- Fixed parent block search conditions when CASE exists within conditional loop directives
- Controlled line breaks for CASE, WHEN, and conditional keywords (AND, OR) in CASE-END blocks
- Refactored indentation handling in `SqlLiteralBlock` to improve block and group indent length calculations
- Updated SQL block handling to use `isParentConditionLoopDirective` for improved readability and consistency
- Added a flag to ensure the correct parent is retrieved for nested CASE-WHEN structures
- Fixed SQL group indentation handling for inline second groups
- Improved SQL block indentation handling for subgroup and inline cases

## How to Test
1. Format SQL files containing CASE statements, including nested and conditional loop scenarios.
2. Verify that the formatting is consistent and readable, with correct indentation and line breaks.
3. Check that parent block detection works correctly for nested CASE-WHEN structures.

## Additional Notes
- These changes do not affect the plugin's runtime behavior, only the formatting logic.
- Please refer to the related issue (#438) for more details and discussion.

