### PR TITLE
Drop redundant Grammar-Kit steps from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,6 @@ jobs:
         with:
           cache-read-only: true
 
-      # Generate Lexer and Parser
-      - name: Generate Lexer
-        run: ./gradlew generateLexer
-
-      - name: Generate Parser
-        run: ./gradlew generateParser
-
       # Publish the plugin to JetBrains Marketplace
       - name: Publish Plugin
         env:


### PR DESCRIPTION
## Overview
Follow-up to #548 (which closed #235).

Now that `generateLexer`/`generateParser` are wired into the compile tasks, the `publishPlugin` task triggers grammar generation automatically (`publishPlugin` → `signPlugin` → `buildPlugin` → compile → generate). The explicit `Generate Lexer`/`Generate Parser` steps that remained in the release workflow are therefore redundant.

## Changes
- `.github/workflows/release.yml`: remove the `Generate Lexer` / `Generate Parser` steps from the `Publish Plugin` job.

## Verification
- `./gradlew publishPlugin --dry-run` shows `generateLexer` → `generateParser` → `compileKotlin` are scheduled ahead of `buildPlugin`/`signPlugin`/`publishPlugin`, confirming generation still runs.
- YAML validated; no remaining `generateLexer`/`generateParser` references in any workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)