### PR TITLE
ci: remove redundant version bump from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,29 +52,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
 
-      - name: Update Version
-        run: |
-          ./gradlew replaceNewVersion -PnewVersion=${{ github.event.release.tag_name }} --no-configuration-cache
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit New Version
-        run: |
-          git config user.email "action@github.com"
-          git config user.name "GitHub Action"
-          git fetch
-          git checkout main
-          git add src/main/kotlin/org/domaframework/doma/intellij/common/util/PluginUtil.kt
-          git add src/main/resources/logback.xml
-          git add src/main/resources/logback-test.xml
-          git add gradle.properties 
-          if [[ -z "$(git status --porcelain)" ]]; then
-            echo "No changes to commit."
-            exit 0
-          fi
-          git commit -am "Update Version With Release - $REPLACE_VERSION"
-          git push origin main
-
   create_release_draft:
     permissions:
       contents: write

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -626,35 +626,6 @@ fun replaceVersion(ver: String) {
 
 val encoding: String by project
 
-tasks.register<Task>("replaceNewVersion") {
-    val releaseVersion =
-        if (project.hasProperty("newVersion")) {
-            project.property("newVersion") as String
-        } else {
-            "0.0.0"
-        }
-
-    doLast {
-        val lastVersions = releaseVersion.substringAfter("v").split(".")
-        val major = lastVersions[0].toInt()
-        val minor = lastVersions[1].toInt()
-        val patch = lastVersions[2].toInt() + 1
-
-        val newVersion = "$major.$minor.$patch-beta"
-        println("Release newVersion: $newVersion")
-        replaceVersion(newVersion)
-        try {
-            val githubEnv = System.getenv("GITHUB_ENV")
-            val envFile = File(githubEnv)
-            envFile.appendText("REPLACE_VERSION=$newVersion\n")
-            println("Set Replace version in GITHUB_ENV: $newVersion")
-        } catch (e: NullPointerException) {
-            println("GITHUB_ENV not found")
-            println(e.stackTrace)
-        }
-    }
-}
-
 tasks.register<Task>("replaceDraftVersion") {
     val draftVersion =
         if (project.hasProperty("draftVersion")) {


### PR DESCRIPTION
**Description**

The `Commit New Version` step in `release.yml` failed during the 2.5.0 release ([run](https://github.com/domaframework/doma-tools-for-intellij/actions/runs/26690822033/job/78683188220)).

Root cause: `Fetch Sources` checks out the release **tag** (detached HEAD). `Update Version` then runs `replaceNewVersion`, modifying the version files in the working tree while on the tag. `Commit New Version` then runs `git checkout main`, which git rejects:

```
error: Your local changes to the following files would be overwritten by checkout:
	gradle.properties
	src/main/kotlin/.../PluginUtil.kt
	src/main/resources/logback-test.xml
	src/main/resources/logback.xml
```

The plugin publish (`Publish Plugin`, `Upload Release Asset`) succeeded, so the release artifact was unaffected. The only thing that failed was pushing the next dev-version (`-beta`) bump to `main` — and that bump is **already handled** by the `update_version` job in `release-drafter.yml`, which checks out `main` directly and pushes the bump on PR merge (e.g. commit `Update Version With Release Draft - 2.5.1`).

This makes the `Update Version` / `Commit New Version` steps in `release.yml` redundant and the sole cause of the failure.

**Changes**

1. Remove the `Update Version` and `Commit New Version` steps from `release.yml`. The dev-version bump is consolidated in `release-drafter.yml`.
2. Remove the now-unused `replaceNewVersion` Gradle task, whose only consumer was the deleted `Update Version` step. `replaceDraftVersion` and the shared `replaceVersion` helpers are kept, since `release-drafter.yml` still uses them.

---
**Related Issue**

N/A

---
**Type of Change**
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test
- [x] Build system change
- [ ] Chore
- [ ] Performance improvement
- [ ] Code style update
- [ ] Security fix

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)