### PR TITLE
test: share a single real JDK across DomaSqlTest subclasses to speed up CI

### DIFF
--- a/src/test/kotlin/org/domaframework/doma/intellij/DomaProjectDiscriptor.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/DomaProjectDiscriptor.kt
@@ -32,7 +32,9 @@
 
 package org.domaframework.doma.intellij
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.projectRoots.JavaSdk
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.ModifiableRootModel
@@ -41,7 +43,15 @@ import com.intellij.testFramework.IdeaTestUtil
 import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor
 
 class DomaProjectDescriptor : DefaultLightProjectDescriptor() {
-    override fun getSdk(): Sdk = IdeaTestUtil.getMockJdk21()
+    /**
+     * Reuse a single real JDK created from the running [java.home] across every
+     * test class. The entities under test reference classes such as
+     * java.time.LocalDate and java.util.Optional that the lightweight mock JDK
+     * does not provide, so a real JDK is required. Creating it scans the JDK
+     * home, which is expensive, so the result is cached and shared instead of
+     * being rebuilt in every test's setUp.
+     */
+    override fun getSdk(): Sdk = sharedJdk
 
     override fun configureModule(
         module: Module,
@@ -49,5 +59,17 @@ class DomaProjectDescriptor : DefaultLightProjectDescriptor() {
         contentEntry: ContentEntry,
     ) {
         IdeaTestUtil.setModuleLanguageLevel(module, LanguageLevel.JDK_21)
+    }
+
+    companion object {
+        private val sharedJdk: Sdk by lazy {
+            ApplicationManager.getApplication().runWriteAction<Sdk> {
+                JavaSdk.getInstance().createJdk(
+                    "Doma Test JDK",
+                    System.getProperty("java.home"),
+                    false,
+                )
+            }
+        }
     }
 }

--- a/src/test/kotlin/org/domaframework/doma/intellij/DomaSqlTest.kt
+++ b/src/test/kotlin/org/domaframework/doma/intellij/DomaSqlTest.kt
@@ -15,17 +15,12 @@
  */
 package org.domaframework.doma.intellij
 
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.module.Module
-import com.intellij.openapi.projectRoots.JavaSdk
-import com.intellij.openapi.projectRoots.ProjectJdkTable
-import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiClass
+import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.PsiTestUtil
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import org.domaframework.doma.intellij.common.CommonPathParameterUtil
@@ -44,10 +39,16 @@ open class DomaSqlTest : LightJavaCodeInsightFixtureTestCase() {
 
     override fun getTestDataPath(): String = "src/test/testData/src/main/"
 
+    /**
+     * Share a single descriptor instance across every test class so the light
+     * fixture reuses the same project and its (real) JDK instead of recreating
+     * the SDK in each test's setUp.
+     */
+    override fun getProjectDescriptor(): LightProjectDescriptor = SHARED_DESCRIPTOR
+
     @Throws(Exception::class)
     override fun setUp() {
         super.setUp()
-        settingJdk()
         setDirectoryRoot()
         addLibrary("doma-core-3.11.0.jar", "doma-core")
 
@@ -70,7 +71,6 @@ open class DomaSqlTest : LightJavaCodeInsightFixtureTestCase() {
     @Throws(Exception::class)
     override fun tearDown() {
         try {
-            deleteSdk()
             CommonPathParameterUtil.clearCache()
         } finally {
             super.tearDown()
@@ -100,33 +100,6 @@ open class DomaSqlTest : LightJavaCodeInsightFixtureTestCase() {
             libPath,
             jarName,
         )
-    }
-
-    private fun settingJdk() {
-        deleteSdk()
-        setUpJdk(myFixture.module)
-    }
-
-    private fun setUpJdk(module: Module) {
-        val newJdk =
-            JavaSdk.getInstance().createJdk("Doma Test JDK", System.getProperty("java.home"), false)
-
-        WriteAction.runAndWait<RuntimeException> {
-            ProjectJdkTable.getInstance().addJdk(newJdk)
-            ModuleRootModificationUtil.updateModel(module) { model: ModifiableRootModel ->
-                model.sdk = newJdk
-            }
-        }
-    }
-
-    private fun deleteSdk() {
-        val oldJdk = ProjectJdkTable.getInstance().findJdk("Doma Test JDK") ?: return
-        WriteAction.runAndWait<RuntimeException> {
-            ProjectJdkTable.getInstance().removeJdk(oldJdk)
-            if (oldJdk is Disposable) {
-                Disposer.dispose(oldJdk)
-            }
-        }
     }
 
     private fun setDirectoryRoot() {
@@ -262,5 +235,9 @@ open class DomaSqlTest : LightJavaCodeInsightFixtureTestCase() {
             "main/java/$packagePath/expression/$fileName",
             file.readText(),
         )
+    }
+
+    companion object {
+        private val SHARED_DESCRIPTOR: LightProjectDescriptor = DomaProjectDescriptor()
     }
 }


### PR DESCRIPTION
## Summary

- 22 test classes extending `DomaSqlTest` were creating and removing a real JDK in every `setUp`/`tearDown` (`JavaSdk.createJdk()` scans the JDK home each time)
- Changed `getProjectDescriptor()` to return a shared `LightProjectDescriptor`, reducing JDK creation to once per test run
- Updated `DomaProjectDescriptor.getSdk()` to return a lazily cached real JDK (MockJDK is insufficient as test entities use `java.time.LocalDate`, `Optional`, etc.)

## Measurement results

| Run | Duration | Notes |
|-----|----------|-------|
| baseline (main branch) | 7m 54s | warm Gradle cache |
| PR first run | 28m 19s | cold cache — IntelliJ IU 2026.1.2 downloaded fresh |
| PR second run | 8m 04s | warm cache |

The code change itself had negligible effect (~10 s). The dominant cost was IntelliJ Platform download on cache miss, not JDK setup overhead. **Closing in favour of a CI-level fix (explicit IntelliJ Platform cache + removing `cache-read-only: true` from the test job).**

## Test plan

- [x] All tests passed on both CI runs