### PR TITLE
Set Upper Limit for Plugin Support Versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ pluginRepositoryUrl = https://github.com/domaframework/doma-tools-for-intellij
 pluginVersion = 2.3.0-beta
 
 pluginSinceBuild=233
+pluginUntilBuild=252.*
 
 platformType = IC
 platformVersion = 2024.3.1


### PR DESCRIPTION
## Background

Starting from IntelliJ 2025.3, Ultimate and Community editions will be unified into a single distribution. This causes the `verifyPlugin` task to fail when attempting to retrieve validation targets based on platform type + version combinations.

```
* What went wrong:
Could not determine the dependencies of task ':verifyPlugin'.
> Could not resolve all files for configuration ':detachedConfiguration7'.
   > Could not find idea:ideaIC:253.17525.95.
     Searched in the following locations:
       - https://cache-redirector.jetbrains.com/intellij-dependencies/idea/ideaIC/253.17525.95/ideaIC-253.17525.95.pom
       - https://cache-redirector.jetbrains.com/intellij-repository/releases/idea/ideaIC/253.17525.95/ideaIC-253.17525.95.pom
       - https://plugins.gradle.org/m2/idea/ideaIC/253.17525.95/ideaIC-253.17525.95.pom
Configuration cache entry stored.
       - https://dl.google.com/dl/android/maven2/idea/ideaIC/253.17525.95/ideaIC-253.17525.95.pom
       - https://repo.maven.apache.org/maven2/idea/ideaIC/253.17525.95/ideaIC-253.17525.95.pom
       - https://download.jetbrains.com/idea/ideaIC-253.17525.95.tar.gz
       - https://download.jetbrains.com/idea/253.17525.95/ideaIC-253.17525.95.tar.gz
       - https://cache-redirector.jetbrains.com/www.jetbrains.com/intellij-repository/releases/idea/ideaIC/253.17525.95/ideaIC-253.17525.95.pom
       - https://cache-redirector.jetbrains.com/www.jetbrains.com/intellij-repository/snapshots/idea/ideaIC/253.17525.95/ideaIC-253.17525.95.pom
       - https://cache-redirector.jetbrains.com/plugins.jetbrains.com/maven/idea/ideaIC/253.17525.95/ideaIC-253.17525.95.pom
     Required by:
         root project 'Doma Tools for IntelliJ'
```

## Changes

As a temporary measure, this PR sets the upper limit of supported versions to 2025.2, excluding the unified 2025.3 version from the support scope.

## Important Notes

After the official release of 2025.3, we need to revisit the plugin's supported version strategy:

- **Option 1**: Consider managing two separate branches:
    - One for pre-2025.3 versions
    - Another with configurations for the unified 2025.3+ versions

- **Option 2**: Consider supporting only the unified 2025.3+ versions going forward

## Impact

- Maintains compatibility with existing IntelliJ versions up to 2025.2
- Prevents build failures during plugin verification
- Requires future planning for 2025.3+ support strategy