### PR TITLE
Run Grammar-Kit tasks automatically before compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,23 +42,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
-      - name: Cache Lexer and Parser
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        id: cache-lexer-parser
-        with:
-          path: ${{ github.workspace }}/src/main/gen
-          key: lexer-parser-${{ hashFiles('**/Sql.bnf','**/Sql.flex') }}
-          restore-keys: |
-            lexer-parser-
-
-      - name: Generate Lexer
-        if: steps.cache-lexer-parser.outputs.cache-hit != 'true'
-        run: ./gradlew generateLexer
-
-      - name: Generate Parser
-        if: steps.cache-lexer-parser.outputs.cache-hit != 'true'
-        run: ./gradlew generateParser
-
       - name: Resolve release version
         run: |
           # Draft releases are only visible to tokens with write access, so
@@ -119,23 +102,6 @@ jobs:
         with:
           cache-read-only: true
 
-      - name: Cache Lexer and Parser
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        id: cache-lexer-parser
-        with:
-          path: ${{ github.workspace }}/src/main/gen
-          key: lexer-parser-${{ hashFiles('**/Sql.bnf','**/Sql.flex') }}
-          restore-keys: |
-            lexer-parser-
-
-      - name: Generate Lexer
-        if: steps.cache-lexer-parser.outputs.cache-hit != 'true'
-        run: ./gradlew generateLexer
-
-      - name: Generate Parser
-        if: steps.cache-lexer-parser.outputs.cache-hit != 'true'
-        run: ./gradlew generateParser
-
       # Run tests
       - name: Run Tests
         run: ./gradlew check
@@ -177,23 +143,6 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
         with:
           cache-read-only: true
-
-      - name: Cache Lexer and Parser
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        id: cache-lexer-parser
-        with:
-          path: ${{ github.workspace }}/src/main/gen
-          key: lexer-parser-${{ hashFiles('**/Sql.bnf','**/Sql.flex') }}
-          restore-keys: |
-            lexer-parser-
-
-      - name: Generate Lexer
-        if: steps.cache-lexer-parser.outputs.cache-hit != 'true'
-        run: ./gradlew generateLexer
-
-      - name: Generate Parser
-        if: steps.cache-lexer-parser.outputs.cache-hit != 'true'
-        run: ./gradlew generateParser
 
       - name: Setup Plugin Verifier IDEs Cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,6 +180,25 @@ tasks {
     publishPlugin {
         dependsOn(patchChangelog)
     }
+
+    // generateLexer purges its output directory, which it shares with the parser
+    // output, so generateParser must always run after it; otherwise the lexer
+    // purge would wipe the generated parser/PSI sources.
+    generateParser {
+        mustRunAfter(generateLexer)
+    }
+
+    // Regenerate the lexer/parser from the latest Sql.flex/Sql.bnf before any
+    // compilation runs. This keeps the generated sources in src/main/gen in sync
+    // with the grammar definitions even after editing the grammar or switching
+    // branches, so developers no longer have to run the Grammar-Kit tasks by hand.
+    val grammarKitTasks = listOf(generateLexer, generateParser)
+    withType<JavaCompile>().configureEach {
+        dependsOn(grammarKitTasks)
+    }
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        dependsOn(grammarKitTasks)
+    }
 }
 
 tasks.register<Task>("encodeBase64") {


### PR DESCRIPTION
## Overview
Closes #235.

When `Sql.flex` or `Sql.bnf` is edited—or when switching between branches with different grammar definitions—the Grammar-Kit tasks (`generateLexer`/`generateParser`) currently have to be run by hand before building. Forgetting to do so leaves stale sources in `src/main/gen` and causes confusing compile/runtime failures.

This change configures the Gradle build so the lexer/parser are regenerated automatically before any compilation runs, and removes the now-redundant manual steps from CI.

## Changes
### `build.gradle.kts`
- Wire `generateLexer` and `generateParser` as dependencies of all Java/Kotlin compile tasks (`compileJava`, `compileKotlin`, `compileTestJava`, `compileTestKotlin`) via `withType { dependsOn(...) }`.
- Enforce that `generateParser` runs **after** `generateLexer` with `mustRunAfter`.

### `.github/workflows/build.yml`
- Remove the explicit `Generate Lexer` / `Generate Parser` steps and the dedicated `src/main/gen` cache from the `build`, `test`, and `verify` jobs. `buildPlugin`/`check`/`verifyPlugin` now trigger generation automatically.

## Why the ordering matters
`generateLexer` has `purgeOldFiles = true` and writes to the same directory that `generateParser` uses for `SqlParser.java`, `psi/`, and `impl/`. Because `dependsOn` does not guarantee execution order, the lexer can run *after* the parser and its purge wipes the generated parser/PSI sources. Ordering the parser after the lexer (the same order CI used) prevents this.

## Why drop the `src/main/gen` cache
On a fresh CI runner Gradle has no task execution history, so it regenerates the sources regardless of whether the cached `src/main/gen` was restored. The `restore-keys` prefix fallback could even restore stale sources from a previous grammar. The cache therefore no longer provides a benefit once generation is part of the build.

## Testing
- Deleted `src/main/gen` entirely and ran `./gradlew compileKotlin` → both lexer and parser are regenerated in the correct order and compilation succeeds.
- `./gradlew spotlessCheck` ✅
- `./gradlew check` ✅ (tests, plugin verification, and Kover coverage all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)