### PR TITLE
Fix DAO/SQL navigation on IntelliJ IDEA 2026.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6
@@ -95,7 +95,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6
@@ -137,7 +137,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 25
 
       # Setup Gradle
       - name: Setup Gradle

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import org.gradle.internal.classpath.Instrumented.systemProperty
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URL
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -45,8 +46,19 @@ grammarKit {
 group = providers.gradleProperty("pluginGroup").get()
 version = providers.gradleProperty("pluginVersion").get()
 
+// IntelliJ Platform 2026.2 ships Java 25 class files, so the compilers have to run on a JDK 25
+// toolchain to be able to read them. The bytecode we emit stays at Java 21, the runtime of the
+// oldest IDE this plugin supports (pluginSinceBuild 252 / IntelliJ IDEA 2025.2).
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_21
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@ pluginRepositoryUrl = https://github.com/domaframework/doma-tools-for-intellij
 pluginVersion = 2.5.1-beta
 
 pluginSinceBuild=252
-pluginUntilBuild=261.*
+pluginUntilBuild=262.*
 
 platformType = IU
-platformVersion = 2026.1.2
+platformVersion = 2026.2.1
 
 platformPlugins =
 platformBundledPlugins = com.intellij.java,org.jetbrains.kotlin,org.toml.lang

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ pluginVerifier = "1.408"
 
 # plugins
 changelog = "2.5.0"
-intelliJPlatform = "2.17.0"
+intelliJPlatform = "2.18.1"
 kotlin = "2.4.0"
 kover = "0.9.8"
 qodana = "2026.1.3"

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/dao/DaoMethodUtil.kt
@@ -38,7 +38,7 @@ import org.domaframework.doma.intellij.extension.getContentRoot
 import org.domaframework.doma.intellij.extension.getJavaClazz
 import org.domaframework.doma.intellij.extension.getModule
 import org.domaframework.doma.intellij.extension.getSourceRootDir
-import org.jetbrains.kotlin.idea.base.util.module
+import org.domaframework.doma.intellij.extension.psi.module
 
 /**
  * Get DAO method corresponding to SQL file

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/dao/JumpActionFunctions.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/dao/JumpActionFunctions.kt
@@ -18,14 +18,15 @@ package org.domaframework.doma.intellij.common.dao
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiMethod
+import com.intellij.util.ExceptionUtil
 import com.intellij.util.PsiNavigateUtil
 import org.domaframework.doma.intellij.common.psi.PsiDaoMethod
 import org.domaframework.doma.intellij.extension.findFile
-import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.utils.rethrow
+import org.jetbrains.uast.UFile
+import org.jetbrains.uast.toUElementOfType
 
 fun jumpSqlFromDao(
     project: Project,
@@ -41,22 +42,28 @@ fun jumpToDaoMethod(
 ) {
     when (val daoPsiFile = project.findFile(daoFile)) {
         is PsiJavaFile -> getJavaFunctionOffset(daoPsiFile, sqlFileName)
-        is KtFile -> getKotlinFunctions(daoPsiFile, sqlFileName)
+        null -> return
+        else -> getFunctionOffsetByUast(daoPsiFile, sqlFileName)
     }
 }
 
-// TODO Support Kotlin Project
-private fun getKotlinFunctions(
-    file: KtFile,
+/**
+ * Navigate to a DAO method in a non Java source file.
+ *
+ * UAST keeps this language agnostic: the Kotlin plugin contributes its UAST support through an
+ * extension point, so no Kotlin plugin class is referenced from here. That matters because the
+ * Kotlin plugin is only an optional dependency of this plugin.
+ */
+private fun getFunctionOffsetByUast(
+    file: PsiFile,
     targetMethodName: String,
 ) {
+    val uastFile = file.toUElementOfType<UFile>() ?: return
     val method =
-        file.declarations
-            .filterIsInstance<KtNamedFunction>()
-            .find { f -> f.name == targetMethodName }
-    if (method != null) {
-        PsiNavigateUtil.navigate(method)
-    }
+        uastFile.classes
+            .flatMap { clazz -> clazz.methods.asIterable() }
+            .find { m -> m.name == targetMethodName } ?: return
+    PsiNavigateUtil.navigate(method.sourcePsi ?: method.javaPsi)
 }
 
 private fun getJavaFunctionOffset(
@@ -67,7 +74,7 @@ private fun getJavaFunctionOffset(
         val dapMethod = findUseSqlDaoMethod(file, targetMethodName) ?: return
         PsiNavigateUtil.navigate(dapMethod)
     } catch (e: Exception) {
-        rethrow(e)
+        ExceptionUtil.rethrow(e)
     }
 }
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/psi/PsiDaoMethod.kt
@@ -41,8 +41,8 @@ import org.domaframework.doma.intellij.extension.getModule
 import org.domaframework.doma.intellij.extension.getResourcesFile
 import org.domaframework.doma.intellij.extension.getSourceRootDir
 import org.domaframework.doma.intellij.extension.psi.DomaAnnotationType
+import org.domaframework.doma.intellij.extension.psi.module
 import org.domaframework.doma.intellij.setting.SqlLanguage
-import org.jetbrains.kotlin.idea.base.util.module
 import java.io.File
 import java.io.IOException
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/StaticDirectiveHandler.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/StaticDirectiveHandler.kt
@@ -26,10 +26,10 @@ import org.domaframework.doma.intellij.common.sql.directive.collector.FunctionCa
 import org.domaframework.doma.intellij.common.sql.directive.collector.StaticClassPackageCollector
 import org.domaframework.doma.intellij.common.sql.directive.collector.StaticPropertyCollector
 import org.domaframework.doma.intellij.common.util.StringUtil.SINGLE_SPACE
+import org.domaframework.doma.intellij.extension.psi.module
 import org.domaframework.doma.intellij.psi.SqlElClass
 import org.domaframework.doma.intellij.psi.SqlElStaticFieldAccessExpr
 import org.domaframework.doma.intellij.psi.SqlTypes
-import org.jetbrains.kotlin.idea.base.util.module
 
 class StaticDirectiveHandler(
     originalFile: PsiElement,

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/collector/FunctionCallCollector.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/sql/directive/collector/FunctionCallCollector.kt
@@ -26,7 +26,7 @@ import org.domaframework.doma.intellij.common.config.DomaCompileConfigUtil
 import org.domaframework.doma.intellij.common.helper.ExpressionFunctionsHelper
 import org.domaframework.doma.intellij.common.util.SqlCompletionUtil.createMethodLookupElement
 import org.domaframework.doma.intellij.extension.getJavaClazz
-import org.jetbrains.kotlin.idea.base.util.module
+import org.domaframework.doma.intellij.extension.psi.module
 
 class FunctionCallCollector(
     private val file: PsiFile?,

--- a/src/main/kotlin/org/domaframework/doma/intellij/common/util/PluginUtil.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/common/util/PluginUtil.kt
@@ -15,19 +15,15 @@
  */
 package org.domaframework.doma.intellij.common.util
 
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
-
-const val PLUGIN_ID = "org.domaframework.doma.intellij"
 const val PLUGIN_VERSION = "2.5.1-beta"
 
 open class PluginUtil {
     companion object {
-        fun getVersion(): String {
-            val pluginId = PluginId.getId(PLUGIN_ID)
-            return PluginManagerCore.getPlugin(pluginId)?.let {
-                return it.version
-            } ?: PLUGIN_VERSION
-        }
+        /**
+         * IntelliJ 2026.2 marked every `PluginManager` lookup of a plugin descriptor as an internal
+         * API, so the version is read from [PLUGIN_VERSION]. The release build keeps that constant in
+         * sync with the `pluginVersion` Gradle property (see `replaceVersionInPluginUtil`).
+         */
+        fun getVersion(): String = PLUGIN_VERSION
     }
 }

--- a/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/SqlCompletionContributor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/contributor/sql/SqlCompletionContributor.kt
@@ -24,7 +24,6 @@ import com.intellij.psi.PsiElement
 import org.domaframework.doma.intellij.common.psi.PsiPatternUtil
 import org.domaframework.doma.intellij.contributor.sql.provider.SqlParameterCompletionProvider
 import org.domaframework.doma.intellij.setting.SqlLanguage
-import org.jetbrains.kotlin.idea.completion.or
 
 /**
  * Code completion of SQL bind variables with DAO method arguments
@@ -34,37 +33,37 @@ open class SqlCompletionContributor : CompletionContributor() {
     init {
         extend(
             CompletionType.BASIC,
-            PsiPatternUtil
-                .createPattern(PsiComment::class.java)
-                .andOr(
-                    PsiPatternUtil
-                        .createPattern(PsiComment::class.java)
-                        .inFile(
-                            PlatformPatterns
-                                .psiFile()
-                                .withLanguage(SqlLanguage.INSTANCE),
-                        ),
-                    PsiPatternUtil
-                        .createPattern(PsiComment::class.java)
-                        .and(PsiPatternUtil.isMatchFileExtension("java")),
-                )
+            StandardPatterns.or(
+                PsiPatternUtil
+                    .createPattern(PsiComment::class.java)
+                    .andOr(
+                        PsiPatternUtil
+                            .createPattern(PsiComment::class.java)
+                            .inFile(
+                                PlatformPatterns
+                                    .psiFile()
+                                    .withLanguage(SqlLanguage.INSTANCE),
+                            ),
+                        PsiPatternUtil
+                            .createPattern(PsiComment::class.java)
+                            .and(PsiPatternUtil.isMatchFileExtension("java")),
+                    ),
                 // Support for directive elements
-                .or(
-                    PlatformPatterns
-                        .psiElement(PsiElement::class.java)
-                        .andOr(
-                            PsiPatternUtil
-                                .createDirectivePattern()
-                                .inFile(
-                                    PlatformPatterns
-                                        .psiFile()
-                                        .withName(StandardPatterns.string().endsWith(".sql")),
-                                ),
-                            PsiPatternUtil
-                                .createDirectivePattern()
-                                .and(PsiPatternUtil.isMatchFileExtension("java")),
-                        ),
-                ),
+                PlatformPatterns
+                    .psiElement(PsiElement::class.java)
+                    .andOr(
+                        PsiPatternUtil
+                            .createDirectivePattern()
+                            .inFile(
+                                PlatformPatterns
+                                    .psiFile()
+                                    .withName(StandardPatterns.string().endsWith(".sql")),
+                            ),
+                        PsiPatternUtil
+                            .createDirectivePattern()
+                            .and(PsiPatternUtil.isMatchFileExtension("java")),
+                    ),
+            ),
             SqlParameterCompletionProvider(),
         )
     }

--- a/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiElementExtension.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/extension/psi/PsiElementExtension.kt
@@ -15,6 +15,8 @@
  */
 package org.domaframework.doma.intellij.extension.psi
 
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -22,6 +24,16 @@ import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.elementType
 import org.domaframework.doma.intellij.psi.SqlTypes
+
+/**
+ * Module this element belongs to.
+ *
+ * The Kotlin plugin offers an identical `PsiElement.module` extension, but it is only an optional
+ * dependency of this plugin, so its classes are not guaranteed to be on the plugin class loader.
+ * Always use this platform-only version instead.
+ */
+val PsiElement.module: Module?
+    get() = ModuleUtilCore.findModuleForPsiElement(this)
 
 fun PsiElement.isNotWhiteSpace(): Boolean = this !is PsiWhiteSpace
 

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/block/SqlBlock.kt
@@ -24,6 +24,7 @@ import com.intellij.formatting.SpacingBuilder
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
 import com.intellij.psi.formatter.common.AbstractBlock
+import com.intellij.psi.util.startOffset
 import org.domaframework.doma.intellij.formatter.block.comment.SqlCommentBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlDefaultCommentBlock
 import org.domaframework.doma.intellij.formatter.block.comment.SqlElConditionLoopCommentBlock
@@ -32,7 +33,6 @@ import org.domaframework.doma.intellij.formatter.builder.SqlCustomSpacingBuilder
 import org.domaframework.doma.intellij.formatter.util.IndentType
 import org.domaframework.doma.intellij.formatter.util.SqlKeywordUtil
 import org.domaframework.doma.intellij.psi.SqlTypes
-import org.jetbrains.kotlin.psi.psiUtil.startOffset
 
 open class SqlBlock(
     node: ASTNode,

--- a/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/formatter/processor/SqlFormatPreProcessor.kt
@@ -32,6 +32,8 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
 import com.intellij.psi.util.endOffset
 import com.intellij.psi.util.prevLeafs
+import com.intellij.psi.util.startOffset
+import com.intellij.util.ExceptionUtil
 import org.domaframework.doma.intellij.common.util.InjectionSqlUtil.isInjectedSqlFile
 import org.domaframework.doma.intellij.common.util.PluginLoggerUtil
 import org.domaframework.doma.intellij.common.util.StringUtil.LINE_SEPARATE
@@ -40,8 +42,6 @@ import org.domaframework.doma.intellij.formatter.util.SqlKeywordUtil
 import org.domaframework.doma.intellij.formatter.visitor.SqlFormatVisitor
 import org.domaframework.doma.intellij.psi.SqlTypes
 import org.domaframework.doma.intellij.setting.SqlLanguage
-import org.jetbrains.kotlin.psi.psiUtil.startOffset
-import org.jetbrains.kotlin.utils.rethrow
 
 class SqlFormatPreProcessor : PreFormatProcessor {
     data class TextReplacement(
@@ -143,7 +143,7 @@ class SqlFormatPreProcessor : PreFormatProcessor {
 
             return ProcessResult(document, rangeToReformat.grown(visitor.replaces.size))
         } catch (e: Exception) {
-            rethrow(e)
+            ExceptionUtil.rethrow(e)
             return ProcessResult(document, rangeToReformat)
         }
     }

--- a/src/main/kotlin/org/domaframework/doma/intellij/gutter/sql/SqlLineMakerProvider.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/gutter/sql/SqlLineMakerProvider.kt
@@ -32,7 +32,7 @@ import org.domaframework.doma.intellij.common.isSupportFileType
 import org.domaframework.doma.intellij.common.psi.PsiDaoMethod
 import org.domaframework.doma.intellij.common.util.InjectionSqlUtil.isInjectedSqlFile
 import org.domaframework.doma.intellij.common.util.PluginLoggerUtil
-import org.jetbrains.kotlin.idea.core.util.toPsiFile
+import org.domaframework.doma.intellij.extension.findFile
 import java.awt.event.MouseEvent
 import javax.swing.Icon
 
@@ -65,8 +65,8 @@ class SqlLineMakerProvider : RelatedItemLineMarkerProvider() {
             RelatedItemLineMarkerInfo(
                 identifier,
                 identifier.textRange,
-                getIcon(daoFile.toPsiFile(project)),
-                getToolTipTitle(daoFile.toPsiFile(project)),
+                getIcon(project.findFile(daoFile)),
+                getToolTipTitle(project.findFile(daoFile)),
                 getHandler(daoFile, identifier, file.virtualFile?.nameWithoutExtension ?: ""),
                 GutterIconRenderer.Alignment.RIGHT,
             ) {

--- a/src/main/kotlin/org/domaframework/doma/intellij/refactoring/dao/DaoPackageRenameListenerProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/refactoring/dao/DaoPackageRenameListenerProcessor.kt
@@ -34,7 +34,7 @@ import org.domaframework.doma.intellij.common.RESOURCES_META_INF_PATH
 import org.domaframework.doma.intellij.common.dao.getDaoClass
 import org.domaframework.doma.intellij.common.util.PluginLoggerUtil
 import org.domaframework.doma.intellij.extension.getResourcesFile
-import org.jetbrains.kotlin.idea.base.util.module
+import org.domaframework.doma.intellij.extension.psi.module
 import java.io.IOException
 
 /**

--- a/src/main/kotlin/org/domaframework/doma/intellij/refactoring/dao/DaoRenameProcessor.kt
+++ b/src/main/kotlin/org/domaframework/doma/intellij/refactoring/dao/DaoRenameProcessor.kt
@@ -24,7 +24,7 @@ import org.domaframework.doma.intellij.common.dao.getDaoClass
 import org.domaframework.doma.intellij.common.util.PluginLoggerUtil
 import org.domaframework.doma.intellij.extension.getContentRoot
 import org.domaframework.doma.intellij.extension.getPackagePathFromDaoPath
-import org.jetbrains.kotlin.idea.base.util.module
+import org.domaframework.doma.intellij.extension.psi.module
 
 /**
  * Rename DAO class


### PR DESCRIPTION
**Description**

DAO to SQL navigation stopped working in IntelliJ IDEA 2026.2. The `Doma Tools` context menu group was greyed out and no gutter icon was shown.

The cause was an exception thrown from `AnAction.update()` and from the line marker provider:

```
java.lang.NoClassDefFoundError: org/jetbrains/kotlin/idea/base/util/GenericPsiUtils
	at PsiDaoMethod.setSqlFilePath(PsiDaoMethod.kt:123)
	at PsiDaoMethod.<init>(PsiDaoMethod.kt:69)
	at JumpToSQLFromDaoAction.update(JumpToSQLFromDaoAction.kt:45)
```

`JumpToSQLFromDaoAction.update()` sets `isEnabledAndVisible = false` before it throws, so the action stayed disabled, and `DaoMethodProvider` failed the same way while collecting line markers. With every child action disabled, the whole group is disabled too.

`GenericPsiUtils` holds the Kotlin plugin's `PsiElement.module` extension. The Kotlin plugin is declared as an *optional* dependency, but its classes were referenced unconditionally from the main module in 11 files. The optional sub-descriptor `kotlin.xml` never resolves (`Plugin 'Doma Tools' misses optional descriptor 'kotlin.xml'` is logged at every startup), so the platform drops the dependency edge and `org.jetbrains.kotlin` never becomes a parent of the plugin class loader. The `ClassNotFoundException` confirms it: the parent list contains only `org.toml.lang`, `com.intellij.java` and IDEA CORE content modules.

This was latent. The same warning appears in the 2026.1 log, but 2026.2 reworked descriptor loading (`PluginMainDescriptor` / `ContentModuleDescriptor` / `DependsSubDescriptor`) and tightened class loader isolation, which exposed it.

A second, independent problem: Marketplace was serving version **2.2.1** to 2026.2 users. `pluginUntilBuild` was `261.*`, so 2.5.x was treated as incompatible with build 262 and the IDE downgraded to the newest release without an until-build.

### Changes

**Remove Kotlin plugin API from the main module** — this is the actual fix.

| Before | After |
| --- | --- |
| `org.jetbrains.kotlin.idea.base.util.module` (6 files) | `ModuleUtilCore.findModuleForPsiElement`, exposed as our own `PsiElement.module` so call sites are unchanged |
| `org.jetbrains.kotlin.psi.psiUtil.startOffset` (2 files) | `com.intellij.psi.util.startOffset` |
| `org.jetbrains.kotlin.utils.rethrow` (2 files) | `com.intellij.util.ExceptionUtil.rethrow` |
| `org.jetbrains.kotlin.idea.core.util.toPsiFile` | the existing `Project.findFile` extension |
| `org.jetbrains.kotlin.idea.completion.or` | `StandardPatterns.or` |
| `KtFile` / `KtNamedFunction` in `JumpActionFunctions` | UAST, which the Kotlin plugin contributes through an extension point |

The built jar now contains no reference to `org/jetbrains/kotlin/{idea,psi,utils}`, so the failure cannot recur.

**Build against 2026.2**

- `pluginUntilBuild` `261.*` -> `262.*`, `platformVersion` -> `2026.2.1`
- IntelliJ Platform Gradle Plugin `2.17.0` -> `2.18.1`
- Compile on a JDK 25 toolchain: the 2026.2 platform jars are Java 25 class files, which javac cannot read on JDK 21. Emitted bytecode stays at Java 21 for `pluginSinceBuild=252`, whose IDE runs on JDK 21. CI JDK raised to 25 to match.

**Replace an API that became internal in 2026.2**

`PluginManagerCore.getPlugin()` and every equivalent `PluginManager` lookup are `@ApiStatus.Internal` in 262 and fail `verifyPlugin`, with no public replacement. The lookup was already dead code — `PLUGIN_ID` was `org.domaframework.doma.intellij` while the plugin id is `org.domaframework.doma`, so it always fell back to the constant. The release build keeps `PLUGIN_VERSION` in sync with the `pluginVersion` Gradle property.

### Behaviour change

Kotlin DAO navigation previously scanned only top level `KtNamedFunction` declarations, so methods of a Kotlin DAO interface were never found (the code carried a `// TODO Support Kotlin Project`). The UAST version walks `UFile.classes`, so those methods are now resolved.

### Verification

- `./gradlew check` — 308 tests pass
- `./gradlew verifyPlugin` — Compatible against `IU-252.28539.97`, `IU-253.33813.55`, `IU-261.27258.48`, `IU-262.9437.185`
- Manually confirmed on IntelliJ IDEA 2026.2.1: the `Doma Tools` menu is enabled again and gutter icons are displayed

### Follow-up

`META-INF/kotlin.xml` is still an empty `<idea-plugin>` and the optional Kotlin dependency still fails to resolve. That is now harmless, but the declaration should either be given real content, migrated to the v2 `<dependencies>` model, or removed. Note that `supportsKotlinPluginMode` has to stay in the main `plugin.xml` for the platform's K2 compatibility check.

---
**Related Issue**

None.

---
**Type of Change**
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)
- [ ] Refactor
- [ ] Test
- [x] Build system change
- [ ] Chore
- [ ] Performance improvement
- [ ] Code style update
- [ ] Security fix
- [ ] Other (please specify)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
