### PR TITLE
 IDEA 2026 Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,17 +71,23 @@ jobs:
       - name: Build Gradle
         run: ./gradlew build -x test
 
-      - name: Get latest draft release title
+      - name: Resolve release version
         run: |
+          # Draft releases are only visible to tokens with write access, so
+          # this returns nothing for pull requests from forks. Fall back to the
+          # pluginVersion declared in gradle.properties in that case.
           TITLE=$(gh api repos/${{ github.repository }}/releases \
             --jq '.[] | select(.draft==true) | .name' | head -n 1)
-          if [[ -z "$TITLE" ]]; then
-            echo "No draft release found."
-            exit 1
-          fi      
-          VERSION=$(echo "$TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          VERSION=""
+          if [[ -n "$TITLE" ]]; then
+            VERSION=$(echo "$TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+          fi
           if [[ -z "$VERSION" ]]; then
-            echo "No version found in version."
+            echo "No draft release version available. Falling back to pluginVersion in gradle.properties."
+            VERSION=$(grep -E '^pluginVersion' gradle.properties | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+          fi
+          if [[ -z "$VERSION" ]]; then
+            echo "No version found."
             exit 1
           fi
           echo "Extracted version: $VERSION"

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="17" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ If you have any questions or suggestions, feel free to open an issue or contact 
 - Install **IntelliJ IDEA** (2024.3 or later)
   - We recommend using the latest stable version of IntelliJ IDEA.
 - Install **Git** and configure your GitHub access
-- Install **JDK 17**
+- Install **JDK 21**
 
 ## Recommended IntelliJ IDEA Plugins
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,6 +182,14 @@ tasks {
     }
 }
 
+tasks.named("instrumentCode") {
+    enabled = false
+}
+
+tasks.named("instrumentTestCode") {
+    enabled = false
+}
+
 tasks.register<Task>("encodeBase64") {
     doLast {
         val currentDir = File("./certificate")
@@ -387,9 +395,7 @@ tasks.register<Task>("updateChangelog") {
                             assigned = true
                             when (version) {
                                 "major" -> versionInfo.updateMajor()
-
                                 "minor" -> versionInfo.updateMinor()
-
                                 "patch" -> versionInfo.updatePatch()
                             }
                         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ group = providers.gradleProperty("pluginGroup").get()
 version = providers.gradleProperty("pluginVersion").get()
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,14 +182,6 @@ tasks {
     }
 }
 
-tasks.named("instrumentCode") {
-    enabled = false
-}
-
-tasks.named("instrumentTestCode") {
-    enabled = false
-}
-
 tasks.register<Task>("encodeBase64") {
     doLast {
         val currentDir = File("./certificate")

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@ pluginRepositoryUrl = https://github.com/domaframework/doma-tools-for-intellij
 pluginVersion = 2.4.1-beta
 
 pluginSinceBuild=233
-pluginUntilBuild=252.*
+pluginUntilBuild=261.*
 
-platformType = IC
-platformVersion = 2024.3.1
+platformType = IU
+platformVersion = 2026.1.2
 
 platformPlugins =
 platformBundledPlugins = com.intellij.java,org.jetbrains.kotlin,org.intellij.intelliLang,org.toml.lang

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginName = Doma Tools for IntelliJ
 pluginRepositoryUrl = https://github.com/domaframework/doma-tools-for-intellij
 pluginVersion = 2.4.1-beta
 
-pluginSinceBuild=233
+pluginSinceBuild=252
 pluginUntilBuild=261.*
 
 platformType = IU

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ intelliJPlatform = "2.14.0"
 kotlin = "2.3.20"
 kover = "0.9.8"
 qodana = "2024.3.4"
-grammarkit = "2022.3.2.2"
+grammarkit = "2023.3.0.3"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/collector/StaticClassPackageCollector.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/collector/StaticClassPackageCollector.kt
@@ -137,5 +137,5 @@ class StaticClassPackageCollector(
             type.isInterface -> "interface"
             type.isRecord -> "record"
             else -> type.containingFile?.fileType?.name ?: ""
-        }.toString()
+        }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/processor/InspectionFunctionCallVisitorProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/inspection/sql/processor/InspectionFunctionCallVisitorProcessor.kt
@@ -16,6 +16,7 @@
 package org.domaframework.doma.intellij.inspection.sql.processor
 
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
 import org.domaframework.doma.intellij.common.CommonPathParameterUtil
@@ -29,7 +30,6 @@ import org.domaframework.doma.intellij.common.validation.result.ValidationResult
 import org.domaframework.doma.intellij.extension.getJavaClazz
 import org.domaframework.doma.intellij.extension.psi.psiClassType
 import org.domaframework.doma.intellij.psi.SqlElFunctionCallExpr
-import org.jetbrains.kotlin.idea.util.projectStructure.module
 
 class InspectionFunctionCallVisitorProcessor(
     val shortName: String,
@@ -47,7 +47,7 @@ class InspectionFunctionCallVisitorProcessor(
 
     private fun getFunctionCallValidationResult(): ValidationResult? {
         val project = element.project
-        val module = element.module ?: return null
+        val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return null
         val expressionHelper = ExpressionFunctionsHelper
         val expressionFunctionalInterface = expressionHelper.setExpressionFunctionsInterface(project)
         val functionName = element.elIdExpr
@@ -110,7 +110,7 @@ class InspectionFunctionCallVisitorProcessor(
 
     private fun getFunctionCall(): PsiMethod? {
         val project = element.project
-        val module = element.module ?: return null
+        val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return null
         val expressionHelper = ExpressionFunctionsHelper
         val expressionFunctionalInterface = expressionHelper.setExpressionFunctionsInterface(project)
         val functionName = element.elIdExpr

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
   <depends>org.intellij.intelliLang</depends>
   <depends>org.toml.lang</depends>
   <depends optional="true" config-file="kotlin.xml">org.jetbrains.kotlin</depends>
-  <idea-version since-build="233"/>
+  <idea-version since-build="252"/>
 
   <resource-bundle>messages.DomaToolsBundle</resource-bundle>
   <resource-bundle>messages.LLMInstallerBundle</resource-bundle>

--- a/src/test/kotlin/org/domaframework/doma/intellij/DomaProjectDiscriptor.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/DomaProjectDiscriptor.kt
@@ -41,13 +41,13 @@ import com.intellij.testFramework.IdeaTestUtil
 import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor
 
 class DomaProjectDescriptor : DefaultLightProjectDescriptor() {
-    override fun getSdk(): Sdk = IdeaTestUtil.getMockJdk17()
+    override fun getSdk(): Sdk = IdeaTestUtil.getMockJdk21()
 
     override fun configureModule(
         module: Module,
         model: ModifiableRootModel,
         contentEntry: ContentEntry,
     ) {
-        IdeaTestUtil.setModuleLanguageLevel(module, LanguageLevel.JDK_17)
+        IdeaTestUtil.setModuleLanguageLevel(module, LanguageLevel.JDK_21)
     }
 }

--- a/src/test/kotlin/org/domaframework/doma/intellij/action/dao/ConvertSqlActionTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/action/dao/ConvertSqlActionTest.kt
@@ -19,6 +19,8 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.psi.PsiDocumentManager
 import org.domaframework.doma.intellij.DomaSqlTest
+import java.nio.file.Files.readString
+import java.nio.file.Path
 
 abstract class ConvertSqlActionTest : DomaSqlTest() {
     protected fun doConvertAction(
@@ -41,7 +43,14 @@ abstract class ConvertSqlActionTest : DomaSqlTest() {
         assertEquals(convertFamilyName, intention.familyName)
 
         myFixture.launchAction(intention)
-        myFixture.checkResultByFile("java/doma/example/dao/$sqlConversionPackage/$daoName.after.java")
+        val expectedFile =
+            Path.of(
+                getTestDataPath(),
+                "/java/doma/example/dao/$sqlConversionPackage/$daoName.after.java",
+            )
+        val expectedText = readString(expectedFile)
+
+        myFixture.checkResult(expectedText)
     }
 
     /**
@@ -109,6 +118,12 @@ abstract class ConvertSqlActionTest : DomaSqlTest() {
         }
         fdm.getDocument(newSqlFile)?.let { fdm.reloadFromDisk(it) }
         myFixture.configureFromExistingVirtualFile(newSqlFile)
-        myFixture.checkResultByFile("resources/META-INF/doma/example/dao/$sqlConversionPackage/$daoName/$sqlFileName.after.$extension")
+        val expectedFile =
+            Path.of(
+                getTestDataPath(),
+                "resources/META-INF/doma/example/dao/$sqlConversionPackage/$daoName/$sqlFileName.after.$extension",
+            )
+        val expectedText = readString(expectedFile)
+        myFixture.checkResult(expectedText)
     }
 }

--- a/src/test/kotlin/org/domaframework/doma/intellij/action/dao/ConvertSqlFileToAnnotationActionTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/action/dao/ConvertSqlFileToAnnotationActionTest.kt
@@ -19,6 +19,8 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.psi.PsiDocumentManager
 import org.domaframework.doma.intellij.action.sql.ConvertSqlFileToAnnotationFromSqlAction
 import org.domaframework.doma.intellij.bundle.MessageBundle
+import java.nio.file.Files.readString
+import java.nio.file.Path
 
 class ConvertSqlFileToAnnotationActionTest : ConvertSqlActionTest() {
     private val sqlToAnnotationPackage = "sqltoannotation"
@@ -164,7 +166,14 @@ class ConvertSqlFileToAnnotationActionTest : ConvertSqlActionTest() {
 
         val daoClass = findDaoClass("$sqlToAnnotationPackage.$daoName")
         myFixture.configureFromExistingVirtualFile(daoClass.containingFile.virtualFile)
-        myFixture.checkResultByFile("java/doma/example/dao/$sqlToAnnotationPackage/$daoName.after.java")
+
+        val expectedFile =
+            Path.of(
+                getTestDataPath(),
+                "java/doma/example/dao/$sqlToAnnotationPackage/$daoName.after.java",
+            )
+        val expectedText = readString(expectedFile)
+        myFixture.checkResult(expectedText)
 
         val sqlFileAfter = findSqlFile("$sqlToAnnotationPackage/$daoName/$sqlFileName.$extension")
         assertNull("SQL file should be deleted after conversion", sqlFileAfter)

--- a/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/formatter/SqlFormatterTest.kt
@@ -20,6 +20,8 @@ import com.intellij.psi.codeStyle.CodeStyleManager
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.domaframework.doma.intellij.setting.SettingComponent
 import org.domaframework.doma.intellij.setting.state.DomaToolsFormatEnableSettings
+import java.nio.file.Files.readString
+import java.nio.file.Path
 
 class SqlFormatterTest : BasePlatformTestCase() {
     override fun getBasePath(): String = "src/test/testData/sql/formatter"
@@ -319,6 +321,13 @@ class SqlFormatterTest : BasePlatformTestCase() {
                     arrayListOf(currentFile.textRange),
                 )
             }
-        myFixture.checkResultByFile(afterFile)
+
+        val expectedFile =
+            Path.of(
+                getTestDataPath(),
+                afterFile,
+            )
+        val expectedText = readString(expectedFile)
+        myFixture.checkResult(expectedText)
     }
 }

--- a/src/test/kotlin/org/domaframework/doma/intellij/refactor/DaoMethodRenameTestCase.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/refactor/DaoMethodRenameTestCase.kt
@@ -15,7 +15,9 @@
  */
 package org.domaframework.doma.intellij.refactor
 
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import org.domaframework.doma.intellij.DomaSqlTest
+import java.nio.file.Paths
 
 /**
  * Refactoring test when changing DAO class name and method name
@@ -32,6 +34,17 @@ class DaoMethodRenameTestCase : DomaSqlTest() {
         addResourceEmptySqlFile(
             "RenameDaoMethod/renameDaoMethodName.sql",
             "RenameDao/renameDaoClassName.sql",
+        )
+        val testDataPath =
+            Paths
+                .get(
+                    "src/test/testData",
+                ).toAbsolutePath()
+                .toString()
+
+        VfsRootAccess.allowRootAccess(
+            testRootDisposable,
+            testDataPath,
         )
     }
 


### PR DESCRIPTION
## Overview

This is my first time contributing code to this project.

I updated Doma Tools for IntelliJ to support IDEA 2026.
The development environment was migrated to IDEA 2026, and the platform version, plugin version, and related library versions were updated accordingly.

In addition, I fixed existing tests so that all test cases pass under the IDEA 2026 environment.

It seems that IDEA 2026 introduced many internal changes in the IntelliJ Platform, so this PR mainly focuses on restoring compatibility and getting the existing test suite working again.

## Changes

* Updated JDK to 21 due to the Grammar-Kit version upgrade
* Replaced project module lookup logic with `ModuleUtilCore`
* Raised the minimum supported IDEA version to 252
* Fixed SQL formatter and plugin action tests to reference expected files using absolute project paths
* Added temporary workaround to suppress `instrumentCode` execution for IDEA 2026 compatibility

## Verified
- Confirmed that the plugin can be built and locally installed on IDEA 2026.1.x
- Confirmed that the basic plugin features work correctly on IDEA 2026.1.x

## Notes

This PR is intended as a temporary compatibility update for IDEA 2026.
There may still be room for cleanup or more appropriate solutions depending on future IntelliJ Platform updates.
