### PR TITLE
ci: speed up Build workflow by parallelizing jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
-    outputs:
-      pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
     steps:
       - name: Fetch Sources
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -43,13 +41,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
-
-      - name: Export Properties
-        id: properties
-        shell: bash
-        run: |
-          PROPERTIES="$(./gradlew properties --console=plain -q)"
-          echo "pluginVerifierHomeDir=~/.pluginVerifier" >> $GITHUB_OUTPUT
 
       - name: Cache Lexer and Parser
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -67,9 +58,6 @@ jobs:
       - name: Generate Parser
         if: steps.cache-lexer-parser.outputs.cache-hit != 'true'
         run: ./gradlew generateParser
-
-      - name: Build Gradle
-        run: ./gradlew build -x test
 
       - name: Resolve release version
         run: |
@@ -115,7 +103,6 @@ jobs:
 
   test:
     name: Test
-    needs: [ build ]
     runs-on: ubuntu-24.04
     steps:
       - name: Fetch Sources
@@ -167,7 +154,8 @@ jobs:
 
   verify:
     name: Verify plugin
-    needs: [ build ]
+    # Plugin compatibility verification is a release gate: run only on push to main, not on every PR.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     steps:
       - name: Maximize Build Space
@@ -210,11 +198,11 @@ jobs:
       - name: Setup Plugin Verifier IDEs Cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
+          path: ~/.pluginVerifier/ides
           key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
 
       - name: Run Plugin Verification tasks
-        run: ./gradlew verifyPlugin -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
+        run: ./gradlew verifyPlugin -Dplugin.verifier.home.dir=~/.pluginVerifier
 
       - name: Collect Plugin Verifier Result
         if: ${{ always() }}


### PR DESCRIPTION
## Summary

Reduce the Build workflow wall-clock time by removing the artificial serialization between jobs and trimming redundant/no-op work.

Previously `test` and `verify` both declared `needs: [build]`, so they only started **after** the 6-minute `build` job finished, even though neither consumes the build artifact. The critical path was therefore `build (~6m) + test (~10m) ≈ 16m`.

## Changes

- **Parallelize jobs**: drop `needs: [build]` from `test` and `verify` so all jobs start at once. `verify` no longer reads `needs.build.outputs.pluginVerifierHomeDir`; the hardcoded `~/.pluginVerifier` path is inlined and the now-unused `build` job `outputs:` block is removed.
- **Verify only on main**: plugin compatibility verification is a release gate, so it now runs only on `push` to `main` (`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`). PRs no longer pay the ~10-minute `verifyPlugin` cost.
- **Remove the `Export Properties` step**: it ran `./gradlew properties` (~54s) but only emitted a hardcoded value that was never derived from the output.
- **Remove the redundant `./gradlew build -x test` step**: lint (spotlessCheck) and test compilation are already covered by the `test` job's `check` task.

## Effect

| | Before | After (PR) |
|---|---|---|
| Jobs on a PR | build → (test ∥ verify) | build ∥ test |
| Critical path | ~16m | ~10m (test only) |
| `verifyPlugin` (~10m) | every PR | on `main` push only |

## Trade-offs / notes

- Fail-fast is relaxed: `test` runs even if `build` fails to compile, so a broken build consumes a bit more runner time.
- Gradle cache is unaffected in practice — it is warmed by `main`-branch runs and restored read-only by `test`/`verify`, independent of the `build` job.
- Plugin compatibility feedback now arrives after merge to `main` rather than on each PR. Run `./gradlew verifyPlugin` locally for changes likely to affect compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)