### PR TITLE
fix: declare intelliLang as a bundled module for IntelliJ Platform 2.16.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,8 @@ dependencies {
 
         bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',') })
 
+        bundledModules(providers.gradleProperty("platformBundledModules").map { it.split(',') })
+
         plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
 
         pluginVerifier(version = "${libs.pluginVerifier.get().version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,8 @@ platformType = IU
 platformVersion = 2026.1.2
 
 platformPlugins =
-platformBundledPlugins = com.intellij.java,org.jetbrains.kotlin,org.intellij.intelliLang,org.toml.lang
+platformBundledPlugins = com.intellij.java,org.jetbrains.kotlin,org.toml.lang
+platformBundledModules = intellij.platform.langInjection
 
 gradleVersion = 8.10.2
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ pluginVerifier = "1.405"
 
 # plugins
 changelog = "2.5.0"
-intelliJPlatform = "2.14.0"
+intelliJPlatform = "2.16.0"
 kotlin = "2.3.21"
 kover = "0.9.8"
 qodana = "2026.1.0"


### PR DESCRIPTION
## Summary

Fixes the CI build failure introduced by updating the IntelliJ Platform Gradle Plugin to **2.16.0** (originally proposed in #547). This PR supersedes #547 by including the version bump together with the required configuration fix.

In 2.16.0 the dependency `org.intellij.intelliLang` is reclassified from a *bundled plugin* to a *bundled module*, so resolving it via `bundledPlugin(...)` fails:

```
Could not resolve all dependencies for configuration ':compileClasspath'.
   > The 'org.intellij.intelliLang' entry refers to a bundled plugin, but it is
     actually a bundled module. Use bundledModule("org.intellij.intelliLang")
     instead of bundledPlugin("org.intellij.intelliLang").
```

The suggested `bundledModule("org.intellij.intelliLang")` does **not** work either — it reports `Specified bundledModule 'org.intellij.intelliLang' doesn't exist`. Inspecting the platform's `product-info.json` shows that `org.intellij.intelliLang` is only a `pluginAlias`; its actual implementation lives in the product module **`intellij.platform.langInjection`**, which declares `<module value="org.intellij.intelliLang"/>` and provides the `org.intellij.intelliLang.injectionConfig` extension point this plugin relies on.

## Changes

- `gradle/libs.versions.toml`: bump `intelliJPlatform` `2.14.0` → `2.16.0`
- `gradle.properties`: remove `org.intellij.intelliLang` from `platformBundledPlugins`; add new `platformBundledModules = intellij.platform.langInjection`
- `build.gradle.kts`: wire the new property through `bundledModules(...)`

## Verification

Ran locally against IntelliJ Platform 2.16.0:

- `./gradlew compileJava` — ✅
- `./gradlew buildPlugin` — ✅
- `./gradlew check` (tests, `spotlessCheck`, `koverVerify`) — ✅

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)