### PR TITLE
ci: cache IntelliJ Platform separately and allow test job to write cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,12 @@ jobs:
           distribution: zulu
           java-version: 17
 
+      - name: Cache IntelliJ Platform
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea
+          key: intellij-platform-${{ runner.os }}-${{ hashFiles('gradle.properties') }}
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
@@ -97,10 +103,14 @@ jobs:
           distribution: zulu
           java-version: 17
 
+      - name: Cache IntelliJ Platform
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea
+          key: intellij-platform-${{ runner.os }}-${{ hashFiles('gradle.properties') }}
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
-        with:
-          cache-read-only: true
 
       # Run tests
       - name: Run Tests


### PR DESCRIPTION
## Summary

Improves CI caching of the IntelliJ Platform dependency, which is a large download that rarely changes.

- Add a dedicated `actions/cache` step for the IntelliJ Platform (`com.jetbrains.intellij.idea`) in both the `build` and `test` jobs, keyed on `runner.os` + a hash of `gradle.properties`. This keeps the platform warm across runs even when the main Gradle cache is invalidated.
- Remove `cache-read-only: true` from the `test` job's Gradle setup so the job can populate the cache, ensuring the IntelliJ Platform stays cached even when the `build` job is skipped or runs in parallel.

## Why

The IntelliJ Platform artifact is large and stable. Caching it separately from the general Gradle cache reduces repeated downloads and speeds up CI.

## Test plan

- CI runs automatically on this PR; verify the `Build` and `Test` jobs succeed and that the new "Cache IntelliJ Platform" steps run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)